### PR TITLE
fix(build)  ensure $ngx_feature_libs is set

### DIFF
--- a/config
+++ b/config
@@ -20,6 +20,11 @@ find_runtime() {
         ngx_feature_libs="$3"
     fi
 
+    if [ -z "$ngx_feature_libs" -a -n "$NGX_WASM_RUNTIME" ]; then
+        ngx_feature="$ngx_feature, -l$NGX_WASM_RUNTIME"
+        ngx_feature_libs="-l$NGX_WASM_RUNTIME"
+    fi
+
     ngx_feature_run=no
     ngx_feature_test=
 


### PR DESCRIPTION
If none of the vars to specify the wasm library is set but
the wasmtime libraries and includes are on /usr/local/lib and
/usr/local/include respecitvely, the `auto/feature` script will
find it but $ngx_feature_libs isn't set, and no library is
added to the link step.

This patch simply sets a default `-lXXXX` value, which would
be overridden by the user variables if set.