### PR TITLE
chore(ci) downgrade wasmtime to 0.25.0

### DIFF
--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -23,7 +23,7 @@ jobs:
         cc: [clang]
         #ngx: [1.18.0, 1.19.1]
         ngx: [1.19.10]
-        wasmtime: [0.26.0]
+        wasmtime: [0.25.0]
         #hup: [1, 0]
         hup: [0]
         #debug: [1, 0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest]
         cc: [gcc-8]
         ngx: [1.19.10]
-        wasmtime: [0.26.0]
+        wasmtime: [0.25.0]
         hup: [1, 0]
         debug: [1, 0]
     steps:
@@ -94,7 +94,7 @@ jobs:
         os: [ubuntu-latest]
         cc: [gcc-8]
         ngx: [1.19.10]
-        wasmtime: [0.26.0]
+        wasmtime: [0.25.0]
         hup: [1, 0]
         #debug: [1, 0]
         debug: [1]
@@ -189,7 +189,7 @@ jobs:
       matrix:
         cc: [clang-9]
         ngx: [1.19.10]
-        wasmtime: [0.26.0]
+        wasmtime: [0.25.0]
     steps:
       - run: |
           sudo apt-get update
@@ -234,7 +234,7 @@ jobs:
         cc: [gcc-8]
         #ngx: [1.18.0, 1.19.1]
         ngx: [1.19.10]
-        wasmtime: [0.26.0]
+        wasmtime: [0.25.0]
         #hup: [1, 0]
         hup: [0]
         #debug: [1, 0]


### PR DESCRIPTION
Due to issues on macOS with 0.26.0