### PR TITLE
fix(proxy-wasm) move next_action flag from pwm to prctx

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -149,13 +149,12 @@ struct ngx_proxy_wasm_s {
     /* dyn config */
 
     ngx_uint_t                         max_pairs;
+    ngx_uint_t                         tick_period;
 
     /* control flow */
 
-    ngx_proxy_wasm_action_t            next_action;
     ngx_uint_t                         ecode;
     ngx_uint_t                         rctxid;
-    ngx_uint_t                         tick_period;
 
     /**
      * SDK

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.h
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.h
@@ -8,6 +8,7 @@
 
 typedef struct {
     ngx_proxy_wasm_t           *pwm;
+    ngx_proxy_wasm_action_t     next_action;
     unsigned                    context_created:1;
 } ngx_http_proxy_wasm_rctx_t;
 

--- a/t/03-proxy_wasm/005-http_next_action.t
+++ b/t/03-proxy_wasm/005-http_next_action.t
@@ -58,7 +58,38 @@ pausing after "RequestBody"
 
 
 
-=== TEST 3: proxy_wasm - on_response_headers -> Pause
+=== TEST 3: proxy_wasm - async subrequests
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: on_phases
+--- config
+    location /pause {
+        internal;
+        proxy_wasm on_phases 'pause_on=request_headers';
+        echo ok;
+    }
+
+    location /nop {
+        internal;
+        proxy_wasm on_phases;
+        echo ok;
+    }
+
+    location /t {
+        echo_subrequest_async GET /pause;
+        echo_subrequest_async GET /nop;
+    }
+--- abort
+--- error_code:
+--- response_body
+--- error_log
+pausing after "RequestHeaders"
+[wasm] NYI - proxy_wasm cannot pause after "rewrite" phase in subrequests
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: proxy_wasm - on_response_headers -> Pause
 NYI
 --- wasm_modules: on_phases
 --- config
@@ -69,13 +100,13 @@ NYI
 --- response_body
 --- error_log
 pausing after "ResponseHeaders"
-[wasm] NYI - proxy_wasm cannot pause after "header_filter"
+[wasm] NYI - proxy_wasm cannot pause after "header_filter" phase
 --- no_error_log
 [error]
 
 
 
-=== TEST 4: proxy_wasm - on_response_body -> Pause
+=== TEST 5: proxy_wasm - on_response_body -> Pause
 NYI
 --- wasm_modules: on_phases
 --- config
@@ -86,6 +117,6 @@ NYI
 --- response_body
 --- error_log
 pausing after "ResponseBody"
-[wasm] NYI - proxy_wasm cannot pause after "body_filter"
+[wasm] NYI - proxy_wasm cannot pause after "body_filter" phase
 --- no_error_log
 [error]


### PR DESCRIPTION
Isolate the next_action flag on a per-request basis (proxy-wasm request
context) instead of per-module basis (proxy-wasm module).