### PR TITLE
Add support for explicitly naming WASM runtime library

### DIFF
--- a/auto/runtime
+++ b/auto/runtime
@@ -6,14 +6,18 @@ ngx_feature="$ngx_wasm_runtime_name library"
 ngx_feature_path=
 ngx_feature_libs=
 
+if [ -z "$ngx_wasm_runtime_lib_name" ]; then
+    ngx_wasm_runtime_lib_name="$ngx_wasm_runtime_name"
+fi
+
 if [ -n "$ngx_wasm_runtime_inc" ]; then
     ngx_feature="$ngx_feature, -I $ngx_wasm_runtime_inc"
     ngx_feature_path="$ngx_wasm_runtime_inc"
 fi
 
 if [ -n "$ngx_wasm_runtime_lib" ]; then
-    ngx_feature="$ngx_feature, -L $ngx_wasm_runtime_lib -l$ngx_wasm_runtime_name"
-    ngx_feature_libs="-L $ngx_wasm_runtime_lib -l$ngx_wasm_runtime_name"
+    ngx_feature="$ngx_feature, -L $ngx_wasm_runtime_lib -l$ngx_wasm_runtime_lib_name"
+    ngx_feature_libs="-L $ngx_wasm_runtime_lib -l$ngx_wasm_runtime_lib_name"
 fi
 
 if [ -n "$ngx_wasm_runtime_opt" ]; then
@@ -21,9 +25,9 @@ if [ -n "$ngx_wasm_runtime_opt" ]; then
     ngx_feature_libs="$ngx_wasm_runtime_opt"
 fi
 
-if [ -z "$ngx_feature_libs" -a -n "$ngx_wasm_runtime_name" ]; then
-    ngx_feature="$ngx_feature, -l$ngx_wasm_runtime_name"
-    ngx_feature_libs="-l$ngx_wasm_runtime_name"
+if [ -z "$ngx_feature_libs" -a -n "$ngx_wasm_runtime_lib_name" ]; then
+    ngx_feature="$ngx_feature, -l$ngx_wasm_runtime_lib_name"
+    ngx_feature_libs="-l$ngx_wasm_runtime_lib_name"
 fi
 
 ngx_feature_run=yes


### PR DESCRIPTION
In some cases the runtime is named differently from the library (for eg WAMR & libiwasm.so). 
The current build system assumes the runtime & library are named the same.

Introduced $ngx_wasm_runtime_lib_name to allow explicit naming of runtime library. 
If $ngx_wasm_runtime_lib_name is not set (for eg in config), we fallback to the old behaviour.

fixes #57