### PR TITLE
chore(*) bump wasmer to 2.1.1

### DIFF
--- a/.github/actions/wasm-runtime/action.yml
+++ b/.github/actions/wasm-runtime/action.yml
@@ -2,7 +2,7 @@ name: 'Wasm runtime'
 description: 'Install a Wasm runtime C API'
 inputs:
   runtime:
-    description: 'Wasm runtime (wasmtimer, wasmer)'
+    description: 'Wasm runtime (wasmtime, wasmer)'
     default: 'wasmtime'
     required: false
   version:

--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -26,7 +26,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
         hup: [1, 0]
         debug: [1, 0]
     steps:
@@ -86,7 +86,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
         hup: [0, 1]
         debug: [1]
     steps:
@@ -153,7 +153,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
     steps:
       - uses: actions/checkout@v2
       - name: "Set up cache - ngx_wasm_module work/ dir"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
         hup: [1, 0]
         debug: [1, 0]
     steps:
@@ -100,7 +100,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
         hup: [0]
         debug: [1]
     steps:
@@ -238,7 +238,7 @@ jobs:
         ngx: [1.21.5]
         runtime: [wasmtime, wasmer]
         wasmtime: [0.30.0]
-        wasmer: [2.0.0]
+        wasmer: [2.1.1]
     steps:
       - uses: actions/checkout@v2
       - name: "Set up cache - ngx_wasm_module work/ dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
   CC: clang
   NGX_VER: 1.21.5
   WASMTIME_VER: 0.30.0
-  WASMER_VER: 2.0.0
+  WASMER_VER: 2.1.1
   RETENTION_DAYS: 2
 
 defaults:

--- a/assets/release/INSTALL
+++ b/assets/release/INSTALL
@@ -16,7 +16,7 @@ and library with:
         --with-ld-opt='-L/path/to/wasmtime/lib -lwasmtime'
 
     Note: when linking against libwasmer, set the 'NGX_WASM_RUNTIME=wasmer'
-    environment variable.
+    environment variable as well.
 
 Build/install Nginx with:
 

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -80,27 +80,32 @@
    fun:_ZN10wasmparser9validator9Validator3end17h754ba0a679ae09d9E
 }
 {
-   <wasmer 2.0.0: wasm_module_validate>
+   <wasmer 2.1.1: wasm_module_validate>
    Memcheck:Cond
-   fun:_ZN10wasmparser9validator9Validator3end17hdbe24a0b33be62d9E
+   fun:_ZN10wasmparser6parser6Parser5parse17ha6f66a955d5ddc0fE
 }
 {
-   <wasmer 2.0.0: wasm_functype_new/wasm_func_type>
+   <wasmer 2.1.1: wasm_module_validate>
+   Memcheck:Cond
+   fun:_ZN10wasmparser9validator9Validator3end17h50fce163da0607f3E
+}
+{
+   <wasmer 2.1.1: wasm_functype_new/wasm_func_type>
    Memcheck:Leak
    match-leak-kinds: definite
    fun:malloc
-   fun:_ZN98_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$alloc..vec..spec_from_iter..SpecFromIter$LT$T$C$I$GT$$GT$9from_iter17h0a4e053b7d1f2fc8E
-   fun:_ZN12wasmer_c_api10wasm_c_api5types8function16WasmFunctionType3new17hbedb716e5b5e187eE
+   fun:_ZN98_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$alloc..vec..spec_from_iter..SpecFromIter$LT$T$C$I$GT$$GT$9from_iter17h443ca409575a9212E
+   fun:_ZN6wasmer10wasm_c_api5types8function16WasmFunctionType3new17h473832a4826bdc04E
 }
 {
-   <wasmer 2.0.0: wasm_func_call>
+   <wasmer 2.1.1: wasm_func_call>
    Memcheck:Leak
    match-leak-kinds: definite
    ...
-   fun:_ZN12wasmer_c_api10wasm_c_api9externals8function22wasm_func_new_with_env28_$u7b$$u7b$closure$u7d$$u7d$17h500109d2acf40e46E
+   fun:_ZN6wasmer10wasm_c_api9externals8function22wasm_func_new_with_env28_$u7b$$u7b$closure$u7d$$u7d$17hd0cd15d537b3518dE
 }
 {
-   <wasmer 2.0.0: wasi_get_unordered_imports>
+   <wasmer 2.1.1: wasi_get_unordered_imports>
    Memcheck:Leak
    match-leak-kinds: definite
    fun:realloc


### PR DESCRIPTION
Noticed 2.1 was out while mem testing instance isolation branch.