### PR TITLE
chore(ci) fix coverage upload of extra unit test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,14 @@ jobs:
         debug: [1, 0]
         include:
           - os: ubuntu-latest
+            cc: gcc-8
             ngx: 1.21.6
             runtime: wasmtime
             wasmtime: 0.36.0
             hup: 1
             debug: 1
           - os: ubuntu-latest
+            cc: gcc-8
             openresty: 1.21.4.1
             runtime: wasmtime
             wasmtime: 0.36.0
@@ -91,7 +93,7 @@ jobs:
         env:
           TEST_NGINX_USE_HUP: ${{ matrix.hup }}
       - uses: codecov/codecov-action@v1
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && matrix.cc == 'gcc-8' }}
         env:
           TEST_NGINX_USE_HUP: ${{ matrix.hup }}
         with:

--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -55,7 +55,7 @@ build_nginx() {
 
     if [[ "$NGX_BUILD_GCOV" == 1 ]]; then
         build_name+=" gcov"
-        NGX_BUILD_CC_OPT="$NGX_BUILD_CC_OPT --coverage"
+        NGX_BUILD_CC_OPT="$NGX_BUILD_CC_OPT --coverage -fprofile-arcs -ftest-coverage"
         NGX_BUILD_LD_OPT="$NGX_BUILD_LD_OPT -fprofile-arcs"
     fi
 


### PR DESCRIPTION
gcov is not properly setup if `matrix.cc` is not explicitly specified.