### PR TITLE
feat(ngx-rust) use more general string type

### DIFF
--- a/lib/ngx-rust/src/resp.rs
+++ b/lib/ngx-rust/src/resp.rs
@@ -13,10 +13,10 @@ pub fn ngx_resp_set_status(status: i32) {
     unsafe { ngx_http_resp_set_status(status) }
 }
 
-pub fn ngx_resp_say(body: String) {
+pub fn ngx_resp_say(body: &str) {
     unsafe { ngx_http_resp_say(body.as_ptr(), body.len() as i32) }
 }
 
-pub fn ngx_resp_local_reason(status: i32, reason: String) {
+pub fn ngx_resp_local_reason(status: i32, reason: &str) {
     unsafe { ngx_http_local_response(status, reason.as_ptr(), reason.len() as i32) }
 }

--- a/t/lib/ngx-rust-tests/src/filter.rs
+++ b/t/lib/ngx-rust-tests/src/filter.rs
@@ -15,17 +15,17 @@ pub fn log_resp_status() {
 
 #[no_mangle]
 pub fn say_hello() {
-    ngx_resp_say("hello say".into());
+    ngx_resp_say("hello say");
 }
 
 #[no_mangle]
 pub fn local_reason() {
-    ngx_resp_local_reason(201, "REASON".into());
+    ngx_resp_local_reason(201, "REASON");
 }
 
 #[no_mangle]
 pub fn say_nothing() {
-    ngx_resp_say(String::new());
+    ngx_resp_say("");
 }
 
 #[no_mangle]


### PR DESCRIPTION
Use &str instead of String in public API functions for ngx_rust, so we can easily use both Strings and string literals.

See:
https://stackoverflow.com/a/40006220
https://blog.thoughtram.io/string-vs-str-in-rust/