### PR TITLE
chore(ci) bump Valgrind timeout to 45 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
   valgrind:
     name: 'Tests - valgrind'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.runtime == 'v8' && 90 || 30 }}
+    timeout-minutes: ${{ matrix.runtime == 'v8' && 90 || 45 }}
     #if: ${{ false }}
     env:
       NGX_BUILD_NOPOOL: 1


### PR DESCRIPTION
Recent runs have been nearing close to 30 min or over, and have started
timing out jobs.