### PR TITLE
chore(codecov) enable wait_for_ci

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 # https://docs.codecov.io/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
 coverage:
   precision: 4
   round: down
@@ -31,4 +36,3 @@ comment:
   require_changes: true
   require_base: no
   require_head: yes
-


### PR DESCRIPTION
These flags should already be `on` by default and it is beyond me why coverage is reported before CI has finished running. It is quite annoying as it causes PRs & commits to have a red cross instead of maintaining a yellow "running CI" icon.

https://docs.codecov.com/docs/codecovyml-reference