### PR TITLE
tests(proxy-wasm) simplify get_config API

### DIFF
--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -50,7 +50,7 @@ impl RootContext for TestRoot {
             self.get_config("tick_period").unwrap()
         );
 
-        match self.get_config("on_tick").unwrap_or(&"".into()).as_str() {
+        match self.get_config("on_tick").unwrap_or("") {
             "log_property" => test_log_property(self),
             "set_property" => test_set_property(self),
             _ => (),

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
@@ -14,19 +14,19 @@ pub enum TestPhase {
 }
 
 pub trait TestContext {
-    fn get_config(&self, name: &str) -> Option<&String>;
+    fn get_config(&self, name: &str) -> Option<&str>;
 }
 
 impl Context for dyn TestContext {}
 
 impl TestContext for TestRoot {
-    fn get_config(&self, name: &str) -> Option<&String> {
-        self.config.get(name)
+    fn get_config(&self, name: &str) -> Option<&str> {
+        self.config.get(name).map(|s| s.as_str())
     }
 }
 
 impl TestContext for TestHttp {
-    fn get_config(&self, name: &str) -> Option<&String> {
-        self.config.get(name)
+    fn get_config(&self, name: &str) -> Option<&str> {
+        self.config.get(name).map(|s| s.as_str())
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -159,7 +159,7 @@ impl TestHttp {
         }
 
         self.dispatch_http_call(
-            self.get_config("host").map(|v| v.as_str()).unwrap_or(""),
+            self.get_config("host").unwrap_or(""),
             headers,
             self.get_config("body").map(|v| v.as_bytes()),
             vec![],


### PR DESCRIPTION
Minor tweak: return an `Option<&str>` instead of an `Option<&String>`. This simplifies client code.

I spotted this while working on `feat/https-socket`, which also uses this function.