### PR TITLE
chore(*) cleanup commented-out code

### DIFF
--- a/src/common/ngx_wasm_socket_tcp.c
+++ b/src/common/ngx_wasm_socket_tcp.c
@@ -543,7 +543,7 @@ ngx_wasm_socket_tcp_send(ngx_wasm_socket_tcp_t *sock, ngx_chain_t *cl)
 
 #if 0
 ngx_int_t
-ngx_wasm_socket_reader_read_all(ngx_wasm_so127.0.0.1:$TEST_NGINX_SERVER_PORTcket_tcp_t *sock, ssize_t bytes)
+ngx_wasm_socket_reader_read_all(ngx_wasm_socket_tcp_t *sock, ssize_t bytes)
 {
     ngx_log_debug0(NGX_LOG_DEBUG_WASM, sock->log, 0,
                    "wasm tcp socket reading all");


### PR DESCRIPTION
Looks like a bad paste escaped in some commented-out code. Quick cleanup just to keep things tidy. Feel free to rename the commit as appropriate when squash-merging.