### PR TITLE
style(*) add new script for additional style checks

### DIFF
--- a/src/common/ddebug.h
+++ b/src/common/ddebug.h
@@ -18,7 +18,8 @@
 #include <stdarg.h>
 
 static ngx_inline void
-dd(const char *fmt, ...) {
+dd(const char *fmt, ...)
+{
 }
 #   endif
 #else
@@ -28,7 +29,8 @@ dd(const char *fmt, ...) {
 #include <stdarg.h>
 
 static ngx_inline void
-dd(const char *fmt, ...) {
+dd(const char *fmt, ...)
+{
 }
 #   endif
 #endif

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -232,7 +232,7 @@ ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
 
         if (buf->tag != tag) {
             if (ll) {
-                //ngx_wasm_assert(ll->next == cl);
+                /* ngx_wasm_assert(ll->next == cl); */
                 ll->next = cl->next;
             }
 

--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -1020,7 +1020,7 @@ ngx_wavm_instance_create(ngx_wavm_module_t *module, ngx_pool_t *pool,
         }
     }
 
-    //ngx_queue_insert_tail(&vm->instances, &instance->q);
+    /* ngx_queue_insert_tail(&vm->instances, &instance->q); */
 
     return instance;
 
@@ -1344,7 +1344,7 @@ ngx_wavm_instance_destroy(ngx_wavm_instance_t *instance)
         instance->cln->handler = NULL;
     }
 
-    //ngx_queue_remove(&instance->q);
+    /* ngx_queue_remove(&instance->q); */
 
     ngx_pfree(instance->pool, instance);
 }

--- a/src/wasm/wrt/ngx_wrt_wasmer.c
+++ b/src/wasm/wrt/ngx_wrt_wasmer.c
@@ -84,7 +84,7 @@ static void
 ngx_wasmer_destroy_engine(ngx_wrt_engine_t *engine)
 {
     wasi_env_delete(engine->wasi_env);
-    //wasi_config_delete(engine->wasi_config);
+    /* wasi_config_delete(engine->wasi_config); */
 
     wasm_store_delete(engine->store);
     wasm_engine_delete(engine->engine);

--- a/util/morestyle.pl
+++ b/util/morestyle.pl
@@ -1,0 +1,262 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+sub output($);
+sub replace_quotes($);
+
+my %files;
+my $space_with = 4;
+
+my ($infile, $lineno, $line);
+
+for my $file (@ARGV) {
+    $infile = $file;
+    #print "$infile\n";
+
+    open my $in, $infile or die $!;
+
+    # comment flags
+    my ($full_comment, $one_line_comment, $half_line_comment, $comment_not_end) = (0, 0, 0, 0);
+
+    # empty line before else code block
+    my ($cur_line_is_empty, $prev_line_is_empty, $consecutive_empty_lines) = (0, 0, 0);
+
+    $lineno = 0;
+
+    my $level = 0;
+
+    ##################################################################
+    # begin new rules - flags
+    ##################################################################
+
+    # label flags
+    my ($in_label, $label_blanks, $prev_label_blanks) = (0);
+
+    # preprocessor directives
+    my ($hash_comment, $prev_hash_comment) = (0);
+
+    ##################################################################
+    # end new rules - flags
+    ##################################################################
+
+    while (<$in>) {
+        $line = $_;
+
+        $lineno++;
+
+        #print "$lineno: $line";
+
+        $prev_line_is_empty = $cur_line_is_empty;
+        if ($line =~ /^\n$/) {
+            $cur_line_is_empty = 1;
+            $consecutive_empty_lines++;
+
+        } else {
+            $cur_line_is_empty = 0;
+            $consecutive_empty_lines = 0;
+        }
+
+        # one line comment
+        if ($line =~ /^#/) {
+            $full_comment = 1;
+
+            if ($line =~ /\\$/) {
+                $comment_not_end = 1;
+            } else {
+                $one_line_comment = 1;
+            }
+        }
+
+        # comment /* */
+        if ($line =~ /(\S*) \s* \/\* .* \*\/ /x) {
+            $one_line_comment = 1;
+
+            if ($1 ne "") {
+                $half_line_comment = 1;
+
+            } else {
+                $full_comment = 1;
+            }
+        }
+
+        # comment block: /* or #if 0
+        if ($line =~ /\/\*((?!\*\/).)*$/ || $line =~ /^#if 0/) {
+            $full_comment = 1;
+            #$print "enter comment block at line: $lineno\n";
+        }
+
+        ##################################################################
+        # begin new rules - including comment lines
+        ##################################################################
+
+        $prev_hash_comment = $hash_comment;
+
+        if ($line =~ /^#/) {
+            $hash_comment = 1;
+
+        } else {
+            $hash_comment = 0;
+        }
+
+        # ignore contents of '#if 0', treat as a comment
+        if ($line =~ /^#if 0/) {
+            $one_line_comment = 0;
+        }
+
+        # in the Nginx codebase, the presence of #if lines generally
+        # doesn't count towards the number of blanks around labels
+        if (!$hash_comment) {
+
+            if ($cur_line_is_empty) {
+                $label_blanks++;
+
+            } else {
+                $prev_label_blanks = $label_blanks;
+                $label_blanks = 0;
+            }
+
+            if ($in_label) {
+                if (!$cur_line_is_empty) {
+                    if ($prev_label_blanks == 0) {
+                        output "need a blank line after a label.";
+
+                    } elsif ($prev_label_blanks > 1) {
+                        output "need one blank line after a label,"
+                        . " got $prev_label_blanks.";
+                    }
+
+                    $in_label = 0;
+                }
+            }
+        }
+
+        ##################################################################
+        # end new rules - including comment lines
+        ##################################################################
+
+        # not full_comment
+        if ($full_comment == 0) {
+
+            ##################################################################
+            # begin new rules - excluding comment lines
+            ##################################################################
+
+            # comment // */
+            if ($line =~ /^\s*\/\//) {
+                output "avoid C99-style comments ( // ), use C89-style ( /* */ )";
+            }
+
+            # top level indent
+
+            if ($line =~ /^\S/) {
+                # not a struct or an assignment
+                if (!($line =~ /^(typedef|struct)/ || $line =~ /=/)) {
+
+                    if ($line =~ /\)\s*{$/) {
+                        output "function declaration needs { in its own line.";
+                    }
+                }
+            }
+
+            # keyword statements need a space
+
+            if ($line =~ /^\s*(if|while|for)\(/) {
+                output "keywords needs a space after open parentheses.";
+            }
+
+            # '} else {' unless after a preprocessor directive
+
+            if (!$prev_hash_comment && $line =~ /^\s*else\s+{/) {
+                output "else needs to be in the same line as closing bracket like so: '} else {'";
+            }
+
+            # for
+
+            if ($line =~ /^\s*for[ (]/) {
+                if ($line =~ /\(;;\)/) {
+                    output "infinite for loop should be 'for ( ;; )'";
+
+                } elsif (!($line =~ /\( ;; \)/) && ($line =~ /;;/)) {
+                    output "for loop without a condition needs '; /* void */ ;'";
+                }
+            }
+
+            # labels need a single blank before and afterwards
+
+            if (!($line =~ /default:/) && $line =~ /^\s*[a-zA-Z_][a-zA-Z0-9_]+:/) {
+                $in_label = 1;
+
+                ## Not the case in the Nginx codebase.
+                #if ($line =~ /^\s+/) {
+                #    output "label needs to be at first column.";
+                #}
+
+                if ($prev_label_blanks == 0) {
+                    output "need a blank line before a label.";
+                }
+
+                if ($prev_label_blanks > 1) {
+                    output "need one blank line before a label,"
+                    . " got $prev_label_blanks.";
+                }
+            }
+
+            # no spaces when or'ing constants
+
+            if ($line =~ /[A-Z_][A-Z_]+ \| [A-Z_][A-Z_]+/) {
+                output "the | operator takes no space when joining flag constants";
+            }
+
+            ##################################################################
+            # end new rules - excluding comment lines
+            ##################################################################
+
+        }
+
+        # leave comment after the comment block end
+        if ($line =~ /^((?<!\*\/).)*\*\// || $line =~ /^#endif/) {
+            $full_comment = 0;
+            #print "out comment block at line: $lineno\n";
+        }
+
+        # leave comment continue
+        if ($comment_not_end == 1 && !($line =~ /\\$/)) {
+            $full_comment = 0;
+            $comment_not_end = 0;
+        }
+
+        # leave comment after the line handled
+        if ($one_line_comment == 1) {
+            $full_comment = 0;
+            $one_line_comment = 0;
+            $half_line_comment = 0;
+        }
+
+    }
+}
+
+
+sub replace_quotes ($) {
+    my ($str) = @_;
+    while ($str =~ s/[^z]/z/g) {}
+    $str;
+}
+
+sub output ($) {
+    my ($str) = @_;
+
+    # skip *_lua_lex.c
+    if ($infile =~ /_lua_lex.c$/) {
+        return;
+    }
+
+    if (!exists($files{$infile})) {
+        print "\n$infile:\n";
+        $files{$infile} = 1;
+    }
+
+    print "\033[31;1m$str\033[0m\n";
+    print "$lineno: $line";
+}

--- a/util/style.sh
+++ b/util/style.sh
@@ -24,6 +24,9 @@ rc=0
 $DIR_BIN/style "$@" >$FILE_OUT &
 wait
 
+$NGX_WASM_DIR/util/morestyle.pl "$@" >>$FILE_OUT &
+wait
+
 if [[ -s "$FILE_OUT" ]]; then
     cat $FILE_OUT
     rc=1


### PR DESCRIPTION
Keeps the old script around rather than forking it, so we can easily upgrade the original one if it gets updates.

I just "hollowed" it out of its existing checks to reuse its main loop and implemented extra checks.

All of the latest style reviews from #128 would have been caught with this one.

What's implemented:

* single blank line before and after a label
* `avoid C99-style comments ( // ), use C89-style ( /* */ )`
* `function declaration needs { in its own line.`
* `keywords needs a space after open parentheses` (e.g `if(`)
* `'} else {'`, unless after a preprocessor directive
* `infinite for loop should be 'for ( ;; )'`
* `for loop without a condition needs '; /* void */ ;'`
* `the | operator takes no space when joining flag constants`