### PR TITLE
chore(makefile) add a 'make coverage' target

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -315,6 +315,13 @@ To run the test suite by restarting workers with a HUP signal:
 $ TEST_NGINX_USE_HUP=1 make test
 ```
 
+To run the test suite and see a coverage report locally (requires
+[Gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html)):
+
+```
+$ make coverage
+```
+
 See [util/test.sh](util/test.sh) and the
 [Test::Nginx](https://metacpan.org/pod/Test::Nginx::Socket) documentation for
 a complete list of these options.

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,17 @@ act-build:
 act: act-build
 	@act --reuse
 
+.PHONY: coverage
+coverage:
+	make clean
+	NGX_BUILD_GCOV=1 make
+	TEST_NGINX_RANDOMIZE=1 make test
+	rm -rf work/coverage_data
+	mkdir work/coverage_data
+	find work/buildroot -name '*.gcda' | xargs -I '{}' cp '{}' work/coverage_data
+	find work/buildroot -name '*.gcno' | xargs -I '{}' cp '{}' work/coverage_data
+	gcov -t -k -o work/coverage_data $$(find src/ -name '*.[ch]') | less -R
+
 .PHONY: clean
 clean:
 	@util/clean.sh


### PR DESCRIPTION
Adds a convenience target for running a clean coverage test locally. This is intended both to be used directly as a make target and also as an aide-mémoire for the gcov flag incantations when running custom invocations by hand.

I couldn't find a clean way to make command-line gcov read the sources from `src/` and the report files from `work/buildroot` since they have different tree structures, hence the `work/coverage_data` hack.