### PR TITLE
chore(test) new TEST_NGINX_CLEAN_LOG environment variable

### DIFF
--- a/util/test.sh
+++ b/util/test.sh
@@ -68,6 +68,7 @@ export LD_PRELOAD=$DIR_MOCKEAGAIN/mockeagain.so
 #export TEST_NGINX_USE_RR=1
 #export TEST_NGINX_NO_CLEAN=1
 #export TEST_NGINX_BENCHMARK='1000 10'
+export TEST_NGINX_CLEAN_LOG=${TEST_NGINX_CLEAN_LOG:=0}
 
 if [[ ! -x "$TEST_NGINX_BINARY" ]]; then
     fatal "no nginx binary at $TEST_NGINX_BINARY"
@@ -75,6 +76,11 @@ fi
 
 if [[ ! -x "$(command -v cargo)" ]]; then
     fatal "missing 'cargo', is the rust toolchain installed?"
+fi
+
+if [[ "$TEST_NGINX_CLEAN_LOG" == 1 ]]; then
+    echo "" > $TEST_NGINX_SERVROOT/logs/error.log || true
+    echo "" > $TEST_NGINX_SERVROOT/logs/access.log || true
 fi
 
 if [[ "$CI" == 'true' ]]; then


### PR DESCRIPTION
Bringing in a small commit form the FFI branch.

When set, empties the contents of nginx logs/ *before* running the
tests, which can come in handy when inspecting error logs while running
a test in isolation over and over again (else it is difficult to discern
when the previous tests ends and when the new one beings). It's also
better than removing and re-introducing the file since some tools don't
support runtime file system changes.