### PR TITLE
chore(release) support building V8 in various containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   NGX_VER: 1.23.1
   WASMTIME_VER: 0.38.1
   WASMER_VER: 2.3.0
-  #V8_VER: 10.5.18 # See https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
+  V8_VER: 10.5.18 # See https://v8.dev/docs/version-numbers#which-v8-version-should-i-use%3F
   RETENTION_DAYS: 2
 
 defaults:

--- a/assets/release/Dockerfiles/Dockerfile.amd64.archlinux
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.archlinux
@@ -5,6 +5,10 @@ RUN pacman -Syyu --noconfirm \
     clang \
     make \
     gcc \
+    python \
+    git \
+    pkg-config \
+    which \
     ninja
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo

--- a/assets/release/Dockerfiles/Dockerfile.amd64.centos7
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.centos7
@@ -2,16 +2,23 @@ FROM amd64/centos:7
 
 RUN yum install -y epel-release && \
     yum update -y && \
+    yum install -y centos-release-scl && \
     yum install -y \
+        devtoolset-8 \
+        devtoolset-8-libatomic-devel \
         ninja-build \
         clang \
-        cmake \
+        cmake3 \
         make \
         gcc \
-        perl
+        perl \
+        python3 \
+        git \
+        glib2-devel
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
 ENV PATH $CARGO_HOME/bin:$PATH
+RUN ln -nfs $(which cmake3) /usr/bin/cmake
 RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \
     chmod -R a=rwX $CARGO_HOME

--- a/assets/release/Dockerfiles/Dockerfile.amd64.centos8
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.centos8
@@ -10,7 +10,12 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
         cmake \
         make \
         gcc \
-        perl
+        libstdc++-devel \
+        libatomic \
+        perl \
+        python3 \
+        git \
+        glib2-devel
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
 ENV PATH $CARGO_HOME/bin:$PATH

--- a/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-18.04
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-18.04
@@ -6,7 +6,13 @@ RUN apt-get update && \
         ca-certificates \
         build-essential \
         ninja-build \
+        python3 \
         cmake \
+        gcc-8 \
+        libstdc++-8-dev \
+        git \
+        pkg-config \
+        libglib2.0-dev \
         clang \
         curl
 

--- a/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04
@@ -6,7 +6,13 @@ RUN apt-get update && \
         ca-certificates \
         build-essential \
         ninja-build \
+        python3 \
         cmake \
+        gcc-8 \
+        libstdc++-8-dev \
+        git \
+        pkg-config \
+        libglib2.0-dev \
         clang \
         curl
 
@@ -24,5 +30,4 @@ RUN apt-get install -y --no-install-recommends \
         valgrind \
         nodejs \
         gcovr \
-        sudo \
-        git
+        sudo

--- a/lib/cwabt/Makefile
+++ b/lib/cwabt/Makefile
@@ -5,13 +5,13 @@ LIBDIR = $(TARGET)/lib
 INCDIR = $(TARGET)/include
 
 build:
-	cargo build
+	cargo build --release
 
 install:
 	mkdir -p "$(INCDIR)"
 	cp cwabt.h "$(INCDIR)"
 	mkdir -p "$(LIBDIR)"
-	cp target/*/libcwabt.a "$(LIBDIR)"
+	cp target/release/libcwabt.a "$(LIBDIR)"
 
 clean:
 	cargo clean


### PR DESCRIPTION
Several tweaks needed to dependencies and scripts to get all containers running `release.sh` happily, but I got them all to work locally including CentOS 7, which is really showing its age. I did it incrementally by tweaking them one by one — I still need to do a full clean local run to make sure I didn't break one while fixing the other, but I'm generally feeling good about this branch.

Fixes #122.
