### PR TITLE
tests(wasi) fix expected number of tests in 000 suite

### DIFF
--- a/t/01-wasm/002-module_directive.t
+++ b/t/01-wasm/002-module_directive.t
@@ -242,7 +242,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 4: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -267,7 +267,7 @@ qr/\[alert\] .*? \[wasm\] NYI: module import type not supported/
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 4: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -294,7 +294,7 @@ qq{
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 4: $::nginxV =~ m/wasmtime/ || defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 4: $::nginxV =~ m/wasmtime/ || $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {

--- a/t/01-wasm/hfuncs/wasi/000-non_host_wasi.t
+++ b/t/01-wasm/hfuncs/wasi/000-non_host_wasi.t
@@ -31,7 +31,7 @@ __DATA__
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 4: ($::nginxV !~ m/v8/) || (defined $ENV{TEST_NGINX_USE_HUP})
+--- skip_eval: 4: $::nginxV !~ m/v8/ || $ENV{TEST_NGINX_USE_HUP} == 1
 --- wasm_modules: wasi_vm_tests
 --- main_config eval
 defined $ENV{TEST_NGINX_USE_VALGRIND} ? '' : 'daemon off;'

--- a/t/03-proxy_wasm/001-proxy_wasm_directives.t
+++ b/t/03-proxy_wasm/001-proxy_wasm_directives.t
@@ -61,7 +61,7 @@ qr/\[emerg\] .*? invalid module name ""/
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 6: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 6: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -90,7 +90,7 @@ qr/\[emerg\] .*? proxy_wasm failed loading "a" filter \(unknown ABI version\)/
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 6: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 6: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -119,7 +119,7 @@ stub
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 6: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 6: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -149,7 +149,7 @@ stub
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 6: defined $ENV{TEST_NGINX_USE_HUP}
+--- skip_eval: 6: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -178,7 +178,7 @@ stub
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: 6: defined $ENV{TEST_NGINX_USE_HUP} || $::nginxV !~ m/--with-debug/
+--- skip_eval: 6: $::nginxV !~ m/--with-debug/ || $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {

--- a/t/TestWasm.pm
+++ b/t/TestWasm.pm
@@ -25,9 +25,10 @@ our @EXPORT = qw(
     skip_valgrind
 );
 
-$ENV{TEST_NGINX_CRATES_DIR} = $crates;
+$ENV{TEST_NGINX_USE_HUP} ||= 0;
 $ENV{TEST_NGINX_HTML_DIR} = html_dir();
 $ENV{TEST_NGINX_DATA_DIR} = "$pwd/t/data";
+$ENV{TEST_NGINX_CRATES_DIR} = $crates;
 $ENV{TEST_NGINX_UNIX_SOCKET} = html_dir() . "/nginx.sock";
 # TODO: drop TEST_NGINX_SERVER_PORT2 when tcp_sock supports
 # unix: sockets to avoid port conflicts in randomized tests


### PR DESCRIPTION
Without the fix:
```
$ ./util/test.sh t/01-wasm/hfuncs/wasi/000-non_host_wasi.t
    Finished release [optimized] target(s) in 0.02s

/[...]/ngx_wasm_module/work/buildroot/nginx

nginx version: nginx/1.23.1 (ngx_wasm_module [dev debug v8])
built by gcc 12.2.0 (GCC) 
built with OpenSSL 1.1.1q  5 Jul 2022
TLS SNI support enabled
configure arguments: --build='ngx_wasm_module [dev debug v8]' --builddir=/home/chasum/code/ngx_wasm_module/work/buildroot --prefix=/home/chasum/code/ngx_wasm_module/t/servroot --with-cc-opt='-O0 -ggdb3 -gdwarf' --with-ld-opt=' -Wl,-rpath,/home/chasum/code/ngx_wasm_module/work/v8-10.5.18/lib' --with-poll_module --with-debug --add-module=/home/chasum/code/ngx_wasm_module --add-dynamic-module=/home/chasum/code/ngx_wasm_module/work/downloads/echo-nginx-module --add-dynamic-module=/home/chasum/code/ngx_wasm_module/work/downloads/headers-more-nginx-module --with-http_ssl_module


t/01-wasm/hfuncs/wasi/000-non_host_wasi.t .. 1/8 # Looks like you planned 8 tests but ran 6.
t/01-wasm/hfuncs/wasi/000-non_host_wasi.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 2/8 subtests 
        (less 4 skipped subtests: 2 okay)

Test Summary Report
-------------------
t/01-wasm/hfuncs/wasi/000-non_host_wasi.t (Wstat: 65280 (exited 255) Tests: 6 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 8 tests but ran 6.
Files=1, Tests=6,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.10 cusr  0.01 csys =  0.14 CPU)
Result: FAIL
```

Unclear on why this did not occur on GH Actions runs.