### PR TITLE
chore(ci) ensure the 'no_ssl' job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
           # No SSL
           - os: ubuntu-latest
             cc: gcc-8
-            ngx: 1.23.1
+            ngx: 1.21.6
             runtime: wasmer
             wasmer: 2.3.0
+            debug: 0
             no_ssl: 1
     steps:
       - run: sudo apt-get update && sudo apt-get install -y gcc-8 libstdc++-8-dev

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,8 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 7
     wait_for_ci: yes
+    after_n_builds: 6
 
 coverage:
   precision: 4


### PR DESCRIPTION
Include job attributes must produce a value not already in the matrix. Fix codecov `after_n_builds` of the OpenResty FFI merge.