### PR TITLE
fix(proxy-wasm) only run on_response_trailers on resp eof

### DIFF
--- a/src/http/ngx_http_wasm_filter_module.c
+++ b/src/http/ngx_http_wasm_filter_module.c
@@ -153,7 +153,7 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
                             &rctx->free_bufs, &rctx->busy_bufs,
                             &rctx->resp_chunk, buf_tag);
 
-    if (r->parent == NULL) {
+    if (rctx->resp_chunk_eof && r->parent == NULL) {
         (void) ngx_wasm_ops_resume(&rctx->opctx,
                                    NGX_HTTP_WASM_TRAILER_FILTER_PHASE);
     }

--- a/t/03-proxy_wasm/004-on_http_phases.t
+++ b/t/03-proxy_wasm/004-on_http_phases.t
@@ -231,8 +231,7 @@ Hello
 
 
 
-=== TEST 11: proxy_wasm - on_response_trailers gets number of response trailers (echo)
-Has trailers in response
+=== TEST 11: proxy_wasm - on_response_trailers gets number of response trailers (with body)
 --- http2
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
@@ -246,15 +245,20 @@ Has trailers in response
 --- response_body eval
 qr/ok
 x-trailer-foo: bar/
---- error_log eval
-qr/\[info\] .*? on_response_trailers, 1 trailers/
+--- grep_error_log eval: qr/#\d+ on_(request|response|log).*/
+--- grep_error_log_out eval
+qr/#\d+ on_response_headers, \d+ headers.*
+#\d+ on_response_body, 3 bytes, eof: false.*
+#\d+ on_response_body, 0 bytes, eof: true.*
+#\d+ on_response_trailers, 1 trailers.*
+#\d+ on_log.*/
 --- no_error_log
 [error]
 [crit]
 
 
 
-=== TEST 12: proxy_wasm - on_response_trailers gets number of response trailers (return)
+=== TEST 12: proxy_wasm - on_response_trailers gets number of response trailers (without body)
 No trailers in response
 --- http2
 --- wasm_modules: on_phases
@@ -357,7 +361,6 @@ ok
 qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
@@ -384,7 +387,6 @@ ok
 qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
@@ -660,8 +662,6 @@ qr/#\d+ on_request_headers, 3 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
@@ -695,8 +695,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
@@ -730,8 +728,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
@@ -762,7 +758,6 @@ should not chain in request; instead, server{} overrides http{}
 qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/


### PR DESCRIPTION
This is a temporary fix that came up on the FFI branch when I noticed this handler was called several times for responses that had a body, and I thought that was strange.

The bigger conversation revolves around our implementation of on_response_trailers: as per the SDK spec, it is to be invoked on *upstream* response trailers, but we our tests only cover locally-produced responses. We should look at Envoy's behavior in this case because if we have to run this handler _before_ trailers are produced by `ngx_http_next_body_filter`, we might need to revisit our implementation strategy. Tests with ngx_http_proxy_module are also needed to guarantee behavior in the Gateway.

What are your thoughts @casimiro? Tomorrow I can take some time to compare Envoy's behavior if nobody has it handy by then.
