### PR TITLE
feat(proxy-wasm) support reading response headers from callouts

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
@@ -63,8 +63,14 @@ ngx_proxy_wasm_maps_get_map(ngx_wavm_instance_t *instance,
     ngx_proxy_wasm_map_type_e map_type)
 {
 #ifdef NGX_WASM_HTTP
-    ngx_http_wasm_req_ctx_t  *rctx = ngx_http_proxy_wasm_get_rctx(instance);
-    ngx_http_request_t       *r = rctx->r;
+    ngx_http_wasm_req_ctx_t         *rctx;
+    ngx_http_request_t              *r;
+    ngx_proxy_wasm_exec_t           *pwexec;
+    ngx_http_proxy_wasm_dispatch_t  *call;
+    ngx_wasm_http_reader_ctx_t      *reader;
+
+    rctx = ngx_http_proxy_wasm_get_rctx(instance);
+    r = rctx->r;
 #endif
 
     switch (map_type) {
@@ -75,6 +81,17 @@ ngx_proxy_wasm_maps_get_map(ngx_wavm_instance_t *instance,
 
     case NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS:
         return &r->headers_out.headers;
+
+    case NGX_PROXY_WASM_MAP_HTTP_CALL_RESPONSE_HEADERS:
+        pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+        call = pwexec->call;
+        if (call == NULL) {
+            return NULL;
+        }
+
+        reader = &call->http_reader;
+
+        return &reader->fake_r.upstream->headers_in.headers;
 #endif
 
     default:

--- a/t/03-proxy_wasm/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/130-proxy_dispatch_http.t
@@ -866,3 +866,26 @@ qr/trap in proxy_on_log:.*? dispatch failed: bad step/
 qr/\[error\] .*? dispatch failed: no :method/
 --- no_error_log
 [crit]
+
+
+
+=== TEST 36: proxy_wasm - dispatch_http_call() echo response headers
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        add_header X-Callout-Header callout-header-value;
+        echo ok;
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              on_http_call_response=echo_response_headers';
+        echo ok;
+    }
+--- response_body_like: response header: X-Callout-Header: callout-header-value
+--- no_error_log
+[error]
+[crit]

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -30,6 +30,18 @@ impl Context for TestHttp {
                     self.send_plain_response(StatusCode::OK, Some(body.trim()));
                 }
             }
+            "echo_response_headers" => {
+                let headers = self.get_http_call_response_headers();
+                let mut s = String::new();
+                for (k, v) in headers {
+                    s.push_str("response header: ");
+                    s.push_str(&k);
+                    s.push_str(": ");
+                    s.push_str(&v);
+                    s.push_str("\n");
+                }
+                self.send_plain_response(StatusCode::OK, Some(&s));
+            }
             _ => {}
         }
 


### PR DESCRIPTION
Cherry-picked commit from `tests/go-sdk` branch, and added a non-Go specific test triggering the same feature via the Rust SDK.

This makes self.get_http_call_response_headers() in the proxy-wasm Rust SDK (and its Go equivalent) to stop crashing.