### PR TITLE
feat(proxy-wasm) allow proxy_set_buffer_bytes to prepend data

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -280,7 +280,13 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
 
 #ifdef NGX_WASM_HTTP
     case NGX_PROXY_WASM_BUFFER_HTTP_REQUEST_BODY:
-        rc = ngx_http_wasm_set_req_body(rctx, &s, offset, max);
+        if (offset == 0 && max == 0 && buf_len > 0) {
+            rc = ngx_http_wasm_prepend_req_body(rctx, &s);
+
+        } else {
+            rc = ngx_http_wasm_set_req_body(rctx, &s, offset, max);
+        }
+
         if (rc == NGX_ABORT) {
             ngx_wavm_instance_trap_printf(instance, "cannot set request body");
         }
@@ -288,7 +294,13 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
         break;
 
     case NGX_PROXY_WASM_BUFFER_HTTP_RESPONSE_BODY:
-        rc = ngx_http_wasm_set_resp_body(rctx, &s, offset, max);
+        if (offset == 0 && max == 0 && buf_len > 0) {
+            rc = ngx_http_wasm_prepend_resp_body(rctx, &s);
+
+        } else{
+            rc = ngx_http_wasm_set_resp_body(rctx, &s, offset, max);
+        }
+
         if (rc == NGX_ABORT) {
             ngx_wavm_instance_trap_printf(instance, "cannot set response body");
         }

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -135,6 +135,10 @@ ngx_int_t ngx_http_wasm_set_req_body(ngx_http_wasm_req_ctx_t *rctx,
     ngx_str_t *body, size_t at, size_t max);
 ngx_int_t ngx_http_wasm_set_resp_body(ngx_http_wasm_req_ctx_t *rctx,
     ngx_str_t *body, size_t at, size_t max);
+ngx_int_t ngx_http_wasm_prepend_req_body(ngx_http_wasm_req_ctx_t *rctx,
+    ngx_str_t *body);
+ngx_int_t ngx_http_wasm_prepend_resp_body(ngx_http_wasm_req_ctx_t *rctx,
+    ngx_str_t *body);
 
 
 /* proxy-wasm with wasm ops */

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -70,6 +70,8 @@ ngx_uint_t ngx_wasm_chain_clear(ngx_chain_t *in, size_t offset, unsigned *eof,
     unsigned *flush);
 ngx_chain_t *ngx_wasm_chain_get_free_buf(ngx_pool_t *p,
     ngx_chain_t **free, size_t len, ngx_buf_tag_t tag, unsigned reuse);
+ngx_int_t ngx_wasm_chain_prepend(ngx_pool_t *pool, ngx_chain_t **in,
+    ngx_str_t *str, ngx_chain_t **free, ngx_buf_tag_t tag);
 ngx_int_t ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
     ngx_str_t *str, ngx_chain_t **free, ngx_buf_tag_t tag);
 ngx_uint_t ngx_wasm_list_nelts(ngx_list_t *list);

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -204,6 +204,29 @@ ngx_wasm_chain_get_free_buf(ngx_pool_t *p, ngx_chain_t **free,
 
 
 ngx_int_t
+ngx_wasm_chain_prepend(ngx_pool_t *pool, ngx_chain_t **in,
+    ngx_str_t *str, ngx_chain_t **free, ngx_buf_tag_t tag)
+{
+    ngx_chain_t  *first;
+    ngx_buf_t    *buf;
+
+    first = ngx_wasm_chain_get_free_buf(pool, free, str->len, tag, 1);
+    if (first == NULL) {
+        return NGX_ERROR;
+    }
+
+    buf = first->buf;
+
+    buf->last = ngx_cpymem(buf->last, str->data, str->len);
+    first->next = *in;
+
+    *in = first;
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
     ngx_str_t *str, ngx_chain_t **free, ngx_buf_tag_t tag)
 {

--- a/t/03-proxy_wasm/114-proxy_set_http_request_body.t
+++ b/t/03-proxy_wasm/114-proxy_set_http_request_body.t
@@ -172,11 +172,18 @@ HelloWorld
     }
 
     location /c {
+        # offset = 0, max = 0, with value: prepend
         proxy_wasm hostcalls 'test=/t/set_request_body value=Goodbye offset=0 max=0';
         proxy_wasm hostcalls 'test=/t/echo/body';
     }
 
     location /d {
+        # offset = 0, max = 0, without value: delete
+        proxy_wasm hostcalls 'test=/t/set_request_body value= offset=0 max=0';
+        proxy_wasm hostcalls 'test=/t/echo/body';
+    }
+
+    location /e {
         proxy_wasm hostcalls 'test=/t/set_request_body value=HelloWorld offset=0 max=20';
         proxy_wasm hostcalls 'test=/t/echo/body';
     }
@@ -186,10 +193,12 @@ HelloWorld
         echo_subrequest GET /b;
         echo_subrequest GET /c;
         echo_subrequest GET /d;
+        echo_subrequest GET /e;
     }
 --- response_body
 HelloWorld
 HelloWas
+GoodbyeHelloWas
 HelloWorld
 --- no_error_log
 [error]


### PR DESCRIPTION
This PR changes the behavior of proxy_set_buffer_bytes so that it matches the append/prepend/replace behaviors of the Envoy implementation of this function, in order to improve compatibility with existing SDK implementations.

This behavior can be observed by the Go SDK implementation, which exposes:

* proxywasm.AppendHttpRequestBody
* proxywasm.PrependHttpRequestBody
* proxywasm.ReplaceHttpRequestBody

See https://github.com/tetratelabs/proxy-wasm-go-sdk/blob/main/proxywasm/hostcall.go#L858-L882 (Note the use of max.MaxInt32 in the arguments.)

Description of proxy_set_buffer_bytes according to Envoy's behavior: https://github.com/tetratelabs/proxy-wasm-go-sdk/issues/117#issuecomment-789530828

> Envoy supports the following buffer manipulations:
> * prepend: start and length needs to be zero
> * append: start needs to be greater or equal to the origin buffer size
> * replace: start needs to be zero and length must be greater or equal
>   to the origin buffer size <- here the whole buffer is drained and
>   then the new data are set

In this PR:

* we add a new ngx_wasm_chain_prepend operation
* we add new lower-level functions ngx_http_wasm_prepend_req_body and ngx_http_wasm_prepend_resp_body, using ngx_wasm_chain_prepend
* we modify our implementation of proxy_set_buffer_bytes to use those functions depending on their input arguments, according to the semantics described above.
* we add tests that exercise these behaviors