### PR TITLE
chore(util) add 2 new rules to morestyle.pl

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -214,8 +214,9 @@ ngx_proxy_wasm_properties_set(ngx_wavm_instance_t *instance,
         ngx_memcpy(p, path->data, path->len);
 
         for (i = 0; i < path->len; i++) {
-            if (p[i] == '\0')
+            if (p[i] == '\0') {
                 p[i] = '.';
+            }
         }
 
         ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -408,8 +408,9 @@ ngx_wasm_list_nelts(ngx_list_t *list)
         h = part->elts;
 
         for (i = 0; i < part->nelts; i++) {
-            if (h[i].hash)
+            if (h[i].hash) {
                 c++;
+            }
         }
 
         part = part->next;

--- a/util/setup_dev.sh
+++ b/util/setup_dev.sh
@@ -34,6 +34,7 @@ pushd $DIR_CPANM
     notice "downloading Test::Nginx dependencies..."
     HOME=$DIR_CPANM ./cpanm $PERL_ARGS Test::Nginx
     HOME=$DIR_CPANM ./cpanm $PERL_ARGS IPC::Run
+    HOME=$DIR_CPANM ./cpanm $PERL_ARGS Regexp::Common
 
     set +e
     patch --forward --ignore-whitespace lib/perl5/Test/Nginx/Util.pm <<'EOF'


### PR DESCRIPTION
- Catch expressions with '{' on next line when it should be on same line
- Catch double-indentation of function declaration arguments accepted by ngx-style.pl