### PR TITLE
tests(proxy_wasm) switch resolver and increase timeout to 60s

### DIFF
--- a/t/03-proxy_wasm/132-proxy_dispatch_http_ssl.t
+++ b/t/03-proxy_wasm/132-proxy_dispatch_http_ssl.t
@@ -4,6 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
+our $ExtResolver = $t::TestWasm::extresolver;
+our $ExtTimeout = $t::TestWasm::exttimeout;
+
 skip_no_ssl();
 skip_valgrind('wasmtime');
 
@@ -21,9 +24,12 @@ run_tests();
 __DATA__
 
 === TEST 1: proxy_wasm - dispatch_https_call() verify off, warn, default port, ok
+--- timeout eval: $::ExtTimeout
 --- wasm_modules: hostcalls
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -34,6 +40,7 @@ __DATA__
                               on_http_call_response=echo_response_body';
         echo fail;
     }
+}
 --- response_body_like
 \s*"Hello": "world",\s*
 .*?
@@ -47,6 +54,7 @@ __DATA__
 
 
 === TEST 2: proxy_wasm - dispatch_https_call() verify off, no warn, default port, ok
+--- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
     wasm {
@@ -54,8 +62,10 @@ qq{
         tls_no_verify_warn off;
     }
 }
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -66,6 +76,7 @@ qq{
                               on_http_call_response=echo_response_body';
         echo fail;
     }
+}
 --- response_body_like
 \s*"Hello": "world",\s*
 .*?
@@ -121,6 +132,7 @@ verifying tls certificate for "127.0.0.1"
 
 
 === TEST 4: proxy_wasm - dispatch_https_call() verify on, fail (expired)
+--- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
     wasm {
@@ -129,8 +141,10 @@ qq{
         tls_verify_cert         on;
     }
 }
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -138,6 +152,7 @@ qq{
                               https=yes';
         echo fail;
     }
+}
 --- error_code: 500
 --- response_body_like: 500 Internal Server Error
 --- error_log
@@ -228,6 +243,7 @@ dispatch failed (tls certificate does not match "localhost")
 
 
 === TEST 7: proxy_wasm - dispatch_https_call() untrusted root
+--- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
     wasm {
@@ -236,8 +252,10 @@ qq{
         tls_verify_cert         on;
     }
 }
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -245,6 +263,7 @@ qq{
                               https=yes';
         echo fail;
     }
+}
 --- error_code: 500
 --- response_body_like: 500 Internal Server Error
 --- error_log eval
@@ -309,6 +328,7 @@ foo
 
 
 === TEST 11: proxy_wasm - dispatch_https_call() no trusted CA
+--- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
     wasm {
@@ -316,8 +336,10 @@ qq{
         tls_verify_cert  on;
     }
 }
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -325,6 +347,7 @@ qq{
                               https=yes';
         echo fail;
     }
+}
 --- error_code: 500
 --- error_log
 dispatch failed (tls certificate verify error: (20:unable to get local issuer certificate))
@@ -335,6 +358,7 @@ dispatch failed (tls certificate verify error: (20:unable to get local issuer ce
 
 
 === TEST 12: proxy_wasm - dispatch_https_call() empty trusted CA path
+--- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
     wasm {
@@ -343,8 +367,10 @@ qq{
         tls_verify_cert         on;
     }
 }
---- config
-    resolver 1.1.1.1 ipv6=off;
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
 
     location /t {
         proxy_wasm hostcalls 'test=/t/dispatch_http_call \
@@ -353,6 +379,7 @@ qq{
                               path=/headers';
         echo fail;
     }
+}
 --- error_code: 500
 --- response_body_like: 500 Internal Server Error
 --- error_log

--- a/t/03-proxy_wasm/200-proxy_wasm_versions/002-go_sdk/006-http_auth_random.t
+++ b/t/03-proxy_wasm/200-proxy_wasm_versions/002-go_sdk/006-http_auth_random.t
@@ -4,6 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
+our $ExtResolver = $t::TestWasm::extresolver;
+our $ExtTimeout = $t::TestWasm::exttimeout;
+
 skip_valgrind();
 repeat_each(3);
 
@@ -14,15 +17,19 @@ run_tests();
 __DATA__
 
 === TEST 1: proxy_wasm Go SDK - http_auth_random example
+--- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: go_http_auth_random
---- config
-    resolver 1.1.1.1;
+--- config eval
+qq{
+    resolver         $::ExtResolver;
+    resolver_timeout $::ExtTimeout;
 
     location /uuid {
         proxy_wasm go_http_auth_random;
         echo ok;
     }
+}
 --- request
 GET /uuid
 --- error_code_like: ^(200|403)$

--- a/t/TestWasm.pm
+++ b/t/TestWasm.pm
@@ -11,6 +11,8 @@ our $crates = "work/lib/wasm";
 our $buildroot = "$pwd/work/buildroot";
 our $nginxbin = $ENV{TEST_NGINX_BINARY} || 'nginx';
 our $nginxV = eval { `$nginxbin -V 2>&1` };
+our $exttimeout = $ENV{TEST_NGINX_EXTERNAL_TIMEOUT} || '60s';
+our $extresolver = $ENV{TEST_NGINX_EXTERNAL_RESOLVER} || '8.8.8.8';
 our @nginx_modules;
 
 our @EXPORT = qw(
@@ -19,6 +21,8 @@ our @EXPORT = qw(
     $buildroot
     $nginxbin
     $nginxV
+    $exttimeout
+    $extresolver
     load_nginx_modules
     skip_no_ssl
     skip_no_debug


### PR DESCRIPTION
Recently several tests needing to resolve external hostnames have been failing due to resolver timeouts. We increase this timeout from 30s (default) to 60s.