### PR TITLE
misc(wasm_core) update TLS initialization debug log

### DIFF
--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -455,6 +455,9 @@ ngx_wasm_core_init_ssl(ngx_cycle_t *cycle)
     ngx_wasm_core_conf_t  *wcf;
     ngx_str_t             *trusted_crt;
 
+    ngx_log_debug0(NGX_LOG_DEBUG_WASM, cycle->log, 0,
+                   "wasm initializing tls");
+
     wcf = ngx_wasm_core_cycle_get_conf(cycle);
     ngx_wasm_assert(wcf);
 
@@ -480,8 +483,6 @@ ngx_wasm_core_init_ssl(ngx_cycle_t *cycle)
     {
         return NGX_ERROR;
     }
-
-    ngx_log_debug0(NGX_LOG_DEBUG_WASM, cycle->log, 0, "tls initialized");
 
     return NGX_OK;
 }


### PR DESCRIPTION
Align the log so it reads like all other initialization debug logs in the module. It is more useful to have a log saying "doing X" than "did X", because if X hangs/fails, there isn't any way of getting a hint out of the former option. If the program starts without errors, it is self-evident X was initialized.