### PR TITLE
chore(util) fix 'make clean' target

### DIFF
--- a/util/clean.sh
+++ b/util/clean.sh
@@ -16,8 +16,8 @@ source $NGX_WASM_DIR/util/_lib.sh
 ###############################################################################
 set +e
 
-if [[ -f "$DIR_SRCROOT/Makefile" ]]; then
-    pushd $DIR_SRCROOT
+if [[ -f "$DIR_PATCHED_ROOT/Makefile" ]]; then
+    pushd $DIR_PATCHED_ROOT
         make clean
         rm -f Makefile
     popd


### PR DESCRIPTION
In 05a76b228b4a4a8bb185b9703c0728f4bcdf12bc we changed the build system to make the Nginx source an intermediate source tree before the patched Nginx source, which is then built.

This changes the `make clean` target to do so in the patched source tree, and not the original one.