### PR TITLE
feat(proxy-wasm) recursive HTTP calls from calls response

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -65,7 +65,7 @@ ngx_proxy_wasm_get_buffer_helper(ngx_wavm_instance_t *instance,
         {
             ngx_wasm_http_reader_ctx_t      *reader;
             ngx_http_proxy_wasm_dispatch_t  *call;
-            ngx_proxy_wasm_exec_t     *pwexec;
+            ngx_proxy_wasm_exec_t           *pwexec;
 
             pwexec = ngx_proxy_wasm_instance2pwexec(instance);
             call = pwexec->call;

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -864,8 +864,6 @@ ngx_http_wasm_content_wev_handler(ngx_http_request_t *r)
     }
 #endif
 
-    ngx_wasm_assert(!rctx->yield);
-
     rc = ngx_http_wasm_content(rctx);
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
@@ -885,6 +883,10 @@ ngx_http_wasm_resume(ngx_http_wasm_req_ctx_t *rctx, unsigned main, unsigned wev)
     ngx_connection_t    *c = r->connection;
 
     ngx_wasm_assert(wev);
+
+    if (rctx->yield) {
+        return;
+    }
 
     if (main) {
         if (wev) {

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -729,8 +729,11 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
 
         ngx_http_proxy_wasm_dispatch_destroy(call);
 
-        pwexec->call = NULL;
-        rctx->yield = 0;
+        if (pwexec->call == call) {
+            /* no further call from the callback */
+            pwexec->call = NULL;
+            rctx->yield = 0;
+        }
 
         /* resume main handled by wasm callback */
         break;

--- a/t/03-proxy_wasm/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/133-proxy_dispatch_http_edge_cases.t
@@ -1,0 +1,74 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasm;
+
+skip_valgrind('wasmtime');
+
+plan tests => repeat_each() * (blocks() * 6);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - dispatch_http_call() on dispatch response (1 subsequent call)
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        echo "Hello world";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              on_http_call_response=call_again';
+        echo fail;
+    }
+--- response_headers_like
+pwm-call-1: Hello world
+--- response_body
+called 2 times
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 2: proxy_wasm - dispatch_http_call() on dispatch response (2 subsequent calls)
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        echo "dispatch 1";
+    }
+
+    location /dispatched1 {
+        echo "dispatch 2";
+    }
+
+    location /dispatched2 {
+        echo "dispatch 3";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              on_http_call_response=call_again \
+                              call_again=2';
+        echo fail;
+    }
+--- response_headers_like
+pwm-call-1: dispatch 1
+pwm-call-2: dispatch 2
+pwm-call-3: dispatch 3
+--- response_body
+called 3 times
+--- no_error_log
+[error]

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -74,6 +74,31 @@ impl Context for TestHttp {
                 }
                 self.send_plain_response(StatusCode::OK, Some(&s));
             }
+            "call_again" => {
+                if let Some(response) = bytes {
+                    let body = String::from_utf8_lossy(&response);
+                    self.add_http_response_header(
+                        format!("pwm-call-{}", self.ncalls + 1).as_str(),
+                        body.trim(),
+                    );
+                }
+
+                let again = self
+                    .config
+                    .get("call_again")
+                    .map_or(1, |v| v.parse().expect("bad call_again value"));
+
+                if self.ncalls < again {
+                    self.ncalls += 1;
+                    self.send_http_dispatch();
+                    return;
+                }
+
+                self.send_plain_response(
+                    StatusCode::OK,
+                    Some(format!("called {} times", self.ncalls + 1).as_str()),
+                );
+            }
             _ => {}
         }
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -92,6 +92,7 @@ impl RootContext for TestRoot {
         Some(Box::new(TestHttp {
             config: self.config.clone(),
             on_phases: phases,
+            ncalls: 0,
         }))
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -9,6 +9,7 @@ use url::Url;
 pub struct TestHttp {
     pub on_phases: Vec<TestPhase>,
     pub config: HashMap<String, String>,
+    pub ncalls: usize,
 }
 
 impl TestHttp {
@@ -134,6 +135,12 @@ impl TestHttp {
     pub fn send_http_dispatch(&mut self) {
         let mut timeout = Duration::from_secs(0);
         let mut headers = Vec::new();
+        let mut path = self
+            .config
+            .get("path")
+            .map(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
 
         if self.get_config("no_method").is_none() {
             headers.push((
@@ -156,10 +163,11 @@ impl TestHttp {
         }
 
         if self.get_config("no_path").is_none() {
-            headers.push((
-                ":path",
-                self.config.get("path").map(|v| v.as_str()).unwrap_or("/"),
-            ));
+            if self.ncalls > 0 {
+                path.push_str(format!("{}", self.ncalls).as_str());
+            }
+
+            headers.push((":path", path.as_str()));
         }
 
         if self.get_config("no_authority").is_none() {


### PR DESCRIPTION
Exploring expanding of our dispatching capabilities, this one is a low-hanging fruit from the list and allows filters to make multiple dispatches during a request.

Next edge-cases to look at:
- [ ] Dispatch from on_tick
  - Will introduce "fake connections" and "fake requests" constructs.
- [ ] Dispatch from on_configure
  - Still need to find an existing example filter of this.
- [ ] Go's "multiple_dispatches" test case
  - It tries to dispatch on response_headers, in which we cannot yield.
  - Multiple dispatches in a yieldable phase instead?