### PR TITLE
[WIP] resty-dns-client support on dispatched http requests

### DIFF
--- a/config
+++ b/config
@@ -195,6 +195,22 @@ if [ $HTTP_SSL = YES -o $STREAM_SSL = YES ]; then
         $ngx_addon_dir/src/common/ngx_wasm_ssl.c"
 fi
 
+# lua
+
+if [ $NGX_BUILD_OPENRESTY ]; then
+    NGX_WASM_DEPS="\
+        $NGX_WASM_DEPS \
+        $ngx_addon_dir/src/common/ngx_wasm_lua.h \
+        $ngx_addon_dir/src/common/ngx_wasm_lua_resolver.h"
+
+    NGX_WASM_SRCS="\
+        $NGX_WASM_SRCS \
+        $ngx_addon_dir/src/common/ngx_wasm_lua.c \
+        $ngx_addon_dir/src/common/ngx_wasm_lua_resolver.c"
+
+    have=NGX_WASM_LUA value=1 . auto/define
+fi
+
 ###############################################################################
 
 if [ "$ngx_module_link" = DYNAMIC ]; then

--- a/src/common/ngx_wasm_lua.c
+++ b/src/common/ngx_wasm_lua.c
@@ -1,0 +1,270 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_wasm_lua.h>
+#include <ngx_http_lua_cache.h>
+
+
+static ngx_int_t
+ngx_wasm_lua_set_lua_context(ngx_wasm_lua_ctx_t *lua_ctx)
+{
+#if (NGX_WASM_HTTP)
+    ngx_http_request_t    *r;
+#endif
+#if (0 && NGX_WASM_STREAM)
+    ngx_stream_session_t  *s;
+#endif
+
+    switch (lua_ctx->subsys) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_LUA_SUBSYS_HTTP:
+        r = lua_ctx->ctx.request->r;
+
+        lua_ctx->rlctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+        if (lua_ctx->rlctx == NULL) {
+            lua_ctx->rlctx = ngx_http_lua_create_ctx(r);
+            if (lua_ctx->rlctx == NULL) {
+                return NGX_ERROR;
+            }
+
+        } else {
+            ngx_http_lua_reset_ctx(r, lua_ctx->L, lua_ctx->rlctx);
+        }
+
+        return NGX_OK;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_LUA_SUBSYS_STREAM:
+        s = lua_ctx->ctx.session->s;
+        lua_ctx->slctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_module);
+        if (lua_ctx->slctx == NULL) {
+            lua_ctx->slctx = ngx_stream_lua_create_ctx(s);
+            if (lua_ctx->slctx == NULL) {
+                return NGX_ERROR;
+            }
+
+        } else {
+            ngx_stream_lua_reset_ctx(s, lua_ctx->L, lua_ctx->slctx);
+        }
+
+        return NGX_OK;
+#endif
+
+    default:
+        /* unreachable */
+        ngx_wasm_assert(0);
+        return NGX_ERROR;
+
+    }
+}
+
+
+static void
+ngx_wasm_lua_init_lua_context(ngx_wasm_lua_ctx_t *lua_ctx)
+{
+    switch (lua_ctx->subsys) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_LUA_SUBSYS_HTTP:
+        lua_ctx->ctx.request->wasm_lua_ctx = lua_ctx;
+
+        /* TODO: set lua_ctx->rlctx->context properly */
+        /* maybe lua_ctx->rlctx->context will be NGX_HTTP_LUA_CONTEXT_TIMER */
+        /* when running from on_tick */
+        lua_ctx->rlctx->context = NGX_HTTP_LUA_CONTEXT_CONTENT;
+        lua_ctx->rlctx->cur_co_ctx = &lua_ctx->rlctx->entry_co_ctx;
+        lua_ctx->rlctx->cur_co_ctx->co = lua_ctx->co;
+        lua_ctx->rlctx->cur_co_ctx->co_ref = lua_ctx->co_ref;
+#if (NGX_LUA_USE_ASSERT)
+        lua_ctx->rlctx->cur_co_ctx->co_top = 1;
+#endif
+#ifndef OPENRESTY_LUAJIT
+        ngx_http_lua_get_globals_table(lua_ctx->co);
+        lua_setfenv(lua_ctx->co, -2);
+#endif
+        ngx_http_lua_set_req(lua_ctx->co, lua_ctx->ctx.request->r);
+        ngx_http_lua_attach_co_ctx_to_L(lua_ctx->co,
+                                        lua_ctx->rlctx->cur_co_ctx);
+        lua_ctx->co_ctx = lua_ctx->rlctx->cur_co_ctx;
+
+        break;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_LUA_SUBSYS_STREAM:
+        /* set lua_ctx->slctx->context properly */
+        lua_ctx->slctx->context = NGX_STREAM_LUA_CONTEXT_CONTENT;
+        lua_ctx->slctx->cur_co_ctx = &lua_ctx->slctx->entry_co_ctx;
+        lua_ctx->slctx->cur_co_ctx->co = lua_ctx->co;
+        lua_ctx->slctx->cur_co_ctx->co_ref = lua_ctx->co_ref;
+#if (NGX_LUA_USE_ASSERT)
+        lua_ctx->slctx->cur_co_ctx->co_top = 1;
+#endif
+#ifndef OPENRESTY_LUAJIT
+        ngx_stream_lua_get_globals_table(lua_ctx->co);
+        lua_setfenv(lua_ctx->co, -2);
+#endif
+        ngx_stream_lua_set_req(co, lua_ctx->ctx.session->s);
+        lua_ctx->co_ctx = lua_ctx->slctx->cur_co_ctx;
+
+        break;
+#endif
+
+    default:
+        /* unreachable */
+        ngx_wasm_assert(0);
+        break;
+
+    }
+}
+
+
+static ngx_int_t
+ngx_wasm_lua_load_code(ngx_wasm_lua_ctx_t *lua_ctx)
+{
+    ngx_int_t   rc;
+    ngx_log_t  *log;
+
+    switch (lua_ctx->subsys) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_LUA_SUBSYS_HTTP:
+        log = lua_ctx->ctx.request->r->connection->log;
+        rc = ngx_http_lua_cache_loadbuffer(log,
+                                           lua_ctx->L, lua_ctx->code,
+                                           lua_ctx->code_len,
+                                           &lua_ctx->code_ref,
+                                           lua_ctx->cache_key,
+                                           lua_ctx->code_name);
+
+        break;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_LUA_SUBSYS_STREAM:
+        log = lua_ctx->ctx.session->s->connection->log;
+        rc = ngx_stream_lua_cache_loadbuffer(log,
+                                             lua_ctx->L, lua_ctx->code,
+                                             lua_ctx->code_len,
+                                             lua_ctx->code_ref,
+                                             lua_ctx->cache_key, lua_ctx->name);
+
+        break;
+#endif
+
+    default:
+        /* unreachable */
+        ngx_wasm_assert(0);
+        return NGX_ERROR;
+
+    }
+
+    if (rc != NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_ERR, log, 0,
+                           "failed loading lua code in wasm lua");
+        return rc;
+    }
+
+    /*  move code closure to new coroutine  */
+    lua_xmove(lua_ctx->L, lua_ctx->co, 1);
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_wasm_lua_init(ngx_wasm_lua_ctx_t *lua_ctx)
+{
+    ngx_log_t             *log;
+#if (0 && NGX_WASM_STREAM)
+    ngx_stream_lua_ctx_t  *ctx;
+#endif
+
+    switch (lua_ctx->subsys) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_LUA_SUBSYS_HTTP:
+        log = lua_ctx->ctx.request->r->connection->log;
+        lua_ctx->L = ngx_http_lua_get_lua_vm(lua_ctx->ctx.request->r, NULL);
+        lua_ctx->co = ngx_http_lua_new_thread(lua_ctx->ctx.request->r,
+                                              lua_ctx->L, &lua_ctx->co_ref);
+        break;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_LUA_SUBSYS_STREAM:
+        log = lua_ctx->ctx.session->s->connection->log;
+        ctx = ngx_stream_get_module_ctx(lua_ctx->session->s,
+                                        ngx_stream_lua_module);
+        lua_ctx->L = ngx_stream_lua_get_lua_vm(lua_ctx->session->s, NULL);
+        lua_ctx->co = ngx_stream_lua_new_thread(ctx->request, lua_ctx->L,
+                                                lua_ctx->co_ref);
+
+        break;
+#endif
+
+    default:
+        /* unreachable */
+        ngx_wasm_assert(0);
+        return NGX_ERROR;
+
+    }
+
+    if (!lua_ctx->L) {
+        ngx_wasm_log_error(NGX_LOG_WASM_NYI, log, 0,
+                           "failed getting lua vm in wasm lua");
+        return NGX_ERROR;
+    }
+
+    if (!lua_ctx->co) {
+        ngx_wasm_log_error(NGX_LOG_WASM_NYI, log, 0,
+                           "failed creating lua thread in wasm lua ");
+        return NGX_ERROR;
+    }
+
+    return ngx_wasm_lua_load_code(lua_ctx);
+}
+
+
+ngx_int_t
+ngx_wasm_lua_resume_coroutine(ngx_wasm_lua_ctx_t *lua_ctx)
+{
+    ngx_int_t              rc;
+#if (NGX_WASM_HTTP)
+    ngx_http_request_t    *r;
+#endif
+#if (0 && NGX_WASM_STREAM)
+    ngx_stream_session_t  *s;
+#endif
+
+    ngx_wasm_lua_set_lua_context(lua_ctx);
+    ngx_wasm_lua_init_lua_context(lua_ctx);
+
+    switch (lua_ctx->subsys) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_LUA_SUBSYS_HTTP:
+        r = lua_ctx->ctx.request->r;
+        rc = ngx_http_lua_run_thread(lua_ctx->L, r, lua_ctx->rlctx, 1);
+
+        return rc;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_LUA_SUBSYS_STREAM:
+        s = lua_ctx->ctx.request->s;
+
+        return ngx_stream_lua_run_thread(lua_ctx->L, s, lua_ctx->slctx, 1);
+#endif
+
+    default:
+        /* unreachable */
+        ngx_wasm_assert(0);
+        return NGX_ERROR;
+
+    }
+}

--- a/src/common/ngx_wasm_lua.h
+++ b/src/common/ngx_wasm_lua.h
@@ -1,0 +1,59 @@
+#ifndef _NGX_WASM_LUA_H_INCLUDED_
+#define _NGX_WASM_LUA_H_INCLUDED_
+
+
+#include <ngx_proxy_wasm.h>
+#if (NGX_WASM_HTTP)
+#include <ngx_http_wasm.h>
+#include <ngx_http_lua_util.h>
+#endif
+#if (0 && NGX_WASM_STREAM)
+#include <ngx_stream_wasm.h>
+#endif
+
+
+typedef enum {
+    NGX_WASM_LUA_SUBSYS_NONE = 0,
+    NGX_WASM_LUA_SUBSYS_HTTP,
+    NGX_WASM_LUA_SUBSYS_STREAM,
+} ngx_wasm_lua_subsys_e;
+
+
+struct ngx_wasm_lua_ctx_s {
+    int                     co_ref;
+    ngx_wasm_lua_subsys_e   subsys;
+    lua_State              *L, *co;
+    ngx_http_lua_co_ctx_t  *co_ctx;
+
+    size_t                  code_len;
+    int                     code_ref;
+    const char             *code_name;
+    const u_char           *code;
+    const u_char           *cache_key;
+
+#if (NGX_WASM_HTTP)
+    ngx_http_lua_ctx_t     *rlctx;
+#endif
+#if (0 && NGX_WASM_STREAM)
+    ngx_stream_lua_ctx_t   *slctx;
+#endif
+
+    union {
+#if (NGX_WASM_HTTP)
+        struct ngx_http_wasm_req_ctx_s  *request;
+#endif
+#if (0 && NGX_WASM_STREAM)
+        ngx_stream_wasm_ctx_t           *session;
+#endif
+    } ctx;
+};
+
+
+typedef struct ngx_wasm_lua_ctx_s  ngx_wasm_lua_ctx_t;
+
+
+ngx_int_t ngx_wasm_lua_init(ngx_wasm_lua_ctx_t *lua_ctx);
+ngx_int_t ngx_wasm_lua_resume_coroutine(ngx_wasm_lua_ctx_t *lua_ctx);
+
+
+#endif /* _NGX_WASM_LUA_H_INCLUDED_ */

--- a/src/common/ngx_wasm_lua_resolver.c
+++ b/src/common/ngx_wasm_lua_resolver.c
@@ -1,0 +1,257 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_wasm_lua.h>
+#include <ngx_wasm_lua_resolver.h>
+
+#if (NGX_WASM_HTTP)
+#include <ngx_http_proxy_wasm_dispatch.h>
+#endif
+
+
+typedef struct {
+    void  *resolver_ctx;
+    char  *name;
+    int    port;
+} ngx_wasm_lua_ffi_resolver_ctx_t;
+
+
+static const u_char *DNS_SOLVING_SCRIPT = (u_char *) ""
+    "local data = ...                                                       \n"
+    "local ffi = require ('ffi')                                            \n"
+    "local client                                                           \n"
+    "if dns_client then                                                     \n"
+    "    ngx.log(ngx.DEBUG, 'lua resolver using existing dns_client')       \n"
+    "    client = dns_client                                                \n"
+    "else                                                                   \n"
+    "    client = require ('resty.dns.client')                              \n"
+    "    client.init({noSynchronisation = true})                            \n"
+    "end                                                                    \n"
+    "                                                                       \n"
+    "ffi.cdef[[                                                             \n"
+    "  typedef struct {                                                     \n"
+    "      void  *resolver_ctx;                                             \n"
+    "      char  *name;                                                     \n"
+    "      int    port;                                                     \n"
+    "  } ngx_wasm_lua_ffi_resolver_ctx_t;                                   \n"
+    "  void ngx_wasm_lua_resolver_handler(                                  \n"
+    "    ngx_wasm_lua_ffi_resolver_ctx_t *ctx, const char *ip, int port);   \n"
+    "]]                                                                     \n"
+    "                                                                       \n"
+    "local ctx = ffi.cast('ngx_wasm_lua_ffi_resolver_ctx_t *', data)        \n"
+    "local name = ffi.string(ctx.name)                                      \n"
+    "                                                                       \n"
+    "local ip, port = client.toip(name, ctx.port)                           \n"
+    "ffi.C.ngx_wasm_lua_resolver_handler(data, ip, port)                    \n";
+
+
+static size_t         DNS_SOLVING_SCRIPT_LEN;
+static const u_char  *DNS_SOLVING_SCRIPT_KEY;
+static const char    *DNS_SOLVING_SCRIPT_NAME = "wasm_lua_resolver";
+
+
+static ngx_inline void
+ngx_wasm_lua_resolver_set_resume_handler(ngx_wasm_socket_tcp_t *sock)
+{
+#if (NGX_WASM_HTTP)
+    ngx_http_request_t       *r;
+    ngx_http_wasm_req_ctx_t  *rctx;
+
+    if (sock->kind == NGX_WASM_SOCKET_TCP_KIND_HTTP) {
+        rctx = sock->env.ctx.request;
+        r = rctx->r;
+
+        if (rctx->entered_content_phase || rctx->fake_request) {
+            r->write_event_handler = ngx_http_wasm_content_wev_handler;
+
+        } else {
+            r->write_event_handler = ngx_http_core_run_phases;
+        }
+    }
+#endif
+}
+
+
+static u_char *
+ngx_wasm_lua_resolver_cache_key(ngx_pool_t *pool, const char *tag,
+    const u_char *src, size_t src_len)
+{
+    u_char  *p, *out;
+    size_t   tag_len;
+
+    tag_len = ngx_strlen(tag);
+
+    out = ngx_pnalloc(pool, tag_len);
+    if (out == NULL) {
+        ngx_wasm_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+                           "failed allocating memory for code cache key in "
+                           "lua_resolver");
+        return NULL;
+    }
+
+    p = ngx_copy(out, tag, tag_len);
+
+#if (NGX_WASM_HTTP)
+    p = ngx_http_lua_digest_hex(p, src, src_len);
+#elif (0 && NGX_WASM_STREAM)
+    p = ngx_stream_lua_digest_hex(p, src, src_len);
+#endif
+
+    *p = '\0';
+
+    return out;
+}
+
+
+void
+ngx_wasm_lua_resolver_handler(ngx_wasm_lua_ffi_resolver_ctx_t *ctx,
+    const char *ip, int port)
+{
+    struct sockaddr_in     *sin;
+    ngx_resolver_ctx_t     *resolver_ctx = ctx->resolver_ctx;
+    ngx_wasm_socket_tcp_t  *sock = resolver_ctx->data;
+
+    resolver_ctx->addr.sockaddr = ngx_pcalloc(sock->pool,
+                                              sizeof(struct sockaddr_in));
+    if (!resolver_ctx->addr.sockaddr) {
+        ngx_wasm_log_error(NGX_LOG_ERR, sock->log, 0,
+                           "failed allocating sockaddr in lua_resolver");
+        return;
+    }
+
+    sin = (struct sockaddr_in *) resolver_ctx->addr.sockaddr;
+
+    resolver_ctx->naddrs = 1;
+    resolver_ctx->addrs = &resolver_ctx->addr;
+    resolver_ctx->addr.socklen = sizeof(struct sockaddr_in);
+    resolver_ctx->addr.sockaddr->sa_family = AF_INET;
+
+    sin->sin_family = AF_INET;
+    sin->sin_port = port;
+    inet_pton(AF_INET, ip, &sin->sin_addr);
+
+    ngx_wasm_lua_resolver_set_resume_handler(sock);
+
+    resolver_ctx->handler(resolver_ctx);
+}
+
+
+static ngx_wasm_lua_ffi_resolver_ctx_t *
+ngx_wasm_lua_resolver_create_ctx(ngx_wasm_socket_tcp_t *sock,
+    ngx_resolver_ctx_t *resolver_ctx)
+{
+    size_t                            name_len;
+    char                             *p;
+    ngx_wasm_lua_ffi_resolver_ctx_t  *ffi_ctx;
+
+    ffi_ctx = ngx_palloc(sock->pool, sizeof(ngx_wasm_lua_ffi_resolver_ctx_t));
+    if (!ffi_ctx) {
+        return NULL;
+    }
+
+    p = (char *) resolver_ctx->name.data;
+    name_len = (strchrnul(p, ':') - p);
+    resolver_ctx->name.data[name_len] = '\0';
+
+    ffi_ctx->resolver_ctx = resolver_ctx;
+    ffi_ctx->name = (char *) resolver_ctx->name.data;
+    ffi_ctx->port = sock->resolved.port;
+
+    return ffi_ctx;
+}
+
+
+static ngx_int_t
+ngx_wasm_lua_resolver_create_lua_ctx(ngx_wasm_socket_tcp_t *sock,
+                                     ngx_wasm_lua_ctx_t **out)
+{
+    (*out) = ngx_palloc(sock->pool, sizeof(ngx_wasm_lua_ctx_t));
+    if (!(*out)) {
+        return NGX_ERROR;
+    }
+
+    (*out)->code_name = DNS_SOLVING_SCRIPT_NAME;
+    (*out)->code = DNS_SOLVING_SCRIPT;
+    (*out)->code_len = DNS_SOLVING_SCRIPT_LEN;
+    (*out)->cache_key = DNS_SOLVING_SCRIPT_KEY;
+
+    switch (sock->kind) {
+
+#if (NGX_WASM_HTTP)
+    case NGX_WASM_SOCKET_TCP_KIND_HTTP:
+        (*out)->subsys = NGX_WASM_LUA_SUBSYS_HTTP;
+        (*out)->ctx.request = sock->env.ctx.request;
+
+        return NGX_OK;
+#endif
+
+#if (0 && NGX_WASM_STREAM)
+    case NGX_WASM_SOCKET_TCP_KIND_STREAM:
+        (*out)->subsys = NGX_WASM_LUA_SUBSYS_STREAM;
+        (*out)->ctx.session = sock->env.ctx.session;
+
+        return NGX_OK;
+#endif
+
+    default:
+        ngx_wasm_assert(0);
+        return NGX_ERROR;
+
+    }
+}
+
+
+void
+ngx_wasm_lua_resolver_init(ngx_conf_t *cf)
+{
+    DNS_SOLVING_SCRIPT_LEN = ngx_strlen((char *) DNS_SOLVING_SCRIPT);
+    DNS_SOLVING_SCRIPT_KEY = ngx_wasm_lua_resolver_cache_key(
+        cf->pool, DNS_SOLVING_SCRIPT_NAME, DNS_SOLVING_SCRIPT,
+        DNS_SOLVING_SCRIPT_LEN);
+}
+
+
+ngx_int_t
+ngx_wasm_lua_resolver_resolve(ngx_resolver_ctx_t *resolver_ctx)
+{
+    ngx_int_t                         rc;
+    ngx_log_t                        *log;
+    ngx_wasm_socket_tcp_t            *sock;
+    ngx_wasm_lua_ctx_t               *lua_ctx;
+    ngx_wasm_lua_ffi_resolver_ctx_t  *ffi_ctx;
+
+    sock = (ngx_wasm_socket_tcp_t *) resolver_ctx->data;
+    log = sock->log;
+
+    rc = ngx_wasm_lua_resolver_create_lua_ctx(sock, &lua_ctx);
+    if (rc != NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_ERR, log, 0, "failed creating lua ctx");
+        return NGX_ERROR;
+    }
+
+    rc = ngx_wasm_lua_init(lua_ctx);
+    if (rc != NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_ERR, log, 0, "failed initializing lua ctx");
+        return NGX_ERROR;
+    }
+
+    ffi_ctx = ngx_wasm_lua_resolver_create_ctx(sock, resolver_ctx);
+    if (ffi_ctx == NULL) {
+        ngx_wasm_log_error(NGX_LOG_ERR, log, 0,
+                           "failed creating lua resolver ctx");
+        return NGX_ERROR;
+    }
+
+    lua_pushlightuserdata(lua_ctx->co, (void *) ffi_ctx);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_WASM, log, 0,
+                   "lua resolver resuming thread (co: %p)", lua_ctx->co);
+
+    rc = ngx_wasm_lua_resume_coroutine(lua_ctx);
+
+    ngx_wasm_lua_resolver_set_resume_handler(sock);
+
+    return rc;
+}

--- a/src/common/ngx_wasm_lua_resolver.h
+++ b/src/common/ngx_wasm_lua_resolver.h
@@ -1,0 +1,12 @@
+#ifndef _NGX_WASM_LUA_RESOLVER_H_INCLUDED_
+#define _NGX_WASM_LUA_RESOLVER_H_INCLUDED_
+
+
+#include <ngx_wasm_socket_tcp.h>
+
+
+void      ngx_wasm_lua_resolver_init(ngx_conf_t *cf);
+ngx_int_t ngx_wasm_lua_resolver_resolve(ngx_resolver_ctx_t *ctx);
+
+
+#endif /* _NGX_WASM_LUA_RESOLVER_H_INCLUDED_ */

--- a/src/common/ngx_wasm_socket_tcp.h
+++ b/src/common/ngx_wasm_socket_tcp.h
@@ -19,6 +19,8 @@ typedef ngx_int_t (*ngx_wasm_socket_tcp_reader_pt)(
     ngx_wasm_socket_tcp_t *sock, ssize_t bytes, void *ctx);
 typedef ngx_int_t (*ngx_wasm_socket_tcp_resume_handler_pt)(
     ngx_wasm_socket_tcp_t *sock);
+typedef ngx_int_t (*ngx_wasm_socket_tcp_dns_resolver_pt)(
+    ngx_resolver_ctx_t *rslv_ctx);
 
 
 typedef struct {

--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -8,6 +8,9 @@
 #ifdef NGX_WASM_HTTP
 #include <ngx_http_proxy_wasm.h>
 #endif
+#if (NGX_WASM_LUA)
+#include <ngx_wasm_lua_resolver.h>
+#endif
 
 
 static ngx_int_t ngx_proxy_wasm_init_abi(ngx_proxy_wasm_filter_t *filter);
@@ -114,6 +117,10 @@ ngx_proxy_wasm_init(ngx_conf_t *cf)
                     ngx_rbtree_insert_value);
 
     ngx_proxy_wasm_properties_init(cf);
+
+#if (NGX_WASM_LUA)
+    ngx_wasm_lua_resolver_init(cf);
+#endif
 }
 
 

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -8,7 +8,9 @@
 #include <ngx_http_wasm_util.h>
 #include <ngx_http_wasm_headers.h>
 #include <ngx_http_wasm_trailers.h>
-
+#if (NGX_WASM_LUA)
+#include <ngx_wasm_lua.h>
+#endif
 
 #define NGX_HTTP_WASM_MAX_REQ_HEADERS      100
 
@@ -20,6 +22,9 @@
     (rctx->state == NGX_HTTP_WASM_REQ_STATE_YIELD)
 
 
+typedef struct ngx_http_wasm_req_ctx_s  ngx_http_wasm_req_ctx_t;
+
+
 typedef enum {
     NGX_HTTP_WASM_REQ_STATE_ERROR = -1,
     NGX_HTTP_WASM_REQ_STATE_CONTINUE = 0,
@@ -27,7 +32,7 @@ typedef enum {
 } ngx_http_wasm_req_state_e;
 
 
-typedef struct {
+struct ngx_http_wasm_req_ctx_s {
     ngx_http_request_t                *r;
     ngx_connection_t                  *connection;
     ngx_pool_t                        *pool;                    /* r->pool */
@@ -35,6 +40,10 @@ typedef struct {
     ngx_wasm_op_ctx_t                  opctx;
     void                              *data;                    /* per-stream extra context */
     ngx_http_wasm_req_state_e          state;                   /* determines next step on resume */
+
+#if (NGX_WASM_LUA)
+    struct ngx_wasm_lua_ctx_s         *wasm_lua_ctx;
+#endif
 
     ngx_chain_t                       *free_bufs;
     ngx_chain_t                       *busy_bufs;
@@ -70,7 +79,9 @@ typedef struct {
     unsigned                           resp_finalized:1;        /* finalized connection (ourselves) */
     unsigned                           ffi_attached:1;
     unsigned                           fake_request:1;
-} ngx_http_wasm_req_ctx_t;
+
+    unsigned                           pwm_lua_resolver:1;      /* loc->pwm_lua_resolver */
+};
 
 
 typedef struct {
@@ -86,6 +97,7 @@ typedef struct {
     ngx_flag_t                         socket_buffer_reuse;    /* wasm_socket_buffer_reuse */
 
     ngx_flag_t                         pwm_req_headers_in_access;
+    ngx_flag_t                         pwm_lua_resolver;
 
     ngx_queue_t                        q;                      /* main_conf */
 } ngx_http_wasm_loc_conf_t;

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -4,6 +4,9 @@
 #include "ddebug.h"
 
 #include <ngx_http_wasm.h>
+#if (NGX_WASM_LUA)
+#include <ngx_http_lua_util.h>
+#endif
 
 
 #define NGX_HTTP_WASM_DONE_IN_LOG 0
@@ -168,6 +171,13 @@ static ngx_command_t  ngx_http_wasm_module_cmds[] = {
       offsetof(ngx_http_wasm_loc_conf_t, pwm_req_headers_in_access),
       NULL },
 
+    { ngx_string("proxy_wasm_lua_resolver"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_wasm_loc_conf_t, pwm_lua_resolver),
+      NULL },
+
       ngx_null_command
 };
 
@@ -275,6 +285,7 @@ ngx_http_wasm_create_loc_conf(ngx_conf_t *cf)
     loc->socket_buffer_size = NGX_CONF_UNSET_SIZE;
     loc->socket_buffer_reuse = NGX_CONF_UNSET;
     loc->pwm_req_headers_in_access = NGX_CONF_UNSET;
+    loc->pwm_lua_resolver = NGX_CONF_UNSET;
 
     if (ngx_wasm_main_vm(cf->cycle)) {
         loc->plan = ngx_wasm_ops_plan_new(cf->pool, &ngx_http_wasm_subsystem);
@@ -328,6 +339,8 @@ ngx_http_wasm_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->pwm_req_headers_in_access,
                          prev->pwm_req_headers_in_access, 0);
+
+    ngx_conf_merge_value(conf->pwm_lua_resolver,  prev->pwm_lua_resolver, 0);
 
     if (conf->plan && !conf->plan->populated) {
         conf->plan = prev->plan;
@@ -510,6 +523,8 @@ ngx_http_wasm_rctx(ngx_http_request_t *r, ngx_http_wasm_req_ctx_t **out)
 
             cln->handler = ngx_http_wasm_cleanup;
             cln->data = rctx;
+
+            rctx->pwm_lua_resolver = loc->pwm_lua_resolver;
 
             if (ngx_wasm_ops_plan_attach(loc->plan, opctx) != NGX_OK) {
                 return NGX_ERROR;
@@ -849,6 +864,10 @@ ngx_http_wasm_content_wev_handler(ngx_http_request_t *r)
 {
     ngx_int_t                  rc;
     ngx_http_wasm_req_ctx_t   *rctx;
+#if (NGX_WASM_LUA)
+    ngx_http_lua_ctx_t        *ctx;
+#endif
+
 #if (NGX_DEBUG)
     ngx_connection_t          *c = r->connection;
     ngx_event_t               *wev = c->write;
@@ -892,6 +911,26 @@ ngx_http_wasm_content_wev_handler(ngx_http_request_t *r)
                     return;
                 }
             }
+        }
+    }
+#endif
+
+#if (NGX_WASM_LUA)
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+
+    if (rctx->wasm_lua_ctx
+        && rctx->wasm_lua_ctx->co_ctx->co_status != NGX_HTTP_LUA_CO_DEAD)
+    {
+        ctx->resume_handler(r);
+
+        if (rctx->wasm_lua_ctx->co_ctx
+            && rctx->wasm_lua_ctx->co_ctx->co_status != NGX_HTTP_LUA_CO_DEAD)
+        {
+            r->write_event_handler = ngx_http_wasm_content_wev_handler;
+            return;
+
+        } else {
+            return;
         }
     }
 #endif

--- a/t/04-openresty/100-ffi/006-proxy_wasm_lua_resolver.t
+++ b/t/04-openresty/100-ffi/006-proxy_wasm_lua_resolver.t
@@ -1,0 +1,105 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasm::Lua;
+
+our $ExtResolver = $t::TestWasm::extresolver;
+our $ExtTimeout = $t::TestWasm::exttimeout;
+
+skip_no_openresty();
+
+plan tests => repeat_each() * (blocks() * 5);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lua-resty-dns-client ran by wasm_tcp_socket (on_request_headers)
+--- skip_no_debug: 4
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'on=request_headers test=/t/dispatch_http_call \
+                              host=www.google.com \
+                              path=/ \
+                              on_http_call_response=echo_response_body';
+        echo failed;
+    }
+--- response_body_like
+.+google.+
+--- error_log eval
+qr/\[debug\] .*? lua resolver resuming thread \(co: .*\)/
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: lua_resolver not ran by wasm_tcp_socket (on_request_headers)
+--- skip_no_debug: 4
+--- timeout eval: $::ExtTimeout
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    resolver         $::ExtResolver ipv6=off;
+    resolver_timeout $::ExtTimeout;
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers test=/t/dispatch_http_call \
+                              host=www.google.com \
+                              path=/ \
+                              on_http_call_response=echo_response_body';
+        echo failed;
+    }
+}
+--- response_body_like
+.+google.+
+--- no_error_log
+[error]
+[crit]
+lua resolver
+
+
+
+=== TEST 3: lua-resty-dns-client ran by wasm_tcp_socket (on_request_headers)
+--- skip_no_debug: 4
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- http_config
+server {
+    listen       $TEST_NGINX_SERVER_PORT2;
+    server_name  local_wasmx;
+
+    location / {
+        echo "wasmx rocks";
+    }
+}
+
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        dns_client.init(
+        {
+            noSynchronisation = true,
+            hosts = {'127.0.0.1 local_wasmx'}
+        })
+    }
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'on=request_headers test=/t/dispatch_http_call \
+                              host=local_wasmx:$TEST_NGINX_SERVER_PORT2 \
+                              path=/ \
+                              on_http_call_response=echo_response_body';
+        echo failed;
+    }
+--- response_body_like
+wasmx rocks
+--- error_log eval
+qr/\[debug\] .*? lua resolver using existing dns_client/
+--- no_error_log
+[error]
+[crit]


### PR DESCRIPTION
# Intent
This PR intends to add [lua-resty-dns-client](https://github.com/Kong/lua-resty-dns-client) support to `wasmx`. 



