### PR TITLE
tests(proxy-wasm) add memory state test for isolation modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "instance-lifecycle"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "proxy-wasm 0.2.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "t/lib/proxy-wasm-tests/hostcalls",
     "t/lib/proxy-wasm-tests/rust-sdk-ver-zero-one",
     "t/lib/proxy-wasm-tests/benchmarks",
+    "t/lib/proxy-wasm-tests/instance-lifecycle",
 ]
 exclude = [
     "lib/cwabt",

--- a/t/03-proxy_wasm/006-instance_lifecycle.t
+++ b/t/03-proxy_wasm/006-instance_lifecycle.t
@@ -212,3 +212,55 @@ qr/\A\*\d+ proxy_wasm "hostcalls" filter new instance.*
 --- no_error_log
 [emerg]
 [alert]
+
+
+
+=== TEST 5: proxy_wasm - globals with default isolation mode
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: instance_lifecycle
+--- config
+    location /t {
+        proxy_wasm instance_lifecycle;
+        echo ok;
+    }
+--- request eval
+["GET /t", "GET /t"]
+--- error_code eval
+[200, 200]
+--- ignore_response_body
+--- grep_error_log eval: qr/\*\d+.*?(on_log).*/
+--- grep_error_log_out eval
+[
+qr/.*?on_log: MY_STATIC_VARIABLE: 123001.*?/,
+qr/.*?on_log: MY_STATIC_VARIABLE: 123002.*?/
+]
+--- no_error_log
+[emerg]
+[alert]
+
+
+
+=== TEST 6: proxy_wasm - globals with stream isolation mode
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: instance_lifecycle
+--- config
+    proxy_wasm_isolation stream;
+
+    location /t {
+        proxy_wasm instance_lifecycle;
+        echo ok;
+    }
+--- request eval
+["GET /t", "GET /t"]
+--- error_code eval
+[200, 200]
+--- ignore_response_body
+--- grep_error_log eval: qr/\*\d+.*?(on_log).*/
+--- grep_error_log_out eval
+[
+qr/.*?on_log: MY_STATIC_VARIABLE: 123001.*?/,
+qr/.*?on_log: MY_STATIC_VARIABLE: 123001.*?/
+]
+--- no_error_log
+[emerg]
+[alert]

--- a/t/lib/proxy-wasm-tests/instance-lifecycle/Cargo.toml
+++ b/t/lib/proxy-wasm-tests/instance-lifecycle/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "instance-lifecycle"
+version = "0.1.0"
+authors = ["Hisham Muhammad <hisham@gobolinux.org>"]
+edition = "2018"
+
+[lib]
+path = "src/filter.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+proxy-wasm = "0.2"
+log = "0.4"

--- a/t/lib/proxy-wasm-tests/instance-lifecycle/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/instance-lifecycle/src/filter.rs
@@ -1,0 +1,44 @@
+use log::info;
+use proxy_wasm::{traits::*, types::*};
+
+static mut MY_STATIC_VARIABLE: i32 = 123000;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Debug);
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
+        Box::new(InstanceLifecycleRoot)
+    });
+}}
+
+struct InstanceLifecycleRoot;
+impl Context for InstanceLifecycleRoot {}
+impl RootContext for InstanceLifecycleRoot {
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+
+    fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(InstanceLifecycleHttp {
+            context_id: context_id,
+        }))
+    }
+}
+
+struct InstanceLifecycleHttp {
+    context_id: u32,
+}
+impl Context for InstanceLifecycleHttp {}
+impl HttpContext for InstanceLifecycleHttp {
+    fn on_http_request_headers(&mut self, _nheaders: usize, _eof: bool) -> Action {
+        unsafe {
+            MY_STATIC_VARIABLE += 1;
+        }
+
+        Action::Continue
+    }
+
+    fn on_log(&mut self) {
+        let value = unsafe { MY_STATIC_VARIABLE };
+        info!("#{} on_log: MY_STATIC_VARIABLE: {}", self.context_id, value);
+    }
+}


### PR DESCRIPTION
Adds a couple of tests that checks for the behavior of global memory under different isolation modes.