### PR TITLE
fix(proxy-wasm) handle get_property() on unset upstream values

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -913,7 +913,6 @@ ngx_proxy_wasm_hfuncs_get_property(ngx_wavm_instance_t *instance,
     ret_size = NGX_WAVM_HOST_LIFT(instance, args[3].of.i32, int32_t);
 
     rc = ngx_proxy_wasm_properties_get(instance, &path, &value);
-
     if (rc == NGX_DECLINED) {
         return ngx_proxy_wasm_result_notfound(rets);
     }

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -152,7 +152,13 @@ get_upstream_address(ngx_wavm_instance_t *instance, ngx_str_t *path,
     ngx_http_wasm_req_ctx_t  *rctx = ngx_http_proxy_wasm_get_rctx(instance);
     ngx_http_request_t       *r = rctx->r;
     ngx_http_upstream_t      *u = r->upstream;
-    u_char                   *p = u->peer.name->data;
+    u_char                   *p;
+
+    if (u == NULL) {
+        return NGX_DECLINED;
+    }
+
+    p = u->peer.name->data;
 
     if (!pwctx->upstream_address.len) {
         len = ((u_char *) strrchr((char *) p, ':')) - p;
@@ -183,7 +189,13 @@ get_upstream_port(ngx_wavm_instance_t *instance, ngx_str_t *path,
     ngx_http_wasm_req_ctx_t  *rctx = ngx_http_proxy_wasm_get_rctx(instance);
     ngx_http_request_t       *r = rctx->r;
     ngx_http_upstream_t      *u = r->upstream;
-    u_char                   *p = u->peer.name->data;
+    u_char                   *p;
+
+    if (u == NULL) {
+        return NGX_DECLINED;
+    }
+
+    p = u->peer.name->data;
 
     if (!pwctx->upstream_port.len) {
         a_len = (((u_char *) strrchr((char *) p, ':')) - p) + 1;

--- a/t/03-proxy_wasm/119-proxy_get_property.t
+++ b/t/03-proxy_wasm/119-proxy_get_property.t
@@ -338,17 +338,16 @@ qr/$checks/
 
 === TEST 8: proxy_wasm - get_property() - upstream properties (IPv6) on: response_headers
 Disabled on GitHub Actions due to IPv6 constraint.
---- skip_eval: 4: system("ping6 -c 1 ::1 >/dev/null 2>&1") ne 0 || defined $ENV{GITHUB_ACTIONS}
+--- skip_eval: 4: system("ping6 -c 1 ipv6.google.com >/dev/null 2>&1") ne 0 || defined $ENV{GITHUB_ACTIONS}
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
     location /t {
-        proxy_pass https://ipv6.google.com;
+        proxy_pass https://ipv6.google.com/;
         proxy_wasm hostcalls 'on=response_headers \
                               test=/t/log/properties \
                               name=upstream.address,upstream.port';
-        echo fail;
     }
 --- response_body_like
 \A\<!doctype html\>.*
@@ -361,7 +360,26 @@ upstream\.port: [0-9]+/
 
 
 
-=== TEST 9: proxy_wasm - get_property() - connection properties on: request_headers,response_headers,response_body,response_trailers
+=== TEST 9: proxy_wasm - get_property() - upstream properties access without an upstream
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        echo ok;
+        proxy_wasm hostcalls 'on=response_headers \
+                              test=/t/log/properties \
+                              name=upstream.address,upstream.port';
+    }
+--- ignore_response_body
+--- error_log
+property not found: upstream.address
+property not found: upstream.port
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: proxy_wasm - get_property() - connection properties on: request_headers,response_headers,response_body,response_trailers
 --- skip_eval: 4: $::nginxV !~ m/built with OpenSSL/
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -438,7 +456,7 @@ qr/$checks/
 
 
 
-=== TEST 10: proxy_wasm - get_property() - connection properties (mTLS) on: request_headers,response_headers,response_body,response_trailers
+=== TEST 11: proxy_wasm - get_property() - connection properties (mTLS) on: request_headers,response_headers,response_body,response_trailers
 --- skip_eval: 4: $::nginxV !~ m/built with OpenSSL/
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -503,7 +521,7 @@ qr/$checks/
 
 
 
-=== TEST 11: proxy_wasm - get_property() - proxy-wasm properties on: request_headers,request_body,response_headers,response_body,response_trailers
+=== TEST 12: proxy_wasm - get_property() - proxy-wasm properties on: request_headers,request_body,response_headers,response_body,response_trailers
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval
@@ -551,7 +569,7 @@ qr/$checks/
 
 
 
-=== TEST 12: proxy_wasm - get_property() - uri encoded request.path on: request_headers
+=== TEST 13: proxy_wasm - get_property() - uri encoded request.path on: request_headers
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -574,7 +592,7 @@ qr/request.path: \/t\?foo=std\:\:min\&bar=\[1,2\]/
 
 
 
-=== TEST 13: proxy_wasm - get_property() - not supported properties on: request_headers
+=== TEST 14: proxy_wasm - get_property() - not supported properties on: request_headers
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval


### PR DESCRIPTION
When using another content handler such as `echo`, the `r->upstream` attribute of a request is not set, which used to cause a segfault in these properties getters. Since the test was disabled on non-IPv6 machines and GitHub Actions this was uncaught until I just switched to an IPv6 machine for the holidays.