### PR TITLE
fix(util) pass absolute path to build_v8bridge()

### DIFF
--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -302,6 +302,10 @@ n_jobs() {
     fi
 }
 
+abs_path() {
+    echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
 get_variable_from_release_yml() {
     local var_name="$1"
     local release_file="$NGX_WASM_DIR/.github/workflows/release.yml"

--- a/util/runtime.sh
+++ b/util/runtime.sh
@@ -85,9 +85,6 @@ while [[ "$1" ]]; do
             shift
             TARGET_DIR="$1"
             ;;
-        --clean)
-            CLEAN="clean"
-            ;;
         --download)
             MODE="download"
             ;;
@@ -124,6 +121,8 @@ fi
 
 if [[ -z "$TARGET_DIR" ]]; then
     TARGET_DIR="$(get_default_runtime_dir "$RUNTIME" "$RUNTIME_VERSION")"
+else
+    TARGET_DIR=$(abs_path $TARGET_DIR)
 fi
 
 if [[ "$CLEAN" = "clean" ]]; then

--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -122,10 +122,10 @@ check_libwee8_build_dependencies() {
 }
 
 build_libwee8() {
-    local v8_ver="$1"
-    local target="$2"
-    local arch="$3"
-    local clean="$4"
+    local target="$1"
+    local clean="$2"
+    local v8_ver="$3"
+    local arch="$4"
 
     case "$arch" in
         x86_64) arch="x64" ;;
@@ -279,7 +279,7 @@ build_v8() {
     local clean="$4"
 
     build_cwabt "$target" "$clean"
-    build_libwee8 "$v8_ver" "$target" "$arch" "$clean"
+    build_libwee8 "$target" "$clean" "$v8_ver" "$arch"
     build_v8bridge "$target" "$clean"
 }
 


### PR DESCRIPTION
We build the V8 bridge with `make -C <v8bridge>` which means when specifying a target directory for the artifacts, the path should be absolute. Prior behavior:

    $ ./util/runtime.sh --build -T work/v8-build -R v8
    building lib/cwabt...
    [...]
    building V8...
    [...]
    building v8bridge...
    make: Entering directory '/home/chasum/code/ngx_wasm_module/lib/v8bridge'
    ar rcs libv8bridge.a bridge.o
    make: Leaving directory '/home/chasum/code/ngx_wasm_module/lib/v8bridge'
    make: Entering directory '/home/chasum/code/ngx_wasm_module/lib/v8bridge'
    cp ./libv8bridge.a work/v8-build/lib/libv8bridge.a
    cp: cannot create regular file 'work/v8-build/lib/libv8bridge.a': No such file or directory
    make: *** [Makefile:13: install] Error 1
    make: Leaving directory '/home/chasum/code/ngx_wasm_module/lib/v8bridge'
    build failed -- deleting work/v8-build...
    removed directory 'work/v8-build'

The `cp` line is the issue, and was executed by libv8bridge's `Makefile`.

Minor cleanups also included in the commit.