### PR TITLE
feat(proxy-wasm) allow running on_request_headers in access

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -491,6 +491,7 @@ ngx_proxy_wasm_ctx_action(ngx_proxy_wasm_ctx_t *pwctx,
         switch (pwctx->phase->index) {
 #ifdef NGX_WASM_HTTP
         case NGX_HTTP_REWRITE_PHASE:
+        case NGX_HTTP_ACCESS_PHASE:
         case NGX_HTTP_CONTENT_PHASE:
             ngx_log_debug6(NGX_LOG_DEBUG_WASM, pwctx->log, 0,
                            "proxy_wasm pausing in \"%V\" phase"

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -234,6 +234,7 @@ struct ngx_proxy_wasm_ctx_s {
 
     unsigned                           main:1;            /* r->main */
     unsigned                           ready:1;
+    unsigned                           req_headers_in_access:1;
 };
 
 

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -75,6 +75,8 @@ typedef struct {
     ngx_bufs_t                         socket_large_buffers;  /* wasm_socket_large_buffer_size */
     ngx_flag_t                         socket_buffer_reuse;   /* wasm_socket_buffer_reuse */
 
+    ngx_flag_t                         pwm_req_headers_in_access;
+
     ngx_queue_t                        q;                     /* main_conf */
 } ngx_http_wasm_loc_conf_t;
 

--- a/src/http/ngx_http_wasm_local_response.c
+++ b/src/http/ngx_http_wasm_local_response.c
@@ -159,6 +159,8 @@ ngx_http_wasm_stash_local_response(ngx_http_wasm_req_ctx_t *rctx,
         rctx->local_resp_body_len = len;
     }
 
+    rctx->resp_content_chosen = 1;
+
     return NGX_OK;
 
 fail:

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -420,6 +420,7 @@ ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
     op->module = filter->module;
     op->host = &ngx_proxy_wasm_host;
     op->on_phases = (1 << NGX_HTTP_REWRITE_PHASE)
+                    | (1 << NGX_HTTP_ACCESS_PHASE)
                     | (1 << NGX_HTTP_CONTENT_PHASE)
                     | (1 << NGX_HTTP_WASM_HEADER_FILTER_PHASE)
                     | (1 << NGX_HTTP_WASM_BODY_FILTER_PHASE)

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -332,10 +332,12 @@ ngx_http_proxy_wasm_ecode(ngx_proxy_wasm_err_e ecode)
 static ngx_proxy_wasm_ctx_t *
 ngx_http_proxy_wasm_ctx(void *data)
 {
-    ngx_proxy_wasm_ctx_t     *pwctx;
-    ngx_http_wasm_req_ctx_t  *rctx = data;
-    ngx_http_request_t       *r = rctx->r;
+    ngx_proxy_wasm_ctx_t      *pwctx;
+    ngx_http_wasm_req_ctx_t   *rctx = data;
+    ngx_http_request_t        *r = rctx->r;
+    ngx_http_wasm_loc_conf_t  *loc;
 
+    loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
     rctx = ngx_http_get_module_ctx(r, ngx_http_wasm_module);
 
     pwctx = (ngx_proxy_wasm_ctx_t *) rctx->data;
@@ -351,6 +353,7 @@ ngx_http_proxy_wasm_ctx(void *data)
         pwctx->log = r->connection->log;
         pwctx->main = r == r->main;
         pwctx->data = rctx;
+        pwctx->req_headers_in_access = loc->pwm_req_headers_in_access;
 
         /* for on_request_body retrieval */
         rctx->data = pwctx;

--- a/src/wasm/ngx_wasm_ops.c
+++ b/src/wasm/ngx_wasm_ops.c
@@ -386,8 +386,31 @@ ngx_wasm_op_proxy_wasm_handler(ngx_wasm_op_ctx_t *opctx,
 
 #ifdef NGX_WASM_HTTP
     case NGX_HTTP_REWRITE_PHASE:
-        rc = ngx_proxy_wasm_resume(pwctx, phase,
-                                   NGX_PROXY_WASM_STEP_REQ_HEADERS);
+        if (!pwctx->req_headers_in_access) {
+            rc = ngx_proxy_wasm_resume(pwctx, phase,
+                                       NGX_PROXY_WASM_STEP_REQ_HEADERS);
+
+        } else {
+            if (!pwctx->main) {
+                ngx_wasm_log_error(NGX_LOG_WARN, opctx->log, 0,
+                                   "proxy_wasm_request_headers_in_access "
+                                   "enabled in a subrequest (no access phase)");
+            }
+
+            rc = NGX_OK;
+        }
+
+        break;
+
+    case NGX_HTTP_ACCESS_PHASE:
+        if (pwctx->req_headers_in_access) {
+            rc = ngx_proxy_wasm_resume(pwctx, phase,
+                                       NGX_PROXY_WASM_STEP_REQ_HEADERS);
+
+        } else {
+            rc = NGX_OK;
+        }
+
         break;
 
     case NGX_HTTP_CONTENT_PHASE:

--- a/t/03-proxy_wasm/190-req_headers_in_access.t
+++ b/t/03-proxy_wasm/190-req_headers_in_access.t
@@ -1,0 +1,116 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasm;
+
+plan tests => repeat_each() * (blocks() * 5);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - on_request_headers in access sanity (number of headers)
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: on_phases
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+        proxy_wasm on_phases;
+        echo ok;
+    }
+--- more_headers
+Hello: wasm
+--- response_body
+ok
+--- error_log eval
+qr/\[info\] .*? on_request_headers, 3 headers/
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: proxy_wasm - on_request_headers in access - dispatch_http_call()
+--- skip_no_debug: 5
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+        proxy_wasm hostcalls 'test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatch \
+                              on_http_call_response=echo_response_body';
+        echo fail;
+    }
+
+    location /dispatch {
+        echo ok;
+    }
+--- response_body
+ok
+--- error_log eval
+qr/proxy_wasm pausing in \"access\" phase/
+--- no_error_log eval
+[
+    qr/\[error\]/,
+    qr/proxy_wasm pausing in \"rewrite\" phase/
+]
+
+
+
+=== TEST 3: proxy_wasm - on_request_headers in rewrite - dispatch_http_call()
+--- skip_no_debug: 5
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access off;
+        proxy_wasm hostcalls 'test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatch \
+                              on_http_call_response=echo_response_body';
+        echo fail;
+    }
+
+    location /dispatch {
+        echo ok;
+    }
+--- response_body
+ok
+--- error_log eval
+qr/proxy_wasm pausing in \"rewrite\" phase/
+--- no_error_log eval
+[
+    qr/\[error\]/,
+    qr/proxy_wasm pausing in \"access\" phase/
+]
+
+
+
+=== TEST 4: proxy_wasm - on_request_headers in access - as a subrequest
+warn users that subrequests do not run an access phase
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: on_phases
+--- config
+    location /dispatch {
+        echo ok;
+    }
+
+    location /subrequest {
+        proxy_wasm_request_headers_in_access on;
+        proxy_wasm on_phases;
+        echo ok;
+    }
+
+    location /t {
+        echo_subrequest GET '/subrequest';
+    }
+--- response_body
+ok
+--- error_log eval
+qr/\[warn\] .*? proxy_wasm_request_headers_in_access enabled in a subrequest \(no access phase\)/
+--- no_error_log
+[error]
+on_request_headers


### PR DESCRIPTION
In Kong Gateway, we plan on attaching proxy-wasm filters during the Gateway's access phase. Hence in this module we need to allow for resuming the filter chain (ngx_wasm_ops) in the access phase as well, instead of rewrite which would be too early.