### PR TITLE
chore(util) install local::lib locally via cpanm and load it

### DIFF
--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -17,6 +17,8 @@ DIR_OPR_PREFIX=$DIR_BUILDROOT/prefix
 DIR_DIST_OUT=$NGX_WASM_DIR/dist
 URL_KONG_WASM_RUNTIMES="https://github.com/kong/ngx_wasm_runtimes"
 
+export PERL5LIB=$DIR_CPANM/lib/perl5
+
 build_nginx() {
     local ngx_src=$1
     local ngx_ver=$2

--- a/util/setup_dev.sh
+++ b/util/setup_dev.sh
@@ -32,6 +32,7 @@ pushd $DIR_CPANM
     fi
 
     notice "downloading Test::Nginx dependencies..."
+    HOME=$DIR_CPANM ./cpanm $PERL_ARGS local::lib
     HOME=$DIR_CPANM ./cpanm $PERL_ARGS Test::Nginx
     HOME=$DIR_CPANM ./cpanm $PERL_ARGS IPC::Run
     HOME=$DIR_CPANM ./cpanm $PERL_ARGS Regexp::Common


### PR DESCRIPTION
Ensures `util/morestyle.pl` finds it in our local environment if not installed on the system-wide cpan tree.