### PR TITLE
chore(build) embed RPATH setting in config script

### DIFF
--- a/auto/runtime
+++ b/auto/runtime
@@ -16,8 +16,13 @@ if [ -n "$ngx_wasm_runtime_inc" ]; then
 fi
 
 if [ -n "$ngx_wasm_runtime_lib" ]; then
-    ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib -l$ngx_wasm_runtime_lib_name"
-    ngx_feature_libs="$ngx_wasm_runtime_lib -l$ngx_wasm_runtime_lib_name"
+    if [ $NGX_RPATH = yes ]; then
+        ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-R/g') -l$ngx_wasm_runtime_lib_name"
+        ngx_feature_libs="$ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-R/g') -l$ngx_wasm_runtime_lib_name"
+    else
+        ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-Wl,-rpath,/g') -l$ngx_wasm_runtime_lib_name"
+        ngx_feature_libs="$ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-Wl,-rpath,/g') -l$ngx_wasm_runtime_lib_name"
+    fi
 fi
 
 if [ -n "$ngx_wasm_runtime_opt" ]; then

--- a/config
+++ b/config
@@ -53,11 +53,13 @@ ngx_wasm_runtime_opt=$NGX_LD_OPT
 
 . $ngx_addon_dir/auto/runtime
 
-ngx_wasm_runtime_inc="-I $NGX_WASM_RUNTIME_INC"
-ngx_wasm_runtime_lib="-L$NGX_WASM_RUNTIME_LIB"
-ngx_wasm_runtime_opt=$NGX_WASM_RUNTIME_LD_OPT
+if [ -n "$NGX_WASM_RUNTIME_INC" -o -n "$NGX_WASM_RUNTIME_LIB" ]; then
+    ngx_wasm_runtime_inc="-I $NGX_WASM_RUNTIME_INC"
+    ngx_wasm_runtime_lib="-L$NGX_WASM_RUNTIME_LIB"
+    ngx_wasm_runtime_opt=$NGX_WASM_RUNTIME_LD_OPT
 
-. $ngx_addon_dir/auto/runtime
+    . $ngx_addon_dir/auto/runtime
+fi
 
 ngx_wasm_runtime_inc="-I /usr/local/opt/include"
 ngx_wasm_runtime_lib="-L/usr/local/opt/lib"

--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -57,10 +57,6 @@ build_nginx() {
         # clang 13: -fsanitize-ignorelist=$NGX_WASM_DIR/asan.ignore
     fi
 
-    if [[ -n "$NGX_WASM_RUNTIME_LIB" ]]; then
-        NGX_BUILD_LD_OPT="$NGX_BUILD_LD_OPT -Wl,-rpath,$NGX_WASM_RUNTIME_LIB"
-    fi
-
     if [[ "$NGX_BUILD_CLANG_ANALYZER" == 1 ]]; then
         build_name+=" clang-analyzer"
         NGX_BUILD_CMD="scan-build -o $DIR_WORK/scans \
@@ -202,6 +198,7 @@ build_nginx() {
               || ! -f "Makefile" \
               || ! -d "$NGX_BUILD_DIR_BUILDROOT" \
               || "$NGX_WASM_DIR/config" -nt "Makefile" \
+              || "$NGX_WASM_DIR/auto/runtime" -nt "Makefile" \
               || "$NGX_WASM_DIR/Makefile" -nt "Makefile" \
               || "$NGX_WASM_DIR/util/build.sh" -nt "Makefile" \
               || "$NGX_WASM_DIR/util/_lib.sh" -nt "Makefile" ]];


### PR DESCRIPTION
* Move the setting of RPATH within the module's config system rather than the dev environment's build system. This enhances the intuitiveness of the `NGX_WASM_RUNTIME_LIB` env variable, and avoids having to also specify the RPATH in `NGX_WASM_RUNTIME_LD_OPT` or `--with-ld-opt=`.
* Skip `NGX_WASM_RUNTIME_*` feature check if env vars are not specified, which makes `autoconf.err` easier to read.
* Consider `auto/runtime` script in the build system's "auto-remake" feature.