### PR TITLE
fix(v8) adjust init order to fix error handling

### DIFF
--- a/src/wasm/wrt/ngx_wrt_v8.c
+++ b/src/wasm/wrt/ngx_wrt_v8.c
@@ -323,6 +323,10 @@ ngx_v8_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
         goto error;
     }
 
+    instance->pool = pool;
+    instance->store = store;
+    instance->module = module;
+
     instance->ctxs = ngx_pcalloc(pool,
                                  sizeof(ngx_v8_hfunc_ctx_t) * module->nimports);
     if (instance->ctxs == NULL) {
@@ -353,10 +357,6 @@ ngx_v8_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
         dd("wasm_instance_new failed");
         goto error;
     }
-
-    instance->pool = pool;
-    instance->store = store;
-    instance->module = module;
 
     wasm_instance_exports(instance->instance, &instance->externs);
 


### PR DESCRIPTION
Field `instance->imports` gets initialized early on in `ngx_v8_init_instance`, but later steps may fail. However, the destructor logic for `instance->imports` in `ngx_v8_destroy_instance` relies on `instance->module` and `instance->pool`. This commits initializes these fields earlier so that any cases that trigger `goto error` can work properly.