### PR TITLE
fix(wasi) return value of clock_time_get in nanoseconds

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -701,21 +701,14 @@ static ngx_int_t
 ngx_proxy_wasm_hfuncs_get_current_time(ngx_wavm_instance_t *instance,
     wasm_val_t args[], wasm_val_t rets[])
 {
-    void        *rtime;
-    uint64_t     t;
-    ngx_time_t  *tp;
+    void  *rtime;
 
     /* WASM might not align 64-bit integers to 8-byte boundaries. So we
      * need to buffer & copy here. */
     rtime = NGX_WAVM_HOST_LIFT_SLICE(instance, args[0].of.i32,
                                      sizeof(uint64_t));
 
-    ngx_time_update();
-
-    tp = ngx_timeofday();
-
-    t = (tp->sec * 1000 + tp->msec) * 1e6;
-    ngx_memcpy(rtime, &t, sizeof(uint64_t));
+    ngx_wasm_wall_time(rtime);
 
     return ngx_proxy_wasm_result_ok(rets);
 }

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -110,6 +110,7 @@ ngx_int_t ngx_wasm_bytes_from_path(wasm_byte_vec_t *out, u_char *path,
 ngx_uint_t ngx_wasm_list_nelts(ngx_list_t *list);
 ngx_str_t *ngx_wasm_get_list_elem(ngx_list_t *map, u_char *key, size_t key_len);
 ngx_msec_t ngx_wasm_monotonic_time();
+void ngx_wasm_wall_time(void *rtime);
 void ngx_wasm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     const char *fmt, ...);
 

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -485,6 +485,24 @@ ngx_wasm_monotonic_time()
 
 
 void
+ngx_wasm_wall_time(void *rtime)
+{
+    uint64_t     t;
+    ngx_time_t  *tp;
+
+    ngx_time_update();
+
+    tp = ngx_timeofday();
+
+    t = (tp->sec * 1000 + tp->msec) * 1e6;
+
+    /* WASM might not align 64-bit integers to 8-byte boundaries. So we
+     * need to buffer & copy here. */
+    ngx_memcpy(rtime, &t, sizeof(uint64_t));
+}
+
+
+void
 ngx_wasm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     const char *fmt, ...)
 {

--- a/t/01-wasm/hfuncs/wasi/004-clock_time_get.t
+++ b/t/01-wasm/hfuncs/wasi/004-clock_time_get.t
@@ -16,9 +16,9 @@ __DATA__
     location /t {
         wasm_call rewrite ngx_rust_tests test_wasi_clock_time_get_via_systemtime;
     }
---- error_code: 204
---- no_error_log
-[error]
+--- error_code: 200
+--- response_body eval
+qr/seconds since Unix epoch: [1-9][0-9]{9}\n/
 
 
 
@@ -40,9 +40,9 @@ __DATA__
     location /t {
         wasm_call rewrite ngx_rust_tests test_wasi_clock_time_get;
     }
---- error_code: 204
---- no_error_log
-[error]
+--- error_code: 200
+--- response_body eval
+qr/test passed with timestamp: [0-9]+\n/
 
 
 

--- a/t/lib/ngx-rust-tests/src/test_wasi.rs
+++ b/t/lib/ngx-rust-tests/src/test_wasi.rs
@@ -65,7 +65,7 @@ pub fn test_wasi_clock_time_get_via_systemtime() {
     match now.duration_since(SystemTime::UNIX_EPOCH) {
         Ok(n) => {
             let msg = format!("seconds since Unix epoch: {}", n.as_secs());
-            resp::ngx_resp_local_reason(204, &msg);
+            resp::ngx_resp_say(&msg);
         }
         Err(_) => {
             resp::ngx_resp_local_reason(500, "test failed, bad system time");
@@ -90,7 +90,7 @@ pub fn test_wasi_clock_time_get() {
     // direct WASI access
     if let Ok(timestamp) = unsafe { wasi::clock_time_get(wasi::CLOCKID_REALTIME, 0) } {
         let msg = format!("test passed with timestamp: {timestamp}");
-        resp::ngx_resp_local_reason(204, &msg);
+        resp::ngx_resp_say(&msg);
     } else {
         resp::ngx_resp_local_reason(500, "test failed");
     }


### PR DESCRIPTION
In the test, ensure we get a 10-digit Unix timestamp (good until the year 2286 ;) ).

My first version of this commit missed the alignment issue that `ngx_proxy_wasm_hfuncs_get_current_time` took care of, so I decided to take the correct implementation from that function and refactor it into a `ngx_wasm_wall_time` utility to be used by both the proxy-wasm and WASI APIs, to ensure that any future fixes to this wall-time operation gets propagated to both evenly.
