### PR TITLE
chore(proxy-wasm) disable on_response_trailers step

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -581,7 +581,9 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     case NGX_PROXY_WASM_STEP_REQ_BODY:
     case NGX_PROXY_WASM_STEP_RESP_HEADERS:
     case NGX_PROXY_WASM_STEP_RESP_BODY:
+#ifdef NGX_WASM_RESPONSE_TRAILERS
     case NGX_PROXY_WASM_STEP_RESP_TRAILERS:
+#endif
         ecode = ngx_proxy_wasm_on_start(ictx, filter, 0);
         if (ecode != NGX_PROXY_WASM_ERR_NONE) {
             pwexec->ecode = ecode;

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -7,14 +7,18 @@
 #include <ngx_http.h>
 #include <ngx_http_wasm_util.h>
 #include <ngx_http_wasm_headers.h>
+#ifdef NGX_WASM_RESPONSE_TRAILERS
 #include <ngx_http_wasm_trailers.h>
+#endif
 
 
 #define NGX_HTTP_WASM_MAX_REQ_HEADERS      100
 
 #define NGX_HTTP_WASM_HEADER_FILTER_PHASE  (NGX_HTTP_LOG_PHASE + 1)
 #define NGX_HTTP_WASM_BODY_FILTER_PHASE    (NGX_HTTP_LOG_PHASE + 2)
+#ifdef NGX_WASM_RESPONSE_TRAILERS
 #define NGX_HTTP_WASM_TRAILER_FILTER_PHASE (NGX_HTTP_LOG_PHASE + 3)
+#endif
 
 #define ngx_http_wasm_req_yielded(rctx)                                      \
     (rctx->state == NGX_HTTP_WASM_REQ_STATE_YIELD)

--- a/src/http/ngx_http_wasm_filter_module.c
+++ b/src/http/ngx_http_wasm_filter_module.c
@@ -157,10 +157,12 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
                             &rctx->free_bufs, &rctx->busy_bufs,
                             &rctx->resp_chunk, buf_tag);
 
+#ifdef NGX_WASM_RESPONSE_TRAILERS
     if (rctx->resp_chunk_eof && r->parent == NULL) {
         (void) ngx_wasm_ops_resume(&rctx->opctx,
                                    NGX_HTTP_WASM_TRAILER_FILTER_PHASE);
     }
+#endif
 
 done:
 

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -67,9 +67,11 @@ static ngx_wasm_phase_t  ngx_http_wasm_phases[] = {
       NGX_HTTP_WASM_BODY_FILTER_PHASE,
       (1 << NGX_HTTP_WASM_BODY_FILTER_PHASE) },
 
+#ifdef NGX_WASM_RESPONSE_TRAILERS
     { ngx_string("trailer_filter"),
       NGX_HTTP_WASM_TRAILER_FILTER_PHASE,
       (1 << NGX_HTTP_WASM_TRAILER_FILTER_PHASE) },
+#endif
 
     { ngx_string("log"),
       NGX_HTTP_LOG_PHASE,

--- a/src/http/ngx_http_wasm_trailers_response.c
+++ b/src/http/ngx_http_wasm_trailers_response.c
@@ -7,8 +7,10 @@
 #include <ngx_http_wasm.h>
 
 
+#ifdef NGX_WASM_RESPONSE_TRAILERS
 size_t
 ngx_http_wasm_resp_trailers_count(ngx_http_request_t *r)
 {
     return ngx_wasm_list_nelts(&r->headers_out.trailers);
 }
+#endif

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -449,7 +449,9 @@ ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
                     | (1 << NGX_HTTP_CONTENT_PHASE)
                     | (1 << NGX_HTTP_WASM_HEADER_FILTER_PHASE)
                     | (1 << NGX_HTTP_WASM_BODY_FILTER_PHASE)
+#ifdef NGX_WASM_RESPONSE_TRAILERS
                     | (1 << NGX_HTTP_WASM_TRAILER_FILTER_PHASE)
+#endif
                     | (1 << NGX_HTTP_LOG_PHASE)
                     | (1 << NGX_WASM_DONE_PHASE);
 

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -241,6 +241,7 @@ ngx_http_proxy_wasm_on_response_body(ngx_proxy_wasm_exec_t *pwexec,
 }
 
 
+#ifdef NGX_WASM_RESPONSE_TRAILERS
 static ngx_int_t
 ngx_http_proxy_wasm_on_response_trailers(ngx_proxy_wasm_exec_t *pwexec,
     ngx_uint_t *ret)
@@ -282,6 +283,7 @@ ngx_http_proxy_wasm_on_response_trailers(ngx_proxy_wasm_exec_t *pwexec,
 
     return rc;
 }
+#endif
 
 
 static ngx_int_t
@@ -410,9 +412,11 @@ ngx_http_proxy_wasm_resume(ngx_proxy_wasm_exec_t *pwexec,
     case NGX_PROXY_WASM_STEP_RESP_BODY:
         rc = ngx_http_proxy_wasm_on_response_body(pwexec, ret);
         break;
+#ifdef NGX_WASM_RESPONSE_TRAILERS
     case NGX_PROXY_WASM_STEP_RESP_TRAILERS:
         rc = ngx_http_proxy_wasm_on_response_trailers(pwexec, ret);
         break;
+#endif
     case NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE:
         rc = ngx_http_proxy_wasm_on_dispatch_response(pwexec);
         break;

--- a/src/wasm/ngx_wasm_ops.c
+++ b/src/wasm/ngx_wasm_ops.c
@@ -430,10 +430,12 @@ ngx_wasm_op_proxy_wasm_handler(ngx_wasm_op_ctx_t *opctx,
                                    NGX_PROXY_WASM_STEP_RESP_BODY);
         break;
 
+#ifdef NGX_WASM_RESPONSE_TRAILERS
     case NGX_HTTP_WASM_TRAILER_FILTER_PHASE:
         rc = ngx_proxy_wasm_resume(pwctx, phase,
                                    NGX_PROXY_WASM_STEP_RESP_TRAILERS);
         break;
+#endif
 
     case NGX_HTTP_LOG_PHASE:
         rc = ngx_proxy_wasm_resume(pwctx, phase,

--- a/t/03-proxy_wasm/004-on_http_phases.t
+++ b/t/03-proxy_wasm/004-on_http_phases.t
@@ -232,6 +232,7 @@ Hello
 
 
 === TEST 11: proxy_wasm - on_response_trailers gets number of response trailers (with body)
+--- SKIP: HTTP trailers support is not ready yet
 --- http2
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
@@ -260,6 +261,7 @@ qr/#\d+ on_response_headers, \d+ headers.*
 
 === TEST 12: proxy_wasm - on_response_trailers gets number of response trailers (without body)
 No trailers in response
+--- SKIP: HTTP trailers support is not ready yet
 --- http2
 --- wasm_modules: on_phases
 --- config
@@ -314,7 +316,6 @@ qr/404 Not Found/
 qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, \d+ bytes.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- error_log eval
 qr/\[error\] .*? open\(\) \".*?\" failed/
@@ -337,7 +338,6 @@ should produce a response in and of itself, proxy_wasm wraps around
 --- grep_error_log_out eval
 qr/#\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 0 bytes.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -362,7 +362,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -388,7 +387,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -425,7 +423,6 @@ qq{
 qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -454,7 +451,6 @@ should not execute a log phase
 qr/#\d+ on_request_headers, 2 headers.*? subrequest: "\/subrequest".*
 #\d+ on_response_headers, 5 headers.*? subrequest: "\/subrequest".*/
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 --- no_error_log
 [error]
 on_log
@@ -487,7 +483,6 @@ qr/#\d+ on_request_headers, 3 headers.*? subrequest: "\/subrequest".*
 #\d+ on_response_headers, 5 headers.*? subrequest: "\/subrequest".*
 #\d+ on_response_body, 3 bytes, eof: false.*? subrequest: "\/subrequest".*
 #\d+ on_response_body, 0 bytes, eof: true.*? subrequest: "\/subrequest".*/
-#\d+ on_response_trailers, 0 trailers.*
 --- no_error_log
 [error]
 on_log
@@ -516,7 +511,6 @@ qr/#\d+ on_request_headers, 3 headers.*? subrequest: "\/subrequest".*
 #\d+ on_response_headers, 5 headers.*? subrequest: "\/subrequest".*
 #\d+ on_response_body, 3 bytes, eof: false.*? subrequest: "\/subrequest".*
 #\d+ on_response_body, 0 bytes, eof: true.*? subrequest: "\/subrequest".*/
-#\d+ on_response_trailers, 0 trailers.*
 --- no_error_log
 [error]
 on_log
@@ -629,7 +623,6 @@ qr/#\d+ on_request_headers, 2 headers.*? subrequest: "\/subrequest\/a".*
 #\d+ on_response_headers, 5 headers.*? subrequest: "\/subrequest\/b".*
 #\d+ on_response_body, 2 bytes, eof: false.*? subrequest: "\/subrequest\/b".*
 #\d+ on_response_body, 0 bytes, eof: true.*? subrequest: "\/subrequest\/b".*/
-#\d+ on_response_trailers, 0 trailers.*
 --- no_error_log
 [error]
 on_log
@@ -664,8 +657,6 @@ qr/#\d+ on_request_headers, 3 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*
 #\d+ on_log.*/
 --- no_error_log
@@ -697,8 +688,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log .*
 #\d+ on_log .*/
 --- no_error_log
@@ -730,8 +719,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log .*
 #\d+ on_log .*/
 --- no_error_log
@@ -759,7 +746,6 @@ qr/#\d+ on_request_headers, 2 headers.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- error_log eval
 qr/log_msg: server .*? request: "GET \/t\s+/
@@ -785,7 +771,6 @@ should not chain; instead, location{} overrides server{}
 --- grep_error_log_out eval
 qr/#\d+ on_response_headers, \d+ headers.*
 #\d+ on_response_body, \d+ bytes.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- error_log eval
 qr/log_msg: location .*? request: "GET \/t\s+/
@@ -813,7 +798,6 @@ should not chain; instead, location{} overrides server{}, server{} overrides htt
 --- grep_error_log_out eval
 qr/#\d+ on_response_headers, \d+ headers.*
 #\d+ on_response_body, \d+ bytes.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- error_log eval
 qr/log_msg: location .*? request: "GET \/t\s+/

--- a/t/03-proxy_wasm/006-instance_lifecycle.t
+++ b/t/03-proxy_wasm/006-instance_lifecycle.t
@@ -35,8 +35,6 @@ should use a global instance reused across streams
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "trailer_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "done" phase.*
@@ -52,8 +50,6 @@ qr/\A\*\d+ proxy_wasm "hostcalls" filter reusing instance.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "trailer_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "done" phase.*
@@ -148,8 +144,6 @@ should use an instance per stream
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "trailer_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "done" phase.*
@@ -166,8 +160,6 @@ qr/\A\*\d+ proxy_wasm "hostcalls" filter new instance.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "trailer_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(2\/2\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/2\) resuming in "done" phase.*

--- a/t/03-proxy_wasm/008-trap_on_phases.t
+++ b/t/03-proxy_wasm/008-trap_on_phases.t
@@ -3,6 +3,7 @@
 use strict;
 use lib '.';
 use t::TestWasm;
+use Test::Nginx::Socket skip_all => 'HTTP trailers support is not ready yet';
 
 skip_no_debug();
 skip_valgrind('wasmtime');

--- a/t/03-proxy_wasm/102-proxy_send_local_response.t
+++ b/t/03-proxy_wasm/102-proxy_send_local_response.t
@@ -155,7 +155,6 @@ qr/.*? on_request_headers, 2 headers, .*
 .*? testing in "RequestHeaders", .*
 .*? on_response_headers, 5 headers, .*
 .*? on_response_body, 0 bytes, eof: true, .*
-.*? on_response_trailers, 0 trailers, .*
 .*? on_log.*/
 --- no_error_log
 [error]
@@ -261,7 +260,6 @@ qr/.*? on_request_headers, 2 headers, .*
 .*? testing in "RequestHeaders", .*
 .*? on_response_headers, 16 headers, .*
 .*? on_response_body, 0 bytes, eof: true, .*
-.*? on_response_trailers, 0 trailers, .*
 .*? on_log.*/
 --- no_error_log
 [error]
@@ -485,8 +483,6 @@ qr/.*? on_request_headers, \d+ headers.*
 .*? on_response_headers, \d+ headers.*
 .*? on_response_body, \d+ bytes, eof: true.*
 .*? on_response_body, \d+ bytes, eof: true.*
-.*? on_response_trailers, \d+ trailers.*
-.*? on_response_trailers, \d+ trailers.*
 .*? on_log.*
 .*? on_log.*/
 --- no_error_log

--- a/t/03-proxy_wasm/119-proxy_get_property.t
+++ b/t/03-proxy_wasm/119-proxy_get_property.t
@@ -80,7 +80,6 @@ my $phases = CORE::join(',', qw(
     request_body
     response_headers
     response_body
-    response_trailers
 ));
 
 qq{
@@ -109,7 +108,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -159,7 +157,7 @@ request.total_size: [1-9]+[0-9]+ at OnHttpCallResponse/
 
 
 
-=== TEST 4: proxy_wasm - get_property() - request.headers.[header_name] on: request_headers,request_body,response_headers,response_body,response_trailers
+=== TEST 4: proxy_wasm - get_property() - request.headers.[header_name] on: request_headers,request_body,response_headers,response_body
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval
@@ -168,7 +166,6 @@ my $phases = CORE::join(',', qw(
     request_body
     response_headers
     response_body
-    response_trailers
 ));
 
 qq {
@@ -195,7 +192,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -209,12 +205,12 @@ qr/$checks/
 
 
 
-=== TEST 5: proxy_wasm - get_property() - response properties on: response_headers,response_body,response_trailers
+=== TEST 5: proxy_wasm - get_property() - response properties on: response_headers,response_body
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
     location /t {
-        proxy_wasm hostcalls 'on=response_headers,response_body,response_trailers \
+        proxy_wasm hostcalls 'on=response_headers,response_body \
                               test=/t/log/properties \
                               name=response.code,response.size,response.total_size';
         echo ok;
@@ -231,16 +227,13 @@ response\.size: 0 at ResponseBody
 response\.total_size: 0 at ResponseBody
 response\.code: 200 at ResponseBody
 response\.size: 0 at ResponseBody
-response\.total_size: 0 at ResponseBody
-response\.code: 200 at ResponseTrailers
-response\.size: [1-9][0-9]* at ResponseTrailers
-response\.total_size: [1-9][0-9]* at ResponseTrailers/
+response\.total_size: 0 at ResponseBody/
 --- no_error_log
 [error]
 
 
 
-=== TEST 6: proxy_wasm - get_property() - response.headers.header_name - on response_headers,response_body,response_trailers
+=== TEST 6: proxy_wasm - get_property() - response.headers.header_name - on response_headers,response_body
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config eval
@@ -261,7 +254,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_wasm hostcalls 'on=response_headers,response_body,response_trailers \
+        proxy_wasm hostcalls 'on=response_headers,response_body \
                               test=/t/log/properties \
                               name=response.headers.foo,response.headers.bar';
         proxy_pass http://test_upstream/;
@@ -275,7 +268,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -289,7 +281,7 @@ qr/$checks/
 
 
 
-=== TEST 7: proxy_wasm - get_property() - upstream properties on: response_headers,response_body,response_trailers
+=== TEST 7: proxy_wasm - get_property() - upstream properties on: response_headers,response_body
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config eval
@@ -309,7 +301,7 @@ qq{
 --- config
     location /t {
         proxy_pass http://test_upstream/;
-        proxy_wasm hostcalls 'on=response_headers,response_body,response_trailers \
+        proxy_wasm hostcalls 'on=response_headers,response_body \
                               test=/t/log/properties \
                               name=upstream.address,upstream.port';
     }
@@ -322,7 +314,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -379,7 +370,7 @@ property not found: upstream.port
 
 
 
-=== TEST 10: proxy_wasm - get_property() - connection properties on: request_headers,response_headers,response_body,response_trailers
+=== TEST 10: proxy_wasm - get_property() - connection properties on: request_headers,response_headers,response_body
 --- skip_eval: 4: $::nginxV !~ m/built with OpenSSL/
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -388,7 +379,6 @@ my $phases = CORE::join(',', qw(
     request_headers
     response_headers
     response_body
-    response_trailers
 ));
 
 my $vars = CORE::join(',', qw(
@@ -438,7 +428,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -456,7 +445,7 @@ qr/$checks/
 
 
 
-=== TEST 11: proxy_wasm - get_property() - connection properties (mTLS) on: request_headers,response_headers,response_body,response_trailers
+=== TEST 11: proxy_wasm - get_property() - connection properties (mTLS) on: request_headers,response_headers,response_body
 --- skip_eval: 4: $::nginxV !~ m/built with OpenSSL/
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -465,7 +454,6 @@ my $phases = CORE::join(',', qw(
     request_headers
     response_headers
     response_body
-    response_trailers
 ));
 
 qq {
@@ -507,7 +495,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {
@@ -521,7 +508,7 @@ qr/$checks/
 
 
 
-=== TEST 12: proxy_wasm - get_property() - proxy-wasm properties on: request_headers,request_body,response_headers,response_body,response_trailers
+=== TEST 12: proxy_wasm - get_property() - proxy-wasm properties on: request_headers,request_body,response_headers,response_body
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval
@@ -530,7 +517,6 @@ my $phases = CORE::join(',', qw(
     request_body
     response_headers
     response_body
-    response_trailers
 ));
 
 qq {
@@ -555,7 +541,6 @@ my @phases = qw(
     ResponseHeaders
     ResponseBody
     ResponseBody
-    ResponseTrailers
 );
 
 foreach my $phase (@phases) {

--- a/t/04-openresty/100-ffi/004-proxy_wasm_attach.t
+++ b/t/04-openresty/100-ffi/004-proxy_wasm_attach.t
@@ -110,7 +110,6 @@ qr/#0 on_configure, config_size: 0.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -168,7 +167,6 @@ qr/#0 on_configure, config_size: 0.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -226,7 +224,6 @@ qr/#0 on_configure, config_size: 0.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]
@@ -344,7 +341,6 @@ qr/.*?\*\d+ proxy_wasm "hostcalls" filter new instance.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "done" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) finalizing context.*
@@ -356,7 +352,6 @@ qr/.*?\*\d+ proxy_wasm "hostcalls" filter new instance.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "header_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "body_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "body_filter" phase.*
-\*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "trailer_filter" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "log" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) resuming in "done" phase.*
 \*\d+ proxy_wasm "hostcalls" filter \(1\/1\) finalizing context.*
@@ -436,7 +431,6 @@ qr/#0 on_configure, config_size: 0.*
 #\d+ on_response_headers, 5 headers.*
 #\d+ on_response_body, 3 bytes, eof: false.*
 #\d+ on_response_body, 0 bytes, eof: true.*
-#\d+ on_response_trailers, 0 trailers.*
 #\d+ on_log.*/
 --- no_error_log
 [error]


### PR DESCRIPTION
`proxy_pass` doesn't support HTTP trailers yet so it won't pass along trailers received from the upstream.
