### PR TITLE
fix(ffi) avoid a double-free in ngx_wasm_ops_plan

### DIFF
--- a/src/common/ngx_wasm_ffi.c
+++ b/src/common/ngx_wasm_ffi.c
@@ -71,9 +71,6 @@ ngx_http_wasm_ffi_plan_new(ngx_wavm_t *vm,
 void
 ngx_http_wasm_ffi_plan_free(ngx_wasm_ops_plan_t *plan)
 {
-    ngx_log_debug1(NGX_LOG_DEBUG_WASM, ngx_cycle->log, 0,
-                   "wasm freeing plan: %p", plan);
-
     ngx_wasm_ops_plan_destroy(plan);
 }
 
@@ -81,9 +78,6 @@ ngx_http_wasm_ffi_plan_free(ngx_wasm_ops_plan_t *plan)
 ngx_int_t
 ngx_http_wasm_ffi_plan_load(ngx_wasm_ops_plan_t *plan)
 {
-    ngx_log_debug1(NGX_LOG_DEBUG_WASM, ngx_cycle->log, 0,
-                   "wasm loading plan: %p", plan);
-
     if (ngx_wasm_ops_plan_load(plan, ngx_cycle->log) != NGX_OK) {
         return NGX_ERROR;
     }

--- a/src/wasm/ngx_wasm_ops.c
+++ b/src/wasm/ngx_wasm_ops.c
@@ -156,7 +156,8 @@ ngx_wasm_ops_plan_load(ngx_wasm_ops_plan_t *plan, ngx_log_t *log)
         return NGX_OK;
     }
 
-    dd("loading new plan (plan: %p)", plan);
+    ngx_log_debug1(NGX_LOG_DEBUG_WASM, log, 0,
+                   "wasm loading plan: %p", plan);
 
     /* initialize pipelines */
 
@@ -234,13 +235,8 @@ ngx_wasm_ops_plan_load(ngx_wasm_ops_plan_t *plan, ngx_log_t *log)
 void
 ngx_wasm_ops_plan_destroy(ngx_wasm_ops_plan_t *plan)
 {
-    size_t                    i;
-    ngx_wasm_ops_pipeline_t  *pipeline;
-
-    for (i = 0; i < plan->subsystem->nphases; i++) {
-        pipeline = &plan->pipelines[i];
-        ngx_array_destroy(&pipeline->ops);
-    }
+    ngx_log_debug1(NGX_LOG_DEBUG_WASM, ngx_cycle->log, 0,
+                   "wasm freeing plan: %p", plan);
 
     if (plan->loaded) {
         ngx_array_destroy(&plan->conf.proxy_wasm.filter_ids);


### PR DESCRIPTION
Detected by enabling Valgrind tests on OpenResty/Wasm FFI test suites in the Lua bridge branch.