### PR TITLE
chore(ci) enable CI on pull requests for all base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: main
   pull_request:
-    branches: '*'
+    branches: '**'
 
 defaults:
   run:


### PR DESCRIPTION
From https://stackoverflow.com/questions/64635032/github-actions-run-on-push-to-all-branches

> I found the Filter pattern cheat sheet after posting the question:
>
> > `'*'`: Matches all branch and tag names that don't contain a slash (`/`).
> > The `*` character is a special character in YAML. When you start a
> > pattern with `*`, you must use quotes.
> >
> > `'**'`: Matches all branch and tag names. This is the default behavior
> > when you don't use a branches or tags filter.
>
> It happened that the branch I was testing contained a slash (`/`),
> so one asterisk (`*`) wasn't enough. I switched to two asterisks
> (`**`) and it works now.