### PR TITLE
style(*) use 'p' instead of 'p != NULL'

### DIFF
--- a/src/common/ngx_wasm_socket_tcp.c
+++ b/src/common/ngx_wasm_socket_tcp.c
@@ -690,7 +690,7 @@ ngx_wasm_socket_tcp_ssl_set_server_name(ngx_connection_t *c, ngx_str_t *name)
 
     p = ngx_strlchr(p, last, ':');
 
-    if (p != NULL) {
+    if (p) {
         name->len = p - name->data;
     }
 

--- a/src/http/ngx_http_wasm_directives.c
+++ b/src/http/ngx_http_wasm_directives.c
@@ -266,9 +266,7 @@ ngx_http_wasm_resolver_add_directive(ngx_conf_t *cf, ngx_command_t *cmd,
     rn->expire = NGX_MAX_UINT32_VALUE;
     rn->node.key = ngx_crc32_short(rn->name, rn->nlen);
 
-    if (ngx_strlchr(address->data, address->data + address->len, ':')
-        != NULL)
-    {
+    if (ngx_strlchr(address->data, address->data + address->len, ':')) {
 
 #if (NGX_HAVE_INET6)
         if (!r->ipv6

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -704,7 +704,7 @@ ngx_http_wasm_finalize_fake_request(ngx_http_request_t *r, ngx_int_t rc)
 
                 if (c && c->ssl) {
                     cctx = ngx_http_lua_ssl_get_ctx(c->ssl->connection);
-                    if (cctx != NULL) {
+                    if (cctx) {
                         cctx->exit_code = 0;
                     }
                 }

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -243,7 +243,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 
     p = ngx_strlchr(p, last, ':');
 
-    if (p != NULL) {
+    if (p) {
         port = ngx_atoi(p + 1, last - p);
     }
 

--- a/src/wasm/vm/ngx_wavm_host.c
+++ b/src/wasm/vm/ngx_wavm_host.c
@@ -129,7 +129,7 @@ ngx_wavm_host_kindvec2typevec(const wasm_valkind_t **valkinds,
 
     for (i = 0; i < out->size; i++) {
         valkind = ((wasm_valkind_t **) valkinds)[i];
-        ngx_wasm_assert(valkind != NULL);
+        ngx_wasm_assert(valkind);
         out->data[i] = wasm_valtype_new(*valkind);
     }
 }

--- a/util/morestyle.pl
+++ b/util/morestyle.pl
@@ -361,6 +361,12 @@ for my $file (@ARGV) {
                  }
             }
 
+            # zero/null tests */
+
+            if ($line =~ /!= NULL/) {
+                output "use 'if (ptr)' instead of if (ptr != NULL)";
+            }
+
             ##################################################################
             # end new rules - excluding comment lines
             ##################################################################


### PR DESCRIPTION
Recommended Nginx-like style for null tests is:

* `if (p == NULL)` for checking that a pointer is `NULL`
* `if (p)` for checking that a pointer is *not* `NULL`

We cannot test lexically that we're not using `if (!p)` because we don't know the type of `p` and `!p` _is_ accepted for integer checks(!) as a synonym of `p == 0`, but we _can_ test lexically that `!= NULL` should not be used, so we do it on `util/morestyle.pl` (triggered by `make lint` and the CI.

We also fix the few places where this rule wasn't being followed in the current codebase.

(More context: https://github.com/Kong/ngx_wasm_module/pull/231#discussion_r1136015512 )