### PR TITLE
chore(ci) fix source release archive and artifact failures upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,38 +19,59 @@ env:
 
 jobs:
   setup:
-    name: "Setup runtime versions"
+    name: "Setup release name & runtime versions"
     runs-on: ubuntu-latest
     outputs:
-      wasmtime_ver: ${{ steps.versions.outputs.wasmtime_ver }}
-      wasmer_ver: ${{ steps.versions.outputs.wasmer_ver }}
-      v8_ver: ${{ steps.versions.outputs.v8_ver }}
+      wasmtime_ver: ${{ steps.assign-versions.outputs.wasmtime_ver }}
+      wasmer_ver: ${{ steps.assign-versions.outputs.wasmer_ver }}
+      v8_ver: ${{ steps.assign-versions.outputs.v8_ver }}
+      release_name: ${{ steps.assign-name.outputs.release_name }}
     steps:
       - uses: actions/checkout@v3
-      - id: versions
+      - id: assign-versions
         run: |
           export NGX_WASM_DIR=$(pwd)
           . ./util/_lib.sh
           echo "wasmtime_ver=$(get_variable_from_makefile WASMTIME)" >> $GITHUB_OUTPUT
           echo "wasmer_ver=$(get_variable_from_makefile WASMER)" >> $GITHUB_OUTPUT
           echo "v8_ver=$(get_variable_from_makefile V8)" >> $GITHUB_OUTPUT
+      - id: assign-name
+        run: |
+          if [ "${{ github.event_name }}" = schedule ]; then
+            echo "release_name=nightly-$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+          else
+            echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+          fi
 
-  build-images:
-    name: "Build Docker binary build images"
+  source-release:
+    name: "Source release"
     needs: setup
     runs-on: ubuntu-latest
-    outputs:
-      release_name: ${{ steps.assign-name.outputs.release_name }}
     steps:
+      - uses: actions/checkout@v3
+      - name: Build archive
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --src
+      - name: Upload archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-artifacts
+          path: dist
+          retention-days: ${{ env.RETENTION_DAYS }}
+
+  build-images:
+    name: "Build Docker compilation images"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.TOKEN_GITHUB }}
-      - name: Set up QEMU
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: "Ubuntu 18.04 build image"
         uses: docker/build-push-action@v2
@@ -82,13 +103,6 @@ jobs:
           file: ./assets/release/Dockerfiles/Dockerfile.amd64.archlinux
           tags: ghcr.io/kong/wasmx-build-arch:latest
           push: true
-      - id: assign-name
-        run: |
-          if [ "${{ github.event_name }}" = schedule ]; then
-            echo "release_name=nightly-$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
-          else
-            echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
-          fi
 
   build-ubuntu-bionic:
     name: "Build Ubuntu 18.04 (bionic) binary"
@@ -106,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -119,7 +133,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   build-ubuntu-focal:
     name: "Build Ubuntu 20.04 (focal) binary"
@@ -137,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -150,7 +164,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   build-centos7:
     name: "Build Centos 7 binary"
@@ -168,7 +182,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -181,7 +195,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   build-centos8:
     name: "Build Centos 8 binary"
@@ -199,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -212,7 +226,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   build-arch:
     name: "Build ArchLinux binary"
@@ -230,7 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -243,7 +257,7 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   build-macos:
     name: "Build macOS binary"
@@ -254,11 +268,11 @@ jobs:
       WASMER_VER: ${{ needs.setup.outputs.wasmer_ver }}
       V8_VER: ${{ needs.setup.outputs.v8_ver }}
     steps:
-      - name: Set up Homebrew dependencies
-        run: brew install ninja
       - uses: actions/checkout@v3
+      - name: Setup Homebrew dependencies
+        run: brew install ninja
       - name: Build binary
-        run: ./util/release.sh ${{ needs.build-images.outputs.release_name }} --bin
+        run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       - name: Upload binary
@@ -271,11 +285,11 @@ jobs:
         if: failure()
         with:
           name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
-          path: work/ngx_wasm_module_dist/build/*
+          path: work/dist/build/*
 
   upload-artifacts:
     name: "Upload release artifacts"
-    needs: [build-images, build-ubuntu-bionic, build-ubuntu-focal, build-centos7, build-centos8, build-arch, build-macos]
+    needs: [source-release, build-images, build-ubuntu-bionic, build-ubuntu-focal, build-centos7, build-centos8, build-arch, build-macos]
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve sibling release artifacts
@@ -288,15 +302,15 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: nightly
           prerelease: true
-          title: ${{ needs.build-images.outputs.release_name }}
+          title: ${{ needs.setup.outputs.release_name }}
           files: |
             *.tar.gz
       - uses: marvinpinto/action-automatic-releases@latest
         if: ${{ github.event_name != 'schedule' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: release-${{ needs.build-images.outputs.release_name }}
+          automatic_release_tag: release-${{ needs.setup.outputs.release_name }}
           prerelease: true
-          title: ${{ needs.build-images.outputs.release_name }}
+          title: ${{ needs.setup.outputs.release_name }}
           files: |
             *.tar.gz


### PR DESCRIPTION
The old `release.sh` script used to build the source module archive when invoked with `--bin`. Now we need an individual job for the `--src` release artifact.

Also fix the path to failed release building uploads.