### PR TITLE
chore(proxy-wasm) increase properties coverage

### DIFF
--- a/src/common/ngx_wasm_ffi.c
+++ b/src/common/ngx_wasm_ffi.c
@@ -98,9 +98,19 @@ ngx_http_wasm_ffi_start(ngx_http_request_t *r)
         return rc;
     }
 
+
+#if 1
+    ngx_wasm_assert(rctx->ffi_attached);
+#else
+    /*
+     * presently, the above rctx rc is already NGX_DECLINED
+     * since loc->plan is empty
+     */
     if (!rctx->ffi_attached) {
+        ngx_wasm_assert(0);
         return NGX_DECLINED;
     }
+#endif
 
     loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -805,10 +805,13 @@ ngx_proxy_wasm_properties_set_ngx(ngx_proxy_wasm_ctx_t *pwctx,
 
     if (v->flags & NGX_HTTP_VAR_INDEXED) {
 
+#if 0
+        /* fake requests are presently caught above */
         if (r->variables == NULL) {
             ngx_wasm_assert(r->connection->fd == NGX_WASM_BAD_FD);
             return NGX_ERROR;
         }
+#endif
 
         vv = &r->variables[v->index];
 

--- a/t/04-openresty/ffi/102-proxy_wasm_start.t
+++ b/t/04-openresty/ffi/102-proxy_wasm_start.t
@@ -88,7 +88,7 @@ plan not loaded and attached
                 return ngx.say(err)
             end
 
-            local ok, err = proxy_wasm.start()
+            ok, err = proxy_wasm.start()
             if not ok then
                 return ngx.say(err)
             end
@@ -130,7 +130,7 @@ plan not loaded and attached
                 return ngx.say(err)
             end
 
-            local ok, err = proxy_wasm.start()
+            ok, err = proxy_wasm.start()
             if not ok then
                 return ngx.say(err)
             end
@@ -184,7 +184,7 @@ qr/#0 on_configure, config_size: 0.*
                 return ngx.say(err)
             end
 
-            local ok, err = proxy_wasm.start()
+            ok, err = proxy_wasm.start()
             if not ok then
                 return ngx.say(err)
             end


### PR DESCRIPTION
- [x] set_property `NGX_DECLINED` was never tested but the intended test wasn't properly updated from its get_property mirror test.
- [x] disable a presently dead code path
- [x] https://coveralls.io/builds/58328480/source?filename=src%2Fcommon%2Fngx_wasm_ffi.c#L102