### PR TITLE
chore(util) bump Go SDK tag to v0.21.0

### DIFF
--- a/util/build_proxy_wasm_go_sdk.sh
+++ b/util/build_proxy_wasm_go_sdk.sh
@@ -19,7 +19,7 @@ if [[ ! -x "$(command -v tinygo)" ]]; then
     fatal "missing 'tinygo', is TinyGo installed?"
 fi
 
-PROXY_WASM_GO_SDK_TAG=${PROXY_WASM_GO_SDK_TAG:-v0.20.0}
+PROXY_WASM_GO_SDK_TAG=${PROXY_WASM_GO_SDK_TAG:-v0.21.0}
 
 if [[ -z "$1" ]]; then
     if ls $DIR_TESTS_LIB_WASM/go_* &> /dev/null; then


### PR DESCRIPTION
We should also consider another matrix dimension with multiple proxy-wasm SDKs & versions.