### PR TITLE
fix(*) handle no http{} block in various cases

### DIFF
--- a/src/common/ngx_wasm_ffi.c
+++ b/src/common/ngx_wasm_ffi.c
@@ -33,6 +33,12 @@ ngx_http_wasm_ffi_plan_new(ngx_wavm_t *vm,
     static ngx_uint_t           isolation = NGX_PROXY_WASM_ISOLATION_STREAM;
 
     mcf = ngx_http_cycle_get_module_main_conf(ngx_cycle, ngx_http_wasm_module);
+    if (mcf == NULL) {
+        /* no http{} block */
+        *errlen = ngx_snprintf(err, *errlen, "%V", &NGX_WASM_STR_NO_HTTP)
+                  - err;
+        return NGX_ERROR;
+    }
 
     plan = ngx_wasm_ops_plan_new(vm->pool, &ngx_http_wasm_subsystem);
     if (plan == NULL) {

--- a/src/common/ngx_wasm_socket_tcp_readers.c
+++ b/src/common/ngx_wasm_socket_tcp_readers.c
@@ -320,6 +320,12 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
     rctx = in_ctx->rctx;
     umcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
                                                ngx_http_upstream_module);
+    if (umcf == NULL) {
+        /* possible path on fake request, no http{} block */
+        ngx_wasm_log_error(NGX_LOG_ERR, in_ctx->log, 0,
+                           "tcp socket - %V", &NGX_WASM_STR_NO_HTTP_UPSTREAM);
+        return NGX_ERROR;
+    }
 
     if (!r->request_start) {
         r->header_in = src;

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -750,7 +750,6 @@ ngx_proxy_wasm_properties_set_ngx(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_http_core_main_conf_t  *cmcf;
 
     rctx = (ngx_http_wasm_req_ctx_t *) pwctx->data;
-
     if (rctx == NULL || rctx->fake_request) {
         ngx_wavm_log_error(NGX_LOG_ERR, pwctx->log, NULL,
                            "cannot set ngx properties outside of a request");
@@ -760,6 +759,12 @@ ngx_proxy_wasm_properties_set_ngx(ngx_proxy_wasm_ctx_t *pwctx,
     r = rctx->r;
 
     cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+    if (cmcf == NULL) {
+        /* possible path on fake request, no http{} block */
+        ngx_wavm_log_error(NGX_LOG_ERR, pwctx->log, NULL,
+                           "%V", &NGX_WASM_STR_NO_HTTP);
+        return NGX_ERROR;
+    }
 
     name.data = (u_char *) (path->data + ngx_prefix_len);
     name.len = path->len - ngx_prefix_len;

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -729,6 +729,8 @@ ngx_http_wasm_create_fake_request(ngx_connection_t *c)
 #if 0
     cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
 
+    /* handle missing http{} block */
+
     r->variables = ngx_pcalloc(r->pool, cmcf->variables.nelts
                                * sizeof(ngx_http_variable_value_t));
     if (r->variables == NULL) {

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -207,4 +207,10 @@ typedef struct {
 } ngx_wasm_subsystem_t;
 
 
+static const ngx_str_t  NGX_WASM_STR_NO_HTTP =
+    ngx_string("failed getting http main conf (no http{} block?)");
+static const ngx_str_t  NGX_WASM_STR_NO_HTTP_UPSTREAM =
+    ngx_string("failed getting http_upstream main conf (no http{} block?)");
+
+
 #endif /* _NGX_WASM_H_INCLUDED_ */


### PR DESCRIPTION
These code paths can be encountered when running builds with or without the http subsystem, so long as they do not have an `http{}` block.

These branches are going to be uncovered for the time being since Test::Nginx does not support producing `nginx.conf` without an `http{}` block, so we will have to develop our own solution.

The `init_process` and `exit_process` branches have been tested locally, not the other ones. The other branches can be encountered when configuring filters through the FFI in an OpenResty build while using an `nginx.conf` without an `http{}` block. Since ngx_wasm_module only supports configuring filters through its http subsystem (`proxy_wasm` directive), these other branches cannot presently be encountered in ngx_wasm_module.