### PR TITLE
docs(ADR) revised 'wasm flags as nginx directives' ADR

### DIFF
--- a/docs/adr/005-wasm-runtimes-flags.md
+++ b/docs/adr/005-wasm-runtimes-flags.md
@@ -16,52 +16,48 @@
 
 ## Problem Statement
 
-How to expose as many wasm runtime/compiler configuration flags as Nginx
+How to expose as many Wasm runtime/compiler configuration flags as Nginx
 directives as possible in a concise and logical way?
-
 
 [Back to TOC](#table-of-contents)
 
 ## Technical Context
 
-WasmX embeds either wasmtime, wasmer or V8 as its wasm runtime. Each of these
-runtimes provides configuration options that can be used to tweak its behavior.
-Each of these runtimes also embeds a wasm compiler, and wasm compilers also
-provide their own set of configuration flags. And not surprisingly, a wasm
-runtime might support different compilers:
+WasmX embeds either Wasmtime, Wasmer or V8 as its Wasm runtime. Each of these
+runtimes provides configuration options that can be used to tweak their
+behavior. Each of these runtimes also embeds a Wasm compiler, and Wasm
+compilers also provide their own set of configuration flags. And not
+surprisingly, a Wasm runtime might support different compilers:
 
-* wasmtime supports cranelift
-* wasmer supports cranelift, llvm and singlepass
-* v8 supports liftoff and turbofan
+* Wasmtime supports cranelift.
+* Wasmer supports cranelift, llvm and singlepass.
+* V8 supports liftoff and turbofan.
 
-Although runtimes and compilers provide a substantial ammount of configuration
-options, WasmX is limited to use those exposed in the runtimes C API. Naturally,
-the C APIs of the runtimes don't necessairly expose all configuration options
-available.
+Although runtimes and compilers provide a substantial amount of configuration
+options, WasmX is limited to use those exposed in the runtimes' C API.
+The C APIs of the runtimes don't always expose all configuration options
+available yet.
 
-It should also be noted that Wasmtime and Wasmer provide in their C API many
-functions for setting configuration flags -- in fact, one function per
-configuration flag (e.g. `wasmtime_config_wasm_reference_types_set`).
-While V8 provide a generic `SetFlagsFromString` function that can be used to
-set any of the supported V8 flags.
-This is relevant because by having something like
-`wasm_runtime_flag v8 flag_name flag_value` would allow WasmX to support all V8
-flags with minimum effort. V8 simply ignores any non existent passed to it.
+It should also be noted that while V8 provides a generic function (i.e.
+`SetFlagsFromString`) for all its flags, Wasmer and Wasmtime provide one
+function for each of their configuration flags (e.g.
+`wasmtime_config_wasm_reference_types_set`). This is relevant because by
+implementing something like `wasm_runtime_flag v8 flag_name flag_value`, we
+could allow WasmX to support all V8 flags with minimum effort.
 
-Finally, it's important to observe that although runtimes/compilers might be
-used interchangeably to run wasm code, each one have a different implementation
-that allows for specific tweaking opportunities. As a result, an optimization
-opportunity might be present, for example, in only two of the 3 runtimes.
-
+Finally, it is important to observe that although runtimes/compilers might be
+used interchangeably to run Wasm code, each one has a different implementation
+that allows for specific tweaking opportunities. As a result, a tweaking
+opportunity might be present, for example, in only two of the three runtimes.
 
 [Back to TOC](#table-of-contents)
 
 ## Decision Drivers
 
-* Minimizes complexity of code handling directives
-* Maximizes configuration simplicity
-* Maximizes configuration flexibility
-* Maximizes configuration conciseness
+* Minimizes complexity of code in handling directives.
+* Maximizes configuration simplicity.
+* Maximizes configuration flexibility.
+* Maximizes configuration conciseness.
 
 [Back to TOC](#table-of-contents)
 
@@ -74,13 +70,11 @@ opportunity might be present, for example, in only two of the 3 runtimes.
 
 ### 1. `flag` directive
 
-The nginx directive `flag` receives two arguments, `flag_name` and `value`. The
+The Nginx directive `flag` receives two arguments: `flag_name` and `value`. The
 directive handler checks if the runtime supports `flag_name` and if it does, the
-flag is added to the list of flags along with its value. If the flag is not
-supported by the runtime the configuration fails and a message is written to the
-log indicating the non supported flag as the cause. Later, when the runtime
-engine is created, the list of flags is iterated and applied to the runtime
-configuration.
+flag is added to the list of flags along with its value. The list of flags is
+later iterated to apply each flag to the underlying runtime, when they are later
+created.
 
 ```nginx
 wasm {
@@ -95,26 +89,29 @@ wasm {
 
 Pros:
 
-* A single nginx directive can handle all use cases while keeping code
+* A single Nginx directive can handle all use cases while keeping code
   complexity low. The directive handler can delegate the call to a runtime
   specific function.
-* In case of V8, this runtime specific function could simply call the bridge
+* In case of V8, this runtime-specific function could simply call the bridge
   code (`ngx_v8_set_flags`) that calls `SetFlagsFromString`.
-* For `wasmtime` and `wasmer`, the code handling flag setting can leverage a
+* For `wasmtime` and `wasmer`, the handling of the flag setting can leverage a
   hash to map flags to their corresponding handler functions (which calls
   the runtime C API appropriately). If a flag is not present in the hash, it's
   not supported by the runtime and we can report it to the user.
 
 Cons:
 
-* Can become verbose when many flags are set.
+* Less verbose when many flags are set (e.g. commenting-out a number of flags to
+  switch to another runtime).
 
 [Back to TOC](#table-of-contents)
 
 ### 2. `flags` directive
 
-The nginx directive `flags` receives one string containing all flags and values,
- paired as `flag_name=value` and separated by a space.
+The Nginx directive `flags` receives one string argument containing all flags
+and values. Flags and values are paired as `flag=value` and separated by a
+space.
+
 The directive handler is slightly more complex than the `flag` one since it has
 to parse the string argument into a list of flag names and values.
 
@@ -129,7 +126,8 @@ wasm {
 Pros:
 
 * `flags` benefits from the same pros that `flag` does.
-* Less verbose when many flags are set
+* Less verbose when many flags are set (e.g. commenting-out a single line of
+  flags to switch to another runtime).
 
 Cons:
 
@@ -137,7 +135,6 @@ Cons:
   flags.
 
 [Back to TOC](#table-of-contents)
-
 
 ## Decision Outcomes
 


### PR DESCRIPTION
@casimiro, I made some clarifications to the ADR which I'd like you to double-check.

Here is another thought I had on the verbosity Pros/Cons: a good use-case for implementing the `flags` directive is to easily switch between runtimes while re-using the same `nginx.conf` directive, or basically sharing `nginx.conf` between runtimes.

E.g. with `flag` users have to do:
```nginx
wasm {
    # wasmer flags
    flag f1 val1;
    flag f2 val2;
    flag f3 val3;

    # v8 flags
    #flag f1 val1;
    #flag f2 val2;
}
```

While with `flags`, they can do:
```nginx
wasm {
    flags 'f1=val1 f2=val2 f3=val3'; # wasmer
    #flags 'f1=val1 f2=val2';        # V8
}
```

So at first I was thinking, "if the cost of implementing `flags` is only looping over space-separated list of flags and reusing the same underlying handlers, why not implement both"?

However I think the re-usable `nginx.conf` file between runtimes is essential to the success of this module, because it greatly simplifies deployment or upgrade processes across large platforms, and even streamlines our lives when we develop the module. The issue I see with `flags` as it is, is that it does not fulfill this requirement and break a premise the module is currently fulfilling.

How about, perhaps we implement both these directives (considering one is only a loop but gives users the choice between long or wide), but we do so with an addition: an optional `runtime` argument?

```nginx
wasm {
    flags wasmer 'f1=val1 f2=val2 f3=val3'; 
    flags v8     'f1=val1 f2=val2 f3=val3'; 
    flag wasmer   f1 val1; # v8-only
    flag v8       f1 val1; # v8-only
    flag          f1 val1; # always set flag
}
```

So `flag` becomes `flag [runtime] flag value;`. It is easy in the directive handler to read the number of arguments, and treat arg1-2 or arg2-3 as the flag/value tuple. 

For the ultimate experience, I think this is what we should aim for:

```nginx
wasm {
    v8 {
        flag f1 val1;
        socket_buffer_size 4k;
    }

    wasmer {
        flag f2 val2;
        socket_buffer_size 32k; # for whatever reason we could easily override specific settings
    }
}
```

It isn't too complicated to re-use the `wasm{}` block code and create sub-blocks within it, and scope directives. But it can probably wait for later, the `[runtime]` flag can maintain our requirement for now.

What do you think? Also cc @hishamhm for thoughts.