### PR TITLE
chore(ci) install openssh in release images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Homebrew dependencies
-        run: brew install ninja
+        run: brew install ninja openssh
       - name: Build binary
         run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:

--- a/assets/release/Dockerfiles/Dockerfile.amd64.archlinux
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.archlinux
@@ -8,6 +8,7 @@ RUN pacman -Syyu --noconfirm \
     gcc \
     python \
     git \
+    openssh \
     pkg-config \
     which \
     ninja

--- a/assets/release/Dockerfiles/Dockerfile.amd64.centos7
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.centos7
@@ -16,6 +16,8 @@ RUN yum install -y epel-release && \
         perl \
         python3 \
         git \
+        openssh-server \
+        openssh-clients \
         glib2-devel
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo

--- a/assets/release/Dockerfiles/Dockerfile.amd64.centos8
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.centos8
@@ -16,6 +16,8 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
         perl \
         python3 \
         git \
+        openssh-server \
+        openssh-clients \
         glib2-devel
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo

--- a/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-18.04
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-18.04
@@ -12,6 +12,8 @@ RUN apt-get update && \
         gcc-8 \
         libstdc++-8-dev \
         git \
+        openssh-server \
+        openssh-clients \
         pkg-config \
         libglib2.0-dev \
         clang \

--- a/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04
+++ b/assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04
@@ -14,6 +14,8 @@ RUN apt-get update && \
         gcc-10 \
         libstdc++-10-dev \
         git \
+        openssh-server \
+        openssh-clients \
         pkg-config \
         libglib2.0-dev \
         clang \


### PR DESCRIPTION
Mysteriously missing since last week, completely unknown reason. Software is soft science.