### PR TITLE
chore(ci) add job to build arm binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,9 @@ jobs:
       - name: "Ubuntu 20.04 build image"
         uses: docker/build-push-action@v2
         with:
-          file: ./assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04
+          file: ./assets/release/Dockerfiles/Dockerfile.ubuntu-20.04
           tags: ghcr.io/kong/wasmx-build-ubuntu:20.04
+          platforms: linux/arm64,linux/amd64
           push: true
       - name: "Centos 7 build image"
         uses: docker/build-push-action@v2
@@ -154,6 +155,42 @@ jobs:
         run: ./util/release.sh ${{ needs.setup.outputs.release_name }} --bin
         env:
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-artifacts
+          path: dist
+          retention-days: ${{ env.RETENTION_DAYS }}
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.workflow }}-${{ github.job }}-sha-${{ github.sha }}-run-${{ github.run_number }}
+          path: work/dist/build/*
+
+  build-ubuntu-focal-arm:
+    name: "Build Ubuntu 20.04 (focal) ARM"
+    needs: [setup, build-images]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+      - run: |
+          docker run \
+              --platform=linux/arm64 \
+              --volume $PWD:/wasmx \
+              --env CARGO_NET_GIT_FETCH_WITH_CLI=true \
+              --env WASMTIME_VER='${{ needs.setup.outputs.wasmtime_ver }}' \
+              --env WASMER_VER='${{ needs.setup.outputs.wasmer_ver }}' \
+              --env V8_VER='${{ needs.setup.outputs.v8_ver }}' \
+              ghcr.io/kong/wasmx-build-ubuntu:20.04 \
+              /wasmx/util/release.sh ${{ needs.setup.outputs.release_name }} --bin
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:
@@ -289,7 +326,7 @@ jobs:
 
   upload-artifacts:
     name: "Upload release artifacts"
-    needs: [source-release, build-images, build-ubuntu-bionic, build-ubuntu-focal, build-centos7, build-centos8, build-arch, build-macos]
+    needs: [source-release, build-images, build-ubuntu-bionic, build-ubuntu-focal, build-ubuntu-focal-arm, build-centos7, build-centos8, build-arch, build-macos]
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve sibling release artifacts

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ todo:
 act-build:
 	@docker build \
 		-t wasmx-build-ubuntu \
-		-f ./assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04 \
+		-f ./assets/release/Dockerfiles/Dockerfile.ubuntu-20.04 \
 		./assets/release/Dockerfiles
 
 .PHONY: act

--- a/assets/release/Dockerfiles/Dockerfile.ubuntu-20.04
+++ b/assets/release/Dockerfiles/Dockerfile.ubuntu-20.04
@@ -1,4 +1,4 @@
-FROM amd64/ubuntu:20.04
+FROM ubuntu:20.04
 COPY . /ngx_wasm_module
 
 ARG GOLANG_VERSION=1.19.5
@@ -17,7 +17,14 @@ RUN apt-get update && \
         pkg-config \
         libglib2.0-dev \
         clang \
-        curl
+        curl \
+        binfmt-support \
+        qemu-user-static
+
+# Note: this image is also used for local CI runs
+RUN /bin/bash -c 'echo $(uname -m) > /TG_ARCH || : ; \
+                  [[ $(cat /TG_ARCH) == "x86_64" ]] && echo "amd64" > /TG_ARCH || : ; \
+                  [[ $(cat /TG_ARCH) == "aarch64" ]] && echo "arm64" > /TG_ARCH || :'
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
 ENV PATH $CARGO_HOME/bin:$PATH
@@ -25,7 +32,6 @@ RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \
     chmod -R a=rwX $CARGO_HOME $RUSTUP_HOME
 
-# Note: this image is also used for local CI runs
 RUN apt-get install -y \
         clang-tools \
         libpcre3-dev \
@@ -35,8 +41,8 @@ RUN apt-get install -y \
         nodejs \
         gcovr \
         sudo && \
-    curl -sLO https://golang.google.cn/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    curl -sLO https://github.com/tinygo-org/tinygo/releases/download/v$TINYGO_VERSION/tinygo_${TINYGO_VERSION}_amd64.deb && \
-    dpkg -i tinygo_${TINYGO_VERSION}_amd64.deb
+    curl -sLO https://golang.google.cn/dl/go${GOLANG_VERSION}.linux-$(cat /TG_ARCH).tar.gz && \
+    sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-$(cat /TG_ARCH).tar.gz && \
+    curl -sLO https://github.com/tinygo-org/tinygo/releases/download/v$TINYGO_VERSION/tinygo_${TINYGO_VERSION}_$(cat /TG_ARCH).deb && \
+    dpkg -i tinygo_${TINYGO_VERSION}_$(cat /TG_ARCH).deb
 ENV PATH $PATH:/usr/local/go/bin

--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -246,6 +246,10 @@ build_v8bridge() {
     # On macOS builds, use the system-provided clang to avoid header issues
     if [[ "$(uname -s)" = "Darwin" ]]; then
         v8_cxx="clang"
+
+    elif [[ "$(uname -m)" = "aarch64" ]]; then
+        # v8 clang is built for x86_64; if running on arm64 defaults to gcc
+        v8_cxx="gcc"
     fi
 
     make -C "$NGX_WASM_DIR/lib/v8bridge" \
@@ -278,6 +282,12 @@ clean="$5"
 
 if [ "$mode" = "download" ]; then
     download_v8 "$target" "$v8_ver" "$arch" "$clean"
+
+elif [[ -n "$CI" && "$arch" = "aarch64" ]]; then
+    # building ARM v8 over qemu on CI is expensive
+    notice "running on aarch64 CI: forcing download mode"
+    download_v8 "$target" "$v8_ver" "$arch" "$clean"
+
 else
     build_v8 "$target" "$v8_ver" "$arch" "$clean"
 fi

--- a/util/runtimes/wasmer.sh
+++ b/util/runtimes/wasmer.sh
@@ -24,7 +24,6 @@ download_wasmer() {
 
     case $arch in
         x86_64)  arch='amd64';;
-        aarch64) arch='arm64';;
     esac
 
     kernel=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
This PR adds CI job `build-ubuntu-focal-arm-binary` that builds WasmX arm64 binaries.

The job uses `docker/setup-qemu-action` to install qemu static binaries in the runner VM and `docker/setup-buildx-action` to build and execute an arm docker image.

The docker image is built out of the multi-platform dockerfile `./assets/release/Dockerfiles/Dockerfile.ubuntu-20.04` which is essentially  `./assets/release/Dockerfiles/Dockerfile.amd64.ubuntu-20.04` -- except for the `FROM` statement and how tinygo installation is invoked.

This approach can be easily expanded to the remaining supported linux distros by applying the necessary changes to `FROM` and `tinygo` installation. 

ARM binaries for `wasmtime` and `wasmer` were prodcued in the job run https://github.com/Kong/ngx_wasm_module/actions/runs/4963922770.

TODO:

- [x] Define which of the supported linux distros we want to ship ARM binaries for.
- [x] Update `Kong/ngx_wasm_runtimes` and `./util/runtimes/v8.sh to also build V8 for ARM64.
- [x] Apply the multi arch build approach to the linux distros defined above.

