### PR TITLE
chore(*) update skipped Alpine Linux Dockerfile

### DIFF
--- a/assets/release/Dockerfiles/skip.Dockerfile.amd64.alpinelinux
+++ b/assets/release/Dockerfiles/skip.Dockerfile.amd64.alpinelinux
@@ -1,4 +1,5 @@
-FROM amd64/alpine:latest
+FROM amd64/alpine:3.17
+COPY . /ngx_wasm_module
 
 RUN apk update && apk upgrade && apk add --no-cache \
     ca-certificates \
@@ -13,7 +14,25 @@ RUN apk update && apk upgrade && apk add --no-cache \
     make \
     bash \
     curl \
-    tar
+    tar \
+    cmake \
+    gcc \
+    python3 \
+    git \
+    openssh \
+    pkgconf \
+    which \
+    ninja && \
+    update-ca-certificates && \
+    ln -sf /usr/bin/pkgconf /usr/bin/pkg-config
+
+RUN mkdir -p /root/.ssh && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
 # force CC to clang
 ENV CC=clang
+
+ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
+ENV PATH $CARGO_HOME/bin:$PATH
+RUN mkdir -p "$CARGO_HOME" && mkdir -p "$RUSTUP_HOME" && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable && \
+    chmod -R a=rwX $CARGO_HOME $RUSTUP_HOME


### PR DESCRIPTION
This is an updated Dockerfile which is able to run a release.yml task for generating Alpine binaries, given a few more tweaks in `util/runtimes`:

* Github URLs need to be `https://github.com`, not `git@github.com`.
* Rust does not support cdylib builds on Musl-based systems, so scripts would need to be tweaked to not attempt to copy the `.so` files after building the Wasm VMs.

Example changes:

```diff
@@ -79,7 +79,7 @@ build_wasmtime() {
         pushd repos
             if [ ! -d wasmtime ]; then
                 notice "fetching Wasmtime repository..."
-                git clone git@github.com:bytecodealliance/wasmtime.git
+                git clone https://github.com/bytecodealliance/wasmtime.git

             else
                 notice "synchronizing Wasmtime repository..."
```

```diff
@@ -120,7 +120,7 @@ build_wasmtime() {
             ### install

             mkdir -p "$target/lib"
-            cp $cargo_target_dir/libwasmtime.{a,so} "$target/lib"
+            cp $cargo_target_dir/libwasmtime.* "$target/lib"

             mkdir -p "$target/include"
             cp -R crates/c-api/include/* "$target/include"
```

After making these two tweaks, it was possible at least to build an nginx using libwasmtime.a using this Dockerfile.

This commit does not apply these tweaks, but leaves them documented here in case we ever want to add Alpine support to our release CI workflows.