### PR TITLE
chore(ci) disable TEST_NGINX_RANDOMIZE in unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,11 @@ defaults:
   run:
     shell: bash
 
-env:
-  TEST_NGINX_RANDOMIZE: 1
-
 jobs:
   tests:
     name: 'Tests - unit'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 30
     #if: ${{ false }}
     outputs:
       coveralls_name: ${{ steps.lcov.outputs.name }}
@@ -37,7 +34,7 @@ jobs:
         debug: [1, 0]
         hup: [0]
         include:
-          # Wasmtime
+          # Wasmtime + HUP
           - os: ubuntu-latest
             cc: gcc-9
             ngx: 1.23.4
@@ -179,6 +176,7 @@ jobs:
     env:
       NGX_BUILD_NOPOOL: 1
       NGX_BUILD_CC_OPT: '-O2'
+      TEST_NGINX_RANDOMIZE: 1
       TEST_NGINX_TIMEOUT: 120
       TEST_NGINX_EXTERNAL_TIMEOUT: 200
       TEST_NGINX_USE_VALGRIND: 1
@@ -361,6 +359,7 @@ jobs:
         wasmer: [3.1.1]
         v8: [10.5.18]
         include:
+          # Old Nginx
           - os: ubuntu-latest
             cc: clang-14
             ngx: 1.21.6


### PR DESCRIPTION
Keep it in Valgrind tests.

Replaces #250.

Before:
Total duration: 1h 24m 2s
Billable time: 8h 3m
Fastest unit job: 8m 34s 
Longest unit job: 15m 32s

After:
Total duration: 1h 18m 20s
Billable time: 8h 32m
Fastest unit job: 12m 52s
Longest unit job: 28m 13s
 