### PR TITLE
chore(release) do not tag manual releases by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       release_name:
         description: "Release name (e.g. v0.1.0)"
         required: true
+      tag_release:
+        type: boolean
+        description: "Tag the release?"
+        required: true
+        default: false
 
 defaults:
   run:
@@ -15,7 +20,7 @@ defaults:
 
 env:
   CC: clang
-  RETENTION_DAYS: 2
+  RETENTION_DAYS: 7
 
 jobs:
   setup:
@@ -343,7 +348,7 @@ jobs:
           files: |
             *.tar.gz
       - uses: marvinpinto/action-automatic-releases@latest
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name != 'schedule' && github.event.inputs.tag_release == 'true' }}
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: release-${{ needs.setup.outputs.release_name }}


### PR DESCRIPTION
This allows for testing release script changes or temporary release builds without having to create a tag (which cannot easily get rid of). For the latter use-case, the retention day variable jumped to 7.