### PR TITLE
chore(util) revised macOS Wasmtime build fix

### DIFF
--- a/util/runtimes/wasmer.sh
+++ b/util/runtimes/wasmer.sh
@@ -118,7 +118,7 @@ build_wasmer() {
             ### install
 
             mkdir -p "$target/lib"
-            cp target/release/libwasmer.* "$target/lib"
+            cp -R target/release/libwasmer.* "$target/lib"
 
             mkdir -p "$target/include"
             cp -R lib/c-api/wasmer*.h "$target/include"

--- a/util/runtimes/wasmtime.sh
+++ b/util/runtimes/wasmtime.sh
@@ -120,7 +120,7 @@ build_wasmtime() {
             ### install
 
             mkdir -p "$target/lib"
-            cp $cargo_target_dir/libwasmtime.* "$target/lib"
+            cp -R $cargo_target_dir/libwasmtime.* "$target/lib"
 
             mkdir -p "$target/include"
             cp -R crates/c-api/include/* "$target/include"


### PR DESCRIPTION
Fixes error:

    cp: target/release/libwasmer.dylib.dSYM is a directory (not copied).