### PR TITLE
feat(shm) configurable eviction policies for shm_kv

### DIFF
--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -426,7 +426,7 @@ Wasm sockets.
 shm_kv
 ------
 
-**usage**    | `shm_kv <name> <size>;`
+**usage**    | `shm_kv <name> <size> [eviction=lru\|none];`
 ------------:|:----------------------------------------------------------------
 **contexts** | `wasm{}`
 **default**  |
@@ -438,6 +438,13 @@ Define a shared key/value memory zone.
   zone.
 - `size` defines the allocated memory slab and must be at least `15k`, but
   accepts other units like `m`.
+- `eviction` defines the eviction policy in the event of unavailable space for
+  storing new entries. Supported values are:
+  - `lru` (default): least recently used entries are evicted until enough space
+    is available for storing the new item.
+  - `none`: no eviction policy. Attempting to insert into a full memory zone
+    will result in an error code produced by the host API, to be interpreted
+    by the language SDK.
 
 Shared memory zones defined as such are accessible through all [Contexts] and by
 all nginx worker processes.
@@ -452,9 +459,6 @@ a means of storage and exchange for worker processes of a server instance.
 
 Shared key/value memory zones can be used via the [proxy-wasm
 SDK](#proxy-wasm)'s `[get\|set]_shared_data` API.
-
-**Note:** shared memory zones do not presently implement an LRU eviction policy,
-and writes will fail when the allocated memory slab is full.
 
 [Back to TOC](#directives)
 

--- a/src/common/shm/ngx_wasm_shm.h
+++ b/src/common/shm/ngx_wasm_shm.h
@@ -14,18 +14,25 @@ typedef enum {
 } ngx_wasm_shm_type_e;
 
 
+typedef enum {
+    NGX_WASM_SHM_EVICTION_LRU,
+    NGX_WASM_SHM_EVICTION_NONE,
+} ngx_wasm_shm_eviction_e;
+
+
 typedef struct {
-    ngx_wasm_shm_type_e     type;
-    ngx_str_t               name;
-    ngx_log_t              *log;
-    ngx_slab_pool_t        *shpool;
-    void                   *data;
+    ngx_wasm_shm_type_e       type;
+    ngx_wasm_shm_eviction_e   eviction;
+    ngx_str_t                 name;
+    ngx_log_t                *log;
+    ngx_slab_pool_t          *shpool;
+    void                     *data;
 } ngx_wasm_shm_t;
 
 
 typedef struct {
-    ngx_str_t               name;
-    ngx_shm_zone_t         *zone;
+    ngx_str_t                 name;
+    ngx_shm_zone_t           *zone;
 } ngx_wasm_shm_mapping_t;
 
 

--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -76,14 +76,14 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
       NULL },
 
     { ngx_string("shm_kv"),
-      NGX_WASM_CONF|NGX_CONF_TAKE23,
+      NGX_WASM_CONF|NGX_CONF_TAKE23|NGX_CONF_TAKE4,
       ngx_wasm_core_shm_kv_directive,
       0,
       0,
       NULL },
 
     { ngx_string("shm_queue"),
-      NGX_WASM_CONF|NGX_CONF_TAKE23,
+      NGX_WASM_CONF|NGX_CONF_TAKE23|NGX_CONF_TAKE4,
       ngx_wasm_core_shm_queue_directive,
       0,
       0,

--- a/t/01-wasm/directives/003-shm_directives.t
+++ b/t/01-wasm/directives/003-shm_directives.t
@@ -145,3 +145,93 @@ qr/\[emerg\] .*? "my_shm" shm already defined/
 [crit]
 stub
 --- must_die
+
+
+
+=== TEST 10: shm directive - kv eviction policies
+--- main_config
+    wasm {
+        shm_kv my_kv_1 1m eviction=lru;
+        shm_kv my_kv_2 64k eviction=none;
+        shm_kv my_kv_3 64k;
+    }
+--- no_error_log
+[error]
+[crit]
+[emerg]
+stub
+
+
+
+=== TEST 11: shm directive - queue does not support eviction policies
+--- main_config
+    wasm {
+        shm_queue my_shm 16k eviction=lru;
+    }
+--- error_log eval
+qr/\[emerg\] .*? shm_queue \"my_shm\": queues do not support eviction policies/
+--- no_error_log
+[error]
+[crit]
+stub
+--- must_die
+
+
+
+=== TEST 12: shm directive - kv invalid option
+--- main_config
+    wasm {
+        shm_kv my_shm 16k foo=bar;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid option \"foo=bar\"/
+--- no_error_log
+[error]
+[crit]
+stub
+--- must_die
+
+
+
+=== TEST 13: shm directive - queue invalid option
+--- main_config
+    wasm {
+        shm_queue my_shm 16k foo=bar;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid option \"foo=bar\"/
+--- no_error_log
+[error]
+[crit]
+stub
+--- must_die
+
+
+
+=== TEST 14: shm directive - kv invalid eviction policy
+--- main_config
+    wasm {
+        shm_kv my_shm 16k eviction=foobar;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid eviction policy \"foobar\"/
+--- no_error_log
+[error]
+[crit]
+stub
+--- must_die
+
+
+
+=== TEST 15: shm directive - kv invalid empty eviction policy
+--- main_config
+    wasm {
+        shm_kv my_shm 16k eviction=;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid eviction policy \"\"/
+--- no_error_log
+[error]
+[crit]
+stub
+--- must_die

--- a/t/03-proxy_wasm/hfuncs/shm/003-kv_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/shm/003-kv_edge_cases.t
@@ -285,3 +285,51 @@ qr/\[crit\] .*? \[wasm\] "test" shm store: no memory; cannot allocate pair with 
 [stub18]
 [stub19]
 [stub20]
+
+
+
+=== TEST 5: proxy_wasm key/value shm - 'no memory' errors if no eviction policy is active
+--- skip_no_debug: 25
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- shm_kv: test 12288 eviction=none
+--- config
+    location /t {
+        # only 4 fit
+        proxy_wasm hostcalls 'test=/t/shm/set_shared_data_by_len key=test/test1 header_ok=set-1 len=512';
+        proxy_wasm hostcalls 'test=/t/shm/set_shared_data_by_len key=test/test2 header_ok=set-2 len=512';
+        proxy_wasm hostcalls 'test=/t/shm/set_shared_data_by_len key=test/test3 header_ok=set-3 len=512';
+        proxy_wasm hostcalls 'test=/t/shm/set_shared_data_by_len key=test/test4 header_ok=set-4 len=512';
+        proxy_wasm hostcalls 'test=/t/shm/set_shared_data_by_len key=test/test5 header_ok=set-5 len=512';
+
+        echo ok;
+    }
+--- error_code: 500
+--- response_body_like: 500 Internal Server Error
+--- grep_error_log eval: qr/(\[crit\]|.*?failed setting value to shm).*/
+--- grep_error_log_out eval
+qr/\[crit\] .*? \[wasm\] "test" shm store: no memory; cannot allocate pair with key size 10 and value size 512
+(.*?\[error\]|Uncaught RuntimeError|\s+).*?host trap \(internal error\): failed setting value to shm \(could not write to slab\).*/
+--- no_error_log
+[emerg]
+[alert]
+[stub1]
+[stub2]
+[stub3]
+[stub4]
+[stub5]
+[stub6]
+[stub7]
+[stub8]
+[stub9]
+[stub10]
+[stub11]
+[stub12]
+[stub13]
+[stub14]
+[stub15]
+[stub16]
+[stub17]
+[stub18]
+[stub19]
+[stub20]


### PR DESCRIPTION
This PR makes eviction policies for `shm_kv` zones configurable. It retains `lru` as the default, and adds `none` as an option for key-value stores without an automatic eviction policy. This also sets the stage for the possibility of adding alternative eviction policies.

(Minor comment on API UX: using the `none` policy is cumbersome in Rust because proxy-wasm-rust-sdk panics when attempting to set a key into a full store, but proxy-wasm-go-sdk returns an error code, making it more ergonomic to use a `none`-policy store "set" as a "[safe_set](https://github.com/openresty/lua-nginx-module/#ngxshareddictsafe_set)" without eviction surprises.)
