### PR TITLE
chore(ci) fix action. fix libwee8 aarch64 build.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
           docker run \
               --platform=linux/arm64 \
               --volume $PWD:/wasmx \
+              --e CI \
               --env CARGO_NET_GIT_FETCH_WITH_CLI=true \
               --env WASMTIME_VER='${{ needs.setup.outputs.wasmtime_ver }}' \
               --env WASMER_VER='${{ needs.setup.outputs.wasmer_ver }}' \

--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -115,6 +115,7 @@ build_libwee8() {
 
     case "$arch" in
         x86_64) arch="x64" ;;
+        aarch64) arch="arm64" ;;
     esac
 
     mkdir -p "$DIR_LIBWEE8"


### PR DESCRIPTION
The release job failed because the `CI` was not being passed along though the `docker run` command that invoked the release script.

As a result, `v8.sh` started building V8 which ended up revealing a bug related to architecture naming (`aarch64` vs `arm64`). 

This PR changes the `docker run` command used in the arm release job to pass along `CI` env var.
It also adds `aarch64` -> `arm64` translation as expected by V8 build scripts.