### PR TITLE
fix(proxy-wasm) handle internal redirects with and without filter chains

### DIFF
--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -342,7 +342,6 @@ ngx_http_proxy_wasm_ctx(void *data)
     ngx_http_wasm_loc_conf_t  *loc;
 
     loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
-    rctx = ngx_http_get_module_ctx(r, ngx_http_wasm_module);
 
     pwctx = (ngx_proxy_wasm_ctx_t *) rctx->data;
     if (pwctx == NULL) {


### PR DESCRIPTION
During internal redirects Nginx clears the request context which in our case holds `rctx`. Leveraged by Kong Gateway to handle a category of HTTP errors, reproduced in LuaJIT FFI tests.

The `r->pool` cleanup will be invoked for any number of attached `rctxs`, which in the case of internal redirects can be more than one (since `rctxs` is auto-created on `ngx_http_wasm_rctx` calls). In this case, `r` contains the newer `rctx`, which is then used in both handlers and causes a use-after-free (or free-after-free) attempt.

Instead, we do not override this function's `rctx` variable since it was already given via `data`, which in this branch comes from the pool cleanup trigger, and will be distinct for each pool cleanup handler run. Multiple `rctxs` can be cleaned up when their associated `r->pool` is freed. This also correctly frees both filter chains (attached to each `rctx`).
