### PR TITLE
chore(ci) fix ARM release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,9 @@ jobs:
           docker run \
               --platform=linux/arm64 \
               --volume $PWD:/wasmx \
-              --e CI \
+              --volume $GITHUB_ENV:$GITHUB_ENV \
+              -e CI \
+              -e GITHUB_ENV \
               --env CARGO_NET_GIT_FETCH_WITH_CLI=true \
               --env WASMTIME_VER='${{ needs.setup.outputs.wasmtime_ver }}' \
               --env WASMER_VER='${{ needs.setup.outputs.wasmer_ver }}' \

--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -24,45 +24,17 @@ download_v8() {
     local os=$(uname -s | tr '[:upper:]' '[:lower:]')
     local tarball="$DIR_DOWNLOAD/v8-$version.tar.gz"
 
+    case "$arch" in
+        aarch64) arch="arm64" ;;
+    esac
+
     if [[ "$clean" = "clean" ]]; then
         rm -rfv "$target"
     fi
 
     if [[ ! -d "$tarball" ]]; then
-
-        if [[ ! -e "$DIR_BIN/fetch" ]]; then
-            local hostarch=$(uname -m)
-            case $hostarch in
-                x86_64)  hostarch='amd64';;
-                aarch64) hostarch='arm64';;
-            esac
-
-            download $DIR_BIN/fetch \
-                "https://github.com/gruntwork-io/fetch/releases/download/v0.4.5/fetch_${os}_${hostarch}"
-
-            chmod +x $DIR_BIN/fetch
-        fi
-
-        local filename="ngx_wasm_runtime-v8-$version-$os-$arch.tar.gz"
-
-        mkdir -p "$DIR_DOWNLOAD"
-
-        # This requires a Personal Access Token in
-        # the $GITHUB_OAUTH_TOKEN environment variable:
-        $DIR_BIN/fetch \
-            --repo "$URL_KONG_WASM_RUNTIMES" \
-            --tag latest \
-            --release-asset "$filename" \
-            "$DIR_DOWNLOAD"
-
-        mv "$DIR_DOWNLOAD/$filename" "$tarball"
-
-        # TODO: replace all of the above with...
-        #
-        # download $tarball \
-        #   "https://github.com/kong/ngx_wasm_runtimes/releases/download/latest/ngx_wasm_runtime-v8-${version}-${os}-${arch}.tar.gz"
-        #
-        # ...once ngx_wasm_runtimes is open-sourced
+        download $tarball \
+          "$URL_KONG_WASM_RUNTIMES/releases/download/latest/ngx_wasm_runtime-v8-${version}-${os}-${arch}.tar.gz"
     fi
 
     if [[ ! -d "$target" ]]; then


### PR DESCRIPTION
This PR fixes the GHA that builds WasmX for ARM by:
- fixing env flag passing `$CI`;
- mounting file path stored in `$GITHUB_ENV` so variables can be exported from within the docker container;
- adding missing `aarch64` to `arm64` translation in `v8.sh`.

It also addresses a TODO in v8.sh to directly download pre-built V8 from `kong/ngx_wasm_runtimes` since that repo is public already.

This [action](https://github.com/Kong/ngx_wasm_module/actions/runs/5246120973/jobs/9502840451) demonstrates a successful run of the fixed version:
