### PR TITLE
chore(ci) add GHA 'run_attempt' to Coveralls uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
   tests:
     name: 'Unit'


### PR DESCRIPTION
Suggested at: https://github.com/lemurheavy/coveralls-public/issues/1716#issuecomment-1594019773