### PR TITLE
Revert "chore(ci) add GHA 'run_attempt' to Coveralls uploads"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
-
 jobs:
   tests:
     name: 'Unit'


### PR DESCRIPTION
This reverts commit 452f184ec7c64a78b9835699a7f4ecdda7ba59f5.