### PR TITLE
chore(*) add NGX_WASM_RUNTIME_NO_RPATH build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ export NGX_WASM_RUNTIME ?= wasmtime
 export NGX_WASM_RUNTIME_INC ?=
 export NGX_WASM_RUNTIME_LIB ?=
 export NGX_WASM_RUNTIME_LD_OPT ?=
+export NGX_WASM_RUNTIME_NO_RPATH ?= 0
 export NGX_WASM_CARGO ?= 1
 export NGX_WASM_CARGO_PROFILE ?= debug
 

--- a/auto/cargo
+++ b/auto/cargo
@@ -41,10 +41,21 @@ if [ $ngx_wasm_rc = 0 ]; then
 
     if [ "$ngx_wasm_cargo_crate_type" = "cdylib" ]; then
         ngx_feature_libs="\
-            -Wl,-rpath=$ngx_wasm_cargo_target_dir \
-            -Wl,-rpath=$NGX_PREFIX/lib \
             -L$ngx_wasm_cargo_target_dir \
             -l$ngx_wasm_cargo_lib_name"
+
+	if [ "$NGX_RPATH" = YES ]; then
+            ngx_feature_libs="\
+                -R $ngx_wasm_cargo_target_dir \
+                -R $NGX_PREFIX/lib \
+                $ngx_feature_libs"
+
+	elif [ "$NGX_WASM_RUNTIME_NO_RPATH" != 1 ]; then
+            ngx_feature_libs="\
+                -Wl,-rpath=$ngx_wasm_cargo_target_dir \
+                -Wl,-rpath=$NGX_PREFIX/lib \
+                $ngx_feature_libs"
+        fi
 
     else
         ngx_feature_libs="$ngx_wasm_cargo_target_dir/lib$ngx_wasm_cargo_lib_name.a"

--- a/auto/runtime
+++ b/auto/runtime
@@ -16,13 +16,17 @@ if [ -n "$ngx_wasm_runtime_inc" ]; then
 fi
 
 if [ -n "$ngx_wasm_runtime_lib" ]; then
-    if [ $NGX_RPATH = yes ]; then
-        ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-R/g') -l$ngx_wasm_runtime_lib_name"
-        ngx_feature_libs="$ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-R/g') -l$ngx_wasm_runtime_lib_name"
-    else
-        ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-Wl,-rpath,/g') -l$ngx_wasm_runtime_lib_name"
-        ngx_feature_libs="$ngx_wasm_runtime_lib $(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-Wl,-rpath,/g') -l$ngx_wasm_runtime_lib_name"
+    ngx_wasm_rpath=""
+
+    if [ $NGX_RPATH = YES ]; then
+        ngx_wasm_rpath="$(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-R/g')"
+
+    elif [ $NGX_WASM_RUNTIME_NO_RPATH != 1 ]; then
+        ngx_wasm_rpath="$(echo "$ngx_wasm_runtime_lib" | sed 's/-L/-Wl,-rpath,/g')"
     fi
+
+    ngx_feature="$ngx_feature, $ngx_wasm_runtime_lib $ngx_wasm_rpath -l$ngx_wasm_runtime_lib_name"
+    ngx_feature_libs="$ngx_wasm_runtime_lib $ngx_wasm_rpath -l$ngx_wasm_runtime_lib_name"
 fi
 
 if [ -n "$ngx_wasm_runtime_opt" ]; then


### PR DESCRIPTION
* Fixes NGX_RPATH check from `yes` to `YES`
* Adds NGX_RPATH check in `auto/runtime`
* Wraps `-Wl,-rpath` use with new variable `NGX_WASM_WL_RPATH` (enabled by default)

Closes #315.