### PR TITLE
chore(ci) bump timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     name: 'Unit'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     #if: ${{ false }}
     outputs:
       coveralls_name: ${{ steps.lcov.outputs.name }}


### PR DESCRIPTION
A few times already these last few days we've had some jobs timing-out while uploading coverage data, a few seconds short of finishing.