### PR TITLE
[hotfix main] chore(*) pin rust nightly version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2023-04-16


### PR DESCRIPTION
The CI error in main doesn't seem related to the V8 version bump -- although it didn't happen with any other runtime.

I reproduced it in my local machine with the following:
```
make cleanall
make act-build
docker run --rm -it -v $PWD:/wasmx --env NGX_WASM_RUNTIME=v8 wasmx-build-ubuntu bash -c 'cd /wasmx && make setup && make'
```

After pinning the rust version in `rust-toolchain`, the above commands successfully compiled wasmx with V8.
