### PR TITLE
chore(util) fix local V8 builds by fetching the repository for release tags

### DIFF
--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -135,6 +135,7 @@ build_libwee8() {
 
     cd repos/v8
 
+    git fetch --tags
     git checkout .
     git checkout "$v8_ver"
 


### PR DESCRIPTION
Prior:

    $ ./util/release.sh archv8 --bin --match 'arch' --v8 11.4.183.23
    Building x86_64 binary...
    deleting /path/to/ngx_wasm_module/work/v8-11.4.183.23...
    building libwee8...
    Updated 0 paths from the index
    error: pathspec '11.4.183.23' did not match any file(s) known to git
    build failed -- deleting /path/to/ngx_wasm_module/work/v8-11.4.183.23...