### PR TITLE
fix(wasm_core) fix lua <-> wasm module swap in mac

### DIFF
--- a/src/wasm/ngx_wasm.c
+++ b/src/wasm/ngx_wasm.c
@@ -56,7 +56,8 @@ ngx_wasm_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     void               ***ctx;
     ngx_uint_t            i;
     ngx_conf_t            pcf;
-    ngx_wasm_module_t    *m;
+    ngx_module_t         *m;
+    ngx_wasm_module_t    *wm;
 
     if (*(void **) conf) {
         return NGX_WASM_CONF_ERR_DUPLICATE;
@@ -83,11 +84,12 @@ ngx_wasm_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
-        m = cf->cycle->modules[i]->ctx;
+        m = cf->cycle->modules[i];
+        wm = m->ctx;
 
-        if (m->create_conf) {
-            (*ctx)[cf->cycle->modules[i]->ctx_index] = m->create_conf(cf);
-            if ((*ctx)[cf->cycle->modules[i]->ctx_index] == NULL) {
+        if (wm->create_conf) {
+            (*ctx)[m->ctx_index] = wm->create_conf(cf);
+            if ((*ctx)[m->ctx_index] == NULL) {
                 return NGX_CONF_ERROR;
             }
         }
@@ -116,10 +118,11 @@ ngx_wasm_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
-        m = cf->cycle->modules[i]->ctx;
+        m = cf->cycle->modules[i];
+        wm = m->ctx;
 
-        if (m->init_conf) {
-            rv = m->init_conf(cf, (*ctx)[cf->cycle->modules[i]->ctx_index]);
+        if (wm->init_conf) {
+            rv = wm->init_conf(cf, (*ctx)[m->ctx_index]);
             if (rv != NGX_CONF_OK) {
                 return rv;
             }


### PR DESCRIPTION
When ngx_wasm_module is compiled as a dynamic module along ngx_lua_module it might need to switch positions in the `cycle->modules` array so that initialization and execution run properly.

However, the modules positions in `cycle->modules` are being changed as the array is iterated.

More specifically, the following line

```
(*ctx)[cf->cycle->modules[i]->ctx_index] = m->create_conf(cf);
```

attempted to assign the new configuration to (*ctx) when the expression `cf->cycle->modules[i]->ctx_index` is not guaranteed to be valid since `create_conf` will potentially change the position of modules within `cycle->modules`, making `i` obsolete.

This behavior is fixed by assigning `cycle->modules[i]` to a variable and referencing the variable instead of `cycle->modules[i]` directly.