### PR TITLE
chore(ci) fix lcov step output when module_type isn't explictly set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           name="$name-${{ matrix.ssl }}"
           name="$name-${{ matrix.debug }}"
           name="$name-${{ matrix.hup }}"
-          name="$name-${{ matrix.module_type }}"
+          name="$name-${{ matrix.module_type != '' && inputs.module_type || 'static' }}"
           echo "name=$name" >> $GITHUB_OUTPUT
           lcov --capture --directory work/buildroot --output-file lcov.info
           lcov --extract lcov.info "*/ngx_wasm_module/src/*" --output-file lcov.info


### PR DESCRIPTION
The respective tag part will have `static` as value when module_type isn't explictly set.

This can be observed [here](https://github.com/Kong/ngx_wasm_module/actions/runs/5526089066/jobs/10080412218#step:12:12) for instance.

![image](https://github.com/Kong/ngx_wasm_module/assets/456648/4e60324b-5b5e-4591-900b-7093333680da)
