### PR TITLE
fix(proxy_wasm) accept unquoted NGX_WASM_HOST_PROPERTY_NAMESPACE var

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -10,8 +10,14 @@
 #endif
 
 #ifndef NGX_WASM_HOST_PROPERTY_NAMESPACE
-#define NGX_WASM_HOST_PROPERTY_NAMESPACE  "wasmx"
+#define NGX_WASM_HOST_PROPERTY_NAMESPACE  wasmx
 #endif
+
+/* see https://gcc.gnu.org/onlinedocs/gcc-13.1.0/cpp/Stringizing.html */
+#define NGX_WASM_XSTR(s)  NGX_WASM_STR(s)
+#define NGX_WASM_STR(s)   #s
+#define NGX_WASM_HOST_PROPERTY_NAMESPACE_STR \
+          NGX_WASM_XSTR(NGX_WASM_HOST_PROPERTY_NAMESPACE)
 
 
 static ngx_int_t ngx_proxy_wasm_properties_get_ngx(
@@ -40,7 +46,7 @@ static ngx_hash_combined_t     pwm2ngx_hash;
 static ngx_hash_keys_arrays_t  pwm2ngx_keys;
 
 
-static const char  *host_prefix = NGX_WASM_HOST_PROPERTY_NAMESPACE ".";
+static const char  *host_prefix = NGX_WASM_HOST_PROPERTY_NAMESPACE_STR ".";
 static size_t       host_prefix_len;
 
 


### PR DESCRIPTION
This is not really a bug in our end, but Nginx's build system doesn't like `--with-cc-opt` entries that feature double-quoted variables as in `"--with-cc-opt=\"-DNGX_WASM_HOST_PROPERTY_NAMESPACE=\\\"kong\\\"\""`.

This _does_ work when expanding the flag and building our module, but the compilation of Nginx itself later fails with:

```
src/core/nginx.c:456:49: note: in expansion of macro 'NGX_CONFIGURE'
  456 |         ngx_write_stderr("configure arguments:" NGX_CONFIGURE NGX_LINEFEED);
      |                                                 ^~~~~~~~~~~~~
src/core/nginx.c:456:25: note: to match this '('
  456 |         ngx_write_stderr("configure arguments:" NGX_CONFIGURE NGX_LINEFEED);
      |                         ^
```

So let's just play nice and drop the quotes in our end.