### PR TITLE
chore(ci) fix coverage name for dynamic test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,11 @@ jobs:
           name="$name-${{ matrix.ssl }}"
           name="$name-${{ matrix.debug }}"
           name="$name-${{ matrix.hup }}"
-          name="$name-${{ matrix.module_type != '' && inputs.module_type || 'static' }}"
+          if [ "${{ matrix.module_type }}" = dynamic ]; then
+            name="$name-dynamic"
+          else
+            name="$name-static"
+          fi
           echo "name=$name" >> $GITHUB_OUTPUT
           lcov --capture --directory work/buildroot --output-file lcov.info
           lcov --extract lcov.info "*/ngx_wasm_module/src/*" --output-file lcov.info


### PR DESCRIPTION
I believe we are bit by wrong expectations of ternary operators in GHA expressions - not the first time - as recent coverage builds are missing the two dynamic jobs: https://coveralls.io/builds/61330792