### PR TITLE
docs(readme) clarify proxy-wasm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ This module enables the embedding of [WebAssembly] runtimes inside of
 for the purpose of extending and/or introspecting the Nginx web-server/proxy
 runtime.
 
-Currently, the module supports the
-[Proxy-Wasm](https://github.com/proxy-wasm/spec) host SDK and supports Wasm
-filters identical to those [running on
-Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/wasm_filter.html).
+Currently, the module implements a [Proxy-Wasm](https://github.com/proxy-wasm/spec)
+host ABI, which allows the use of client SDKs written in multiple languages,
+such as [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk)
+and [Go](https://github.com/tetratelabs/proxy-wasm-go-sdk). Proxy-Wasm
+("WebAssembly for Proxies") is an emerging standard for Wasm filters,
+adopted by API gateways such as [Kong](https://konghq.com)
+and [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/wasm_filter.html).
 
 ## What is WasmX?
 


### PR DESCRIPTION
* Adjust the terminology (host ABI vs. client SDK)
* Avoid "_identical_ to those running on Envoy" terminology (to make it clear we're not aiming for bug-for-bug compatibility)
* Mention it's a format adopted by multiple gateways, including Kong