### PR TITLE
docs(user) remove zig proxy-wasm SDK link

### DIFF
--- a/docs/PROXY_WASM.md
+++ b/docs/PROXY_WASM.md
@@ -47,7 +47,6 @@ Presently, the _Proxy-Wasm SDK libraries_ are implemented in 5 languages:
 2. [C++](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/)
 3. [Go (TinyGo)](https://github.com/tetratelabs/proxy-wasm-go-sdk/)
 4. [Rust](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/)
-5. [Zig](https://github.com/mathetake/proxy-wasm-zig-sdk/)
 
 The _Proxy-Wasm host ABI_ is implemented by Envoy and a handful of [other
 proxies](https://github.com/proxy-wasm/spec#servers), including ngx_wasm_module.


### PR DESCRIPTION
[PROXY_WASM.md](/Kong/ngx_wasm_module/blob/main/docs/PROXY_WASM.md) currently links out to [mathetake/proxy-wasm-zig-sdk](https://github.com/mathetake/proxy-wasm-zig-sdk/) for the Zig SDK, but this repo appears to have been removed by its author, who has also [removed its link from the proxy-wasm spec README](https://github.com/proxy-wasm/spec/commit/d2c545ba2d09a1ffa303dedb6626021347d23f17).

Of note, I found what looks to be somebody's [unofficial mirror](https://github.com/iCodeIN/proxy-wasm-zig-sdk) of this repo, but it's likely to be considered unmaintained, so I think we should just remove Zig altogether.