### PR TITLE
fix(wrt/wasmtime) call wasmtime functions after fork

### DIFF
--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -463,18 +463,10 @@ ngx_wasm_core_init_conf(ngx_conf_t *cf, void *conf)
 static ngx_int_t
 ngx_wasm_core_init(ngx_cycle_t *cycle)
 {
-    ngx_wavm_t            *vm;
-    ngx_wasm_core_conf_t  *wcf;
+    ngx_wasm_core_conf_t  *wcf = ngx_wasm_core_cycle_get_conf(cycle);
 
-    wcf = ngx_wasm_core_cycle_get_conf(cycle);
     if (wcf == NULL) {
         return NGX_OK;
-    }
-
-    vm = wcf->vm;
-
-    if (vm && ngx_wavm_init(vm) != NGX_OK) {
-        return NGX_ERROR;
     }
 
     if (ngx_wasm_shm_init(cycle) != NGX_OK) {
@@ -483,7 +475,7 @@ ngx_wasm_core_init(ngx_cycle_t *cycle)
 
 #if (NGX_SSL)
     if (ngx_wasm_core_init_ssl(cycle) != NGX_OK) {
-        ngx_wavm_destroy(vm);
+        ngx_wavm_destroy(wcf->vm);
         return NGX_ERROR;
     }
 #endif
@@ -500,6 +492,10 @@ ngx_wasm_core_init_process(ngx_cycle_t *cycle)
     vm = ngx_wasm_main_vm(cycle);
     if (vm == NULL) {
         return NGX_OK;
+    }
+
+    if (ngx_wavm_init(vm) != NGX_OK) {
+        return NGX_ERROR;
     }
 
     if (ngx_wavm_load(vm) != NGX_OK) {

--- a/t/01-wasm/directives/001-module_directive.t
+++ b/t/01-wasm/directives/001-module_directive.t
@@ -174,7 +174,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 ]
 --- no_error_log
 [error]
---- must_die
+--- must_die: 0
 
 
 
@@ -236,7 +236,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 ]
 --- no_error_log
 [error]
---- must_die
+--- must_die: 0
 
 
 

--- a/t/01-wasm/directives/001-module_directive.t
+++ b/t/01-wasm/directives/001-module_directive.t
@@ -136,7 +136,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 
@@ -155,7 +155,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 ]
 --- no_error_log
 [error]
---- must_die
+--- must_die: 0
 
 
 
@@ -192,7 +192,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 ]
 --- no_error_log
 [error]
---- must_die
+--- must_die: 0
 
 
 
@@ -214,7 +214,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 ]
 --- no_error_log
 [error]
---- must_die
+--- must_die: 0
 
 
 

--- a/t/01-wasm/directives/002-compiler_directive.t
+++ b/t/01-wasm/directives/002-compiler_directive.t
@@ -40,7 +40,7 @@ qr/\[emerg\] .*? invalid number of arguments in "compiler" directive/
 ]
 --- no_error_log
 [alert]
---- must_die
+--- must_die: 0
 
 
 

--- a/t/01-wasm/directives/008-flag_directive_wasmtime.t
+++ b/t/01-wasm/directives/008-flag_directive_wasmtime.t
@@ -37,7 +37,7 @@ qr/\[emerg\] .*? failed setting wasmtime flag: invalid value "10U"/
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 
@@ -54,7 +54,7 @@ qr/\[emerg\] .*? failed setting wasmtime flag: invalid value "no"/
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 

--- a/t/01-wasm/directives/009-flag_directive_wasmer.t
+++ b/t/01-wasm/directives/009-flag_directive_wasmer.t
@@ -27,7 +27,7 @@ qr/\[emerg\] .*? failed setting wasmer flag: invalid value "no"/
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 

--- a/t/01-wasm/directives/010-flag_directive_v8.t
+++ b/t/01-wasm/directives/010-flag_directive_v8.t
@@ -35,7 +35,7 @@ qr/\[emerg\] .*? failed setting v8 flag: args list too long \(512 bytes max\) "-
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 
@@ -52,7 +52,7 @@ qr/\[emerg\] .*? failed setting v8 flag: invalid value "no"/
 --- no_error_log
 [error]
 [crit]
---- must_die
+--- must_die: 0
 
 
 


### PR DESCRIPTION
When configured to run as a daemon, Nginx will fork itself right after parsing its configuration.

Before this commit `ngx_wavm_init` was being called during config initialization, i.e. before Nginx fork.

Because of this, Wasmtime C API `wasm_engine_new_with_config` function was being called before Nginx would fork itself while the remaining Wasmtime API calls would be invoked in the newly forked process.

Unfortunately, this use case is not well handled by Wasmtime, leading it to panic when `wasmtime_func_call` is called.

This commit moves `ngx_wavm_init` invocation from `ngx_wasm_core_init` to `ngx_wasm_core_init_process`. Which causes `ngx_wavm_engine_init` to be called after Nginx would fork itself.