### PR TITLE
chore(release) only build V8 of all runtimes during binary build

### DIFF
--- a/util/release.sh
+++ b/util/release.sh
@@ -305,14 +305,19 @@ build_with_runtime() {
 
     local distro="$(get_distro)"
     local runtime_dir="$DIR_DIST_WORK/$runtime-$version-$distro"
+    local mode="--download"
 
-    $NGX_WASM_DIR/util/runtime.sh \
+    if [ $runtime = v8 ]; then
+        mode="--build"
+    fi
+
+    eval $NGX_WASM_DIR/util/runtime.sh \
         --runtime $runtime \
         --runtime-version "$version" \
         --target-dir "$runtime_dir" \
         --arch "$arch" \
-        --build \
-        --clean
+        --clean \
+        $mode
 
     local save_CC_FLAGS="$CC_FLAGS"
     local save_LD_FLAGS="$LD_FLAGS"

--- a/util/runtime.sh
+++ b/util/runtime.sh
@@ -145,6 +145,7 @@ if check_target "$TARGET_DIR"; then
     exit 0
 fi
 
+notice "installing $RUNTIME in $TARGET_DIR..."
 BUILD_SCRIPT=$NGX_WASM_DIR/util/runtimes/$RUNTIME.sh
 
 # TODO: change argument order to


### PR DESCRIPTION
Attempt at speeding up the release build pipeline as much as possible.