### PR TITLE
chore(tests) enable rust backtrace

### DIFF
--- a/t/03-proxy_wasm/003-on_tick.t
+++ b/t/03-proxy_wasm/003-on_tick.t
@@ -128,6 +128,7 @@ ok
 
 
 === TEST 5: proxy_wasm - multiple ticks
+--- disable_rust_backtrace
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code

--- a/t/TestWasm.pm
+++ b/t/TestWasm.pm
@@ -107,10 +107,15 @@ add_block_preprocessor(sub {
     # --- env variables
 
     my $main_config = $block->main_config || '';
+    my $disable_rust_backtrace = $block->disable_rust_backtrace;
 
-    $block->set_value("main_config",
-                      "env WASMTIME_BACKTRACE_DETAILS=1;\n"
-                      . $main_config);
+    my @env_vars = ("env WASMTIME_BACKTRACE_DETAILS=1");
+    if (!defined $disable_rust_backtrace) {
+        push @env_vars, "env RUST_BACKTRACE=full";
+    }
+    my $env_section = join(";\n", @env_vars) . ";\n\n";
+
+    $block->set_value("main_config", $env_section . $main_config);
 
     # --- load_nginx_modules: ngx_http_echo_module
 


### PR DESCRIPTION
Add `env RUST_BACKTRACE=full;` to nginx.conf