### PR TITLE
chore(deps) bump OpenSSL to 3.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NGX ?= 1.25.1
-OPENSSL ?= 1.1.1u
+OPENSSL ?= 3.1.2
 WASMTIME ?= 8.0.1
 WASMER ?= 3.1.1
 V8 ?= 11.4.183.23


### PR DESCRIPTION
"CI Large" once re-enabled will help covering other OpenSSL versions if needed.