### PR TITLE
chore(util/v8) use 'gclient sync -D'

### DIFF
--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -140,7 +140,7 @@ build_libwee8() {
     git checkout "$v8_ver"
 
     notice "synchronizing V8 repository..."
-    gclient sync
+    gclient sync -D
 
     ### build
 


### PR DESCRIPTION
With existing clones being updated, gclient sometimes complain that existing dependencies have been removed, and that we should run with `-D`. Since this is not a development environment, let's always run with `-D`.

See: https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/08e2e0cc9dc3404f1905a2f2741a8553c86d6f77/gclient.py#3092