### PR TITLE
feat(*) wasm_socket unix domain socket support

### DIFF
--- a/src/common/ngx_wasm_socket_tcp.h
+++ b/src/common/ngx_wasm_socket_tcp.h
@@ -94,8 +94,7 @@ struct ngx_wasm_socket_tcp_s {
 
 
 ngx_int_t ngx_wasm_socket_tcp_init(ngx_wasm_socket_tcp_t *sock,
-    ngx_str_t *host, in_port_t port, unsigned tls,
-    ngx_wasm_subsys_env_t *env);
+    ngx_str_t *host, unsigned tls, ngx_wasm_subsys_env_t *env);
 ngx_int_t ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock);
 ngx_int_t ngx_wasm_socket_tcp_send(ngx_wasm_socket_tcp_t *sock,
     ngx_chain_t *cl);

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -136,8 +136,6 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 {
     static uint32_t                  callout_ids = 0;
     size_t                           i;
-    in_port_t                        port = 0;
-    u_char                          *p, *last;
     ngx_buf_t                       *buf;
     ngx_event_t                     *ev;
     ngx_table_elt_t                 *elts, *elt;
@@ -226,25 +224,6 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 
     ngx_memcpy(call->host.data, host->data, host->len);
     call->host.data[call->host.len] = '\0';
-
-    /* port */
-
-    p = host->data;
-    last = p + host->len;
-
-    if (*p == '[') {
-        /* IPv6 */
-        p = ngx_strlchr(p, last, ']');
-        if (p == NULL) {
-            p = host->data;
-        }
-    }
-
-    p = ngx_strlchr(p, last, ':');
-
-    if (p) {
-        port = ngx_atoi(p + 1, last - p);
-    }
 
     /* headers/trailers */
 
@@ -354,8 +333,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 
     ngx_wasm_assert(rctx);
 
-    if (ngx_wasm_socket_tcp_init(sock, &call->host, port, enable_ssl,
-                                 &rctx->env)
+    if (ngx_wasm_socket_tcp_init(sock, &call->host, enable_ssl, &rctx->env)
         != NGX_OK)
     {
         dd("tcp init error");

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -178,13 +178,23 @@ impl TestHttp {
         }
 
         if self.get_config("no_authority").is_none() {
-            headers.push((
-                ":authority",
-                self.config
-                    .get("host")
-                    .map(|v| v.as_str())
-                    .unwrap_or("default"),
-            ));
+            if self.get_config("authority").is_none() {
+                headers.push((
+                    ":authority",
+                    self.config
+                        .get("host")
+                        .map(|v| v.as_str())
+                        .unwrap_or("default"),
+                ));
+            } else {
+                headers.push((
+                    ":authority",
+                    self.config
+                        .get("authority")
+                        .map(|v| v.as_str())
+                        .unwrap_or("default"),
+                ));
+            }
         }
 
         if self.get_config("https") == Some("yes") {


### PR DESCRIPTION
- [x] Update wasm_socket port parsing
- [x] Add test cases (sanity, missing socket file, missing :authority)
- [x] ~Update tests relying `TEST_NGINX_SERVER_PORT2` to use unix domain socket instead~. 
- [x] ~If possible, drop `TEST_NGINX_SERVER_PORT2`~

Updating tests that were using `TEST_NGINX_SERVER_PORT2` ended up being a substantial amount of work on it's own, deserving it's own PR or PRs.