### PR TITLE
fix(wrt/wasmtime) do not override 'WASMTIME_BACKTRACE_DETAILS' if specified

### DIFF
--- a/src/wasm/wrt/ngx_wrt_wasmtime.c
+++ b/src/wasm/wrt/ngx_wrt_wasmtime.c
@@ -137,7 +137,7 @@ ngx_wasmtime_init_conf(ngx_wavm_conf_t *conf, ngx_log_t *log)
         setenv("WASMTIME_BACKTRACE_DETAILS", "1", 1);
 
     } else {
-        setenv("WASMTIME_BACKTRACE_DETAILS", "0", 1);
+        setenv("WASMTIME_BACKTRACE_DETAILS", "0", 0);
     }
 
     config = wasm_config_new();

--- a/t/01-wasm/directives/006-backtraces_directive.t
+++ b/t/01-wasm/directives/006-backtraces_directive.t
@@ -81,10 +81,13 @@ for my $i (21..$::n) {
 
 
 === TEST 3: backtraces directive - wasmtime 'cranelift', backtraces 'on'
+Also assert that WASMTIME_BACKTRACE_DETAILS is overriden.
 --- skip_eval: 30: $::nginxV !~ m/wasmtime/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{
+    env WASMTIME_BACKTRACE_DETAILS=0;
+
     wasm {
         module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
         compiler cranelift;
@@ -131,7 +134,60 @@ for my $i (24..$::n) {
 
 
 
-=== TEST 4: backtraces directive - wasmer 'auto', backtraces 'off'
+=== TEST 4: backtraces directive - wasmtime 'cranelift', backtraces 'off', WASMTIME_BACKTRACE_DETAILS=1
+--- skip_eval: 30: $::nginxV !~ m/wasmtime/
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    env WASMTIME_BACKTRACE_DETAILS=1;
+
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+        compiler cranelift;
+        backtraces off;
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/trap';
+        echo ok;
+    }
+--- error_code: 500
+--- response_body_like: 500 Internal Server Error
+--- error_log eval
+[
+    qr/\[info\] .*? \[wasm\] using wasmtime with compiler: "cranelift" \(backtraces: 0\)/,
+    qr/\[crit\] .*? panicked at/,
+    qr/custom trap/,
+    qr/\[error\] .*? \[wasm\] error while executing at wasm backtrace:/,
+    qr#    0: 0x[0-9a-f]+ - .*?abort#,
+    qr#                    at /rustc/[0-9a-f]+/library/panic_abort/src/lib.rs:[0-9]+:[0-9]+ *- __rust_start_panic#,
+    qr#                    at /rustc/[0-9a-f]+/library/panic_abort/src/lib.rs:[0-9]+:[0-9]+#,
+    qr#    1: 0x[0-9a-f]+ - .*?rust_panic#,
+    qr#                    at /rustc/[0-9a-f]+/library/std/src/panicking.rs:[0-9]+:[0-9]+#,
+    qr#    2: 0x[0-9a-f]+ - .*?rust_panic_with_hook#,
+    qr#                    at /rustc/[0-9a-f]+/library/std/src/panicking.rs:[0-9]+:[0-9]+#,
+    qr#    3: 0x[0-9a-f]+ - <unknown>!std::panicking::begin_panic::\{\{closure\}\}::h[0-9a-f]+#,
+    qr#    4: 0x[0-9a-f]+ - <unknown>!std::sys_common::backtrace::__rust_end_short_backtrace::h[0-9a-f]+#,
+    qr#    5: 0x[0-9a-f]+ - <unknown>!std::panicking::begin_panic::h[0-9a-f]+#,
+    qr#    6: 0x[0-9a-f]+ - <unknown>!hostcalls::types::test_http::TestHttp::exec_tests::h[0-9a-f]+#,
+    qr#    7: 0x[0-9a-f]+ - <unknown>!hostcalls::filter::<impl proxy_wasm::traits::HttpContext for hostcalls::types::test_http::TestHttp>::on_http_request_headers::h[0-9a-f]+#,
+    qr#    8: 0x[0-9a-f]+ - <unknown>!proxy_wasm::dispatcher::Dispatcher::on_http_request_headers::h[0-9a-f]+#,
+    qr#    9: 0x[0-9a-f]+ - <unknown>!proxy_on_request_headers#,
+    qr#^$#,
+    qr#Caused by:#,
+    qr#    wasm trap: wasm `unreachable` instruction executed#,
+]
+--- no_error_log eval
+my @checks;
+for my $i (24..$::n) {
+    push(@checks, "stub$i\n");
+}
+[@checks]
+
+
+
+=== TEST 5: backtraces directive - wasmer 'auto', backtraces 'off'
 --- skip_eval: 30: $::nginxV !~ m/wasmer/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -176,7 +232,7 @@ for my $i (18..$::n) {
 
 
 
-=== TEST 5: backtraces directive - wasmer 'cranelift', backtraces 'on'
+=== TEST 6: backtraces directive - wasmer 'cranelift', backtraces 'on'
 --- skip_eval: 30: $::nginxV !~ m/wasmer/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -221,7 +277,7 @@ for my $i (17..$::n) {
 
 
 
-=== TEST 6: backtraces directive - wasmer 'singlepass', backtraces 'on'
+=== TEST 7: backtraces directive - wasmer 'singlepass', backtraces 'on'
 --- skip_eval: 30: $::nginxV !~ m/wasmer/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -266,7 +322,7 @@ for my $i (18..$::n) {
 
 
 
-=== TEST 7: backtraces directive - wasmer 'llvm', backtraces 'on'
+=== TEST 8: backtraces directive - wasmer 'llvm', backtraces 'on'
 --- SKIP: no llvm support in upstream releases
 --- skip_eval: 30: $::nginxV !~ m/wasmer/
 --- load_nginx_modules: ngx_http_echo_module
@@ -312,7 +368,7 @@ for my $i (18..$::n) {
 
 
 
-=== TEST 8: backtraces directive - v8 'auto', backtraces 'off'
+=== TEST 9: backtraces directive - v8 'auto', backtraces 'off'
 --- skip_eval: 30: $::nginxV !~ m/v8/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -358,7 +414,7 @@ for my $i (18..$::n) {
 
 
 
-=== TEST 9: backtraces directive - v8 'auto', backtraces 'on'
+=== TEST 10: backtraces directive - v8 'auto', backtraces 'on'
 --- skip_eval: 30: $::nginxV !~ m/v8/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval

--- a/t/TestWasm.pm
+++ b/t/TestWasm.pm
@@ -104,11 +104,10 @@ add_block_preprocessor(sub {
 
     # --- env variables
 
-    my $main_config = $block->main_config || '';
-
-    $block->set_value("main_config",
-                      "env WASMTIME_BACKTRACE_DETAILS=1;\n"
-                      . $main_config);
+    #my $main_config = $block->main_config || '';
+    #$block->set_value("main_config",
+    #                  "env WASMTIME_BACKTRACE_DETAILS=1;\n"
+    #                  . $main_config);
 
     # --- load_nginx_modules: ngx_http_echo_module
 
@@ -130,6 +129,7 @@ add_block_preprocessor(sub {
 
     if (@dyn_modules) {
         @arr = map { "load_module $buildroot/$_.so;" } @dyn_modules;
+        my $main_config = $block->main_config || '';
         $block->set_value("main_config",
                           (join "\n", @arr)
                           . "\n\n"
@@ -151,7 +151,6 @@ add_block_preprocessor(sub {
         @arr = split /\s+/, $wasm_modules;
         if (@arr) {
             @arr = map { "module $_ $crates/$_.wasm;" } @arr;
-            my $main_config = $block->main_config || '';
             my $wasm_config = "wasm {\n" .
                               "    " . (join "\n", @arr) . "\n";
 
@@ -199,6 +198,7 @@ add_block_preprocessor(sub {
 
             $wasm_config = $wasm_config . "}\n";
 
+            my $main_config = $block->main_config || '';
             $block->set_value("main_config", $main_config . $wasm_config);
         }
     }


### PR DESCRIPTION


With `backtraces on`, `WASMTIME_BACKTRACE_DETAILS` is forcefully enabled.

With `backtraces off` (default), `WASMTIME_BACKTRACE_DETAILS` still defaults to `0` but can be overridden if specified in the `env` directive.

This commit also ensures the `env` directives in `TestWasm.pm` are actually injected, although it disables the injection since no environment variable is presently injected.