### PR TITLE
hotfix(config) fix external ngx-wasm-rs builds

### DIFF
--- a/auto/cargo
+++ b/auto/cargo
@@ -67,11 +67,8 @@ if [ $ngx_wasm_rc = 0 ]; then
     . auto/feature
 
     if [ $ngx_found = yes ]; then
-        for d in $ngx_wasm_cargo_defines; do
-            have=$d value=1 . auto/define
-        done
 
-        if [ "$ngx_wasm_cargo_crate_type" = "cdylib" ]; then
+        if [ "$ngx_wasm_cargo_crate_type" = cdylib ]; then
             ngx_wasm_cargo_cdylib="$ngx_wasm_cargo_target_dir/lib$ngx_wasm_cargo_lib_name.so"
             ngx_wasm_cargo_cdylibs="$ngx_wasm_cargo_cdylibs $ngx_wasm_cargo_cdylib"
 
@@ -103,7 +100,7 @@ fi
 
 if [ $ngx_found = no ]; then
     if [ $ngx_wasm_cargo_mandatory = yes ]; then
-        echo "$0: error: $ngx_addon_name requires lib$ngx_wasm_cargo_lib_name - aborting."
+        echo "$0: error: $ngx_addon_name with $NGX_WASM_RUNTIME requires lib$ngx_wasm_cargo_lib_name - aborting."
         echo
         exit 1
     fi

--- a/config
+++ b/config
@@ -100,11 +100,17 @@ if [ "$ngx_wasm_cargo_lib_name" = ngx_wasm_rs ]; then
             ngx_wasm_runtime_path="$ngx_wasm_runtime_path $ngx_feature_path"
             ngx_wasm_runtime_libs="$ngx_wasm_runtime_libs $ngx_feature_libs"
         fi
+    fi
 
-    else
+    if echo -n "$ngx_wasm_runtime_libs\n$NGX_LD_OPT" | grep -q "ngx-wasm-rs"; then
         for d in $ngx_wasm_cargo_defines; do
             have=$d value=1 . auto/define
         done
+
+    elif [ $ngx_wasm_cargo_mandatory = yes ]; then
+        echo "$0: error: $ngx_addon_name with $NGX_WASM_RUNTIME requires lib$ngx_wasm_cargo_lib_name - aborting."
+        echo
+        exit 1
     fi
 fi
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -225,9 +225,8 @@ following tweaks:
 
 1. Set the `NGX_WASM_CARGO=0` environment variable so that it does not run
    `cargo` itself.
-2. Specify compiler and linker flags to the library you compiled:
-    1. Either via the `NGX_CC_OPT` and `NGX_LD_OPT` environment variables.
-    2. Or via the equivalent `--with-cc-opt` and `--with-ld-opt` arguments.
+2. Specify compiler and linker flags to the library you compiled via the
+   `--with-cc-opt` and `--with-ld-opt` arguments.
 
 The example below uses a static build of ngx-wasm-rs located in some path
 `/.../include` and `/.../lib`:

--- a/t/10-build/004-ngx_wasm_rs_linking.t
+++ b/t/10-build/004-ngx_wasm_rs_linking.t
@@ -12,9 +12,47 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: dynamically linked libwasmer (environment variables) + dynamic ngx-wasm-rs built separately
+=== TEST 1: libwasmer without ngx-wasm-rs
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
---- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug -lngx_wasm_rs" make}
+--- build: NGX_WASM_CARGO=0 make
+--- grep_nginxV
+ngx_wasm_module [dev debug wasmer]
+--- grep_libs
+libwasmer
+--- no_grep_libs
+libngx_wasm_rs
+stub1
+stub2
+
+
+
+=== TEST 2: libwee8 without ngx-wasm-rs
+--- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
+--- build: NGX_WASM_CARGO=0 make
+--- exit_code: 2
+--- expect_stderr
+--- grep_build
+./configure: error: ngx_wasm_module with v8 requires libngx_wasm_rs - aborting.
+--- no_grep_build
+stub1
+stub2
+stub3
+stub4
+
+
+
+=== TEST 3: dynamically linked libwee8 (environment variables) + dynamic ngx-wasm-rs built separately
+--- SKIP: NYI - the V8 build system builds libwee8 statically
+--- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug-lngx_wasm_rs" make}
+--- grep_nginxV
+ngx_wasm_module [dev debug v8]
+
+
+
+=== TEST 4: dynamically linked libwasmer (environment variables) + dynamic ngx-wasm-rs built separately
+--- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug -lngx_wasm_rs" make}
 --- grep_nginxV
 ngx_wasm_module [dev debug wasmer]
 --- grep_libs
@@ -26,7 +64,7 @@ stub2
 
 
 
-=== TEST 2: dynamically linked libwasmer (./configure arguments) + dynamic ngx-wasm-rs built separately
+=== TEST 5: dynamically linked libwasmer (./configure arguments) + dynamic ngx-wasm-rs built separately
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
 --- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_WASM_RUNTIME_INC= NGX_WASM_RUNTIME_LIB= NGX_WASM_RUNTIME_LD_OPT= NGX_BUILD_CONFIGURE_OPT="--with-cc-opt='-I$ENV{NGX_WASM_RUNTIME_DIR}/include -I$pwd/lib/ngx-wasm-rs/include' --with-ld-opt='-L$ENV{NGX_WASM_RUNTIME_DIR} -L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug -lngx_wasm_rs'" make}
 --- grep_nginxV
@@ -40,10 +78,10 @@ stub2
 
 
 
-=== TEST 3: dynamically linked libwee8 (environment variables) + dynamic ngx-wasm-rs built separately
+=== TEST 6: dynamically linked libwee8 (environment variables) + dynamic ngx-wasm-rs built separately
 --- SKIP: NYI - the V8 build system builds libwee8 statically
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
---- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug-lngx_wasm_rs" make}
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug-lngx_wasm_rs" make}
 --- grep_nginxV
 ngx_wasm_module [dev debug v8]
 --- grep_libs
@@ -55,7 +93,7 @@ stub2
 
 
 
-=== TEST 4: dynamically linked libwee8 (./configure arguments) + dynamic ngx-wasm-rs built separately
+=== TEST 7: dynamically linked libwee8 (./configure arguments) + dynamic ngx-wasm-rs built separately
 --- SKIP: NYI - the V8 build system builds libwee8 statically
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
 --- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_WASM_RUNTIME_INC= NGX_WASM_RUNTIME_LIB= NGX_WASM_RUNTIME_LD_OPT= NGX_BUILD_CONFIGURE_OPT="--with-cc-opt='-I$ENV{NGX_WASM_RUNTIME_DIR}/include -I$pwd/lib/ngx-wasm-rs/include' --with-ld-opt='-L$ENV{NGX_WASM_RUNTIME_DIR} -L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug-lngx_wasm_rs'" make}
@@ -70,10 +108,10 @@ stub2
 
 
 
-=== TEST 5: statically linked libwasmer (environment variables) + static ngx-wasm-rs built separately
+=== TEST 8: statically linked libwasmer (environment variables) + static ngx-wasm-rs built separately
 --- SKIP: Cannot link two static Rust libraries linked with different compilers
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
---- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_LD_OPT="$pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a" NGX_WASM_RUNTIME_INC="$ENV{NGX_WASM_RUNTIME_DIR}/include" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a" make}
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="$pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a" NGX_WASM_RUNTIME_INC="$ENV{NGX_WASM_RUNTIME_DIR}/include" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a" make}
 --- grep_nginxV
 ngx_wasm_module [dev debug wasmer]
 --- run_cmd eval: qq{nm -g $::buildroot/nginx}
@@ -88,7 +126,7 @@ libngx_wasm_rs
 
 
 
-=== TEST 6: statically linked libwasmer (./configure arguments) + static ngx-wasm-rs built separately
+=== TEST 9: statically linked libwasmer (./configure arguments) + static ngx-wasm-rs built separately
 --- SKIP: Cannot link two static Rust libraries linked with different compilers
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
 --- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_WASM_RUNTIME_INC= NGX_WASM_RUNTIME_LIB= NGX_WASM_RUNTIME_LD_OPT= NGX_BUILD_CONFIGURE_OPT="--with-cc-opt='-I$ENV{NGX_WASM_RUNTIME_DIR}/include -I$pwd/lib/ngx-wasm-rs/include' --with-ld-opt='$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a $pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a'" make}
@@ -106,9 +144,9 @@ libngx_wasm_rs
 
 
 
-=== TEST 7: statically linked libwee8 (environment variables) + static ngx-wasm-rs built separately
+=== TEST 10: statically linked libwee8 (environment variables) + static ngx-wasm-rs built separately
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
---- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_LD_OPT="$pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/libwee8.a -L$ENV{NGX_WASM_RUNTIME_DIR}/lib" make}
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="$pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/libwee8.a -L$ENV{NGX_WASM_RUNTIME_DIR}/lib" make}
 --- grep_nginxV
 ngx_wasm_module [dev debug v8]
 --- run_cmd eval: qq{nm -g $::buildroot/nginx}
@@ -123,7 +161,7 @@ libngx_wasm_rs
 
 
 
-=== TEST 8: statically linked libwee8 (./configure arguments) + static ngx-wasm-rs built separately
+=== TEST 11: statically linked libwee8 (./configure arguments) + static ngx-wasm-rs built separately
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'v8'
 --- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build --features wat ) && NGX_WASM_CARGO=0 NGX_WASM_RUNTIME_INC= NGX_WASM_RUNTIME_LIB= NGX_WASM_RUNTIME_LD_OPT= NGX_BUILD_CONFIGURE_OPT="--with-cc-opt='-I$ENV{NGX_WASM_RUNTIME_DIR}/include -I$pwd/lib/ngx-wasm-rs/include' --with-ld-opt='$ENV{NGX_WASM_RUNTIME_DIR}/lib/libwee8.a -L$ENV{NGX_WASM_RUNTIME_DIR} $pwd/lib/ngx-wasm-rs/target/debug/libngx_wasm_rs.a' " make}
 --- grep_nginxV
@@ -140,9 +178,9 @@ libngx_wasm_rs
 
 
 
-=== TEST 9: statically linked libwasmer (environment variables) + dynamic ngx-wasm-rs built separately
+=== TEST 12: statically linked libwasmer (environment variables) + dynamic ngx-wasm-rs built separately
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
---- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug -lngx_wasm_rs" NGX_WASM_RUNTIME_INC="$ENV{NGX_WASM_RUNTIME_DIR}/include" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a" make}
+--- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_BUILD_CC_OPT="-I $pwd/lib/ngx-wasm-rs/include" NGX_BUILD_LD_OPT="-L$pwd/lib/ngx-wasm-rs/target/debug -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug -lngx_wasm_rs" NGX_WASM_RUNTIME_INC="$ENV{NGX_WASM_RUNTIME_DIR}/include" NGX_WASM_RUNTIME_LD_OPT="$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a" make}
 --- grep_nginxV
 ngx_wasm_module [dev debug wasmer]
 --- run_cmd eval: qq{nm -g $::buildroot/nginx}
@@ -161,7 +199,7 @@ libwasmer
 
 
 
-=== TEST 10: statically linked libwasmer (./configure arguments) + dynamic ngx-wasm-rs built separately
+=== TEST 13: statically linked libwasmer (./configure arguments) + dynamic ngx-wasm-rs built separately
 --- skip_eval: 6: $ENV{NGX_WASM_RUNTIME} ne 'wasmer'
 --- build eval: use Cwd qw(cwd); my $pwd = cwd(); qq{( cd $pwd/lib/ngx-wasm-rs; cargo build ) && NGX_WASM_CARGO=0 NGX_WASM_RUNTIME_INC= NGX_WASM_RUNTIME_LIB= NGX_WASM_RUNTIME_LD_OPT= NGX_BUILD_CONFIGURE_OPT="--with-cc-opt='-I$ENV{NGX_WASM_RUNTIME_DIR}/include -I$pwd/lib/ngx-wasm-rs/include' --with-ld-opt='$ENV{NGX_WASM_RUNTIME_DIR}/lib/lib$ENV{NGX_WASM_RUNTIME}.a -L$pwd/lib/ngx-wasm-rs/target/debug/ -Wl,-rpath=$pwd/lib/ngx-wasm-rs/target/debug/ -lngx_wasm_rs'" make}
 --- grep_nginxV

--- a/t/TestBuild.pm
+++ b/t/TestBuild.pm
@@ -230,6 +230,7 @@ sub run_test ($) {
 
     if (defined $out) {
         grep_something($block, "grep_build", $out);
+        grep_something($block, "no_grep_build", $out);
 
         # --- grep_nginxV
 

--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -285,6 +285,7 @@ build_nginx() {
                         ld_opt=$NGX_BUILD_LD_OPT.\
                         ssl=$NGX_BUILD_SSL.\
                         dynamic=$NGX_BUILD_DYNAMIC_MODULE.\
+                        cargo=$NGX_WASM_CARGO.\
                         hash_src=$hash_src"
 
     local hash_opt=$(echo $hash_opt_txt | shasum | awk '{ print $1 }')


### PR DESCRIPTION
First this fixes the test cases and documentation as they were merged, which wrongly assumed `NGX_CC_OPT` and `NGX_LD_OPT` were digested by Nginx's `auto` scripts, they are not. They are derived from `--with-{cc,ld}-opt` arguments.

Second, it moves defines and mandatory checks to `config` since we need both even when `NGX_WASM_CARGO=0` and `auto/cargo` does not run.

The above fixes `NGX_WASM_CARGO=0` as a mean to *completely* disable ngx-wasm-rs, as supported by Wasmer. This "mandatory={yes,no}" behavior is tested for both Wasmer and V8 as well.

Finally, we also consider `NGX_WASM_CARGO` in the local development environment freshness build script.