### PR TITLE
refactor(lib): make Rust module compile-able under stable Rust

### DIFF
--- a/lib/ngx-wasm-rs/lib/backtrace/src/lib.rs
+++ b/lib/ngx-wasm-rs/lib/backtrace/src/lib.rs
@@ -1,3 +1,2 @@
-#![feature(vec_into_raw_parts)]
 pub(crate) mod backtrace;
 pub mod c_api;

--- a/lib/ngx-wasm-rs/lib/wat/src/lib.rs
+++ b/lib/ngx-wasm-rs/lib/wat/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(vec_into_raw_parts)]
 use ngx_wasm_c_api::*;
 use regex::Regex;
 use std::mem;
@@ -26,9 +25,10 @@ fn extract_message(err: &str) -> Option<String> {
 
 fn vec_into_wasm_byte_vec_t(bv: *mut wasm_byte_vec_t, v: Vec<u8>) -> () {
     unsafe {
-        let (ptr, len, _cap) = v.into_raw_parts();
-        (*bv).size = len;
-        (*bv).data = ptr;
+        // FIXME Update this when vec_into_raw_parts is stabilized
+        let mut v = mem::ManuallyDrop::new(v);
+        (*bv).size = v.len();
+        (*bv).data = v.as_mut_ptr();
     }
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable

--- a/util/test.sh
+++ b/util/test.sh
@@ -106,9 +106,14 @@ export RUSTFLAGS="$TEST_NGINX_CARGO_RUSTFLAGS"
 eval cargo build \
     --lib \
     "${args[@]}" \
-    --target wasm32-wasi \
-    --out-dir $DIR_TESTS_LIB_WASM \
-    -Z unstable-options
+    --target wasm32-wasi
+
+if [ "$TEST_NGINX_CARGO_PROFILE" = release ]; then
+    cp target/wasm32-wasi/release/*.wasm $DIR_TESTS_LIB_WASM
+
+else
+    cp target/wasm32-wasi/debug/*.wasm $DIR_TESTS_LIB_WASM
+fi
 
 if [ $(uname -s) = Linux ]; then
     export TEST_NGINX_EVENT_TYPE=epoll


### PR DESCRIPTION
Implementation based on the Rust standard library implementation for `vec_into_raw_parts`.

See examples from: https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#538-546
Implementation in: https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#818-822

With this change the Rust library now compiles cleanly with stable Rust 1.71.1.

This makes building under a production setup easier as Rust nightly can not be easily pinned and might introduce breaking changes without notice.

Helps unblock: https://github.com/Kong/ngx_wasm_module/pull/392