### PR TITLE
fix(proxy-wasm) improve instance recycling robustness

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -878,15 +878,6 @@ ngx_proxy_wasm_store_destroy(ngx_proxy_wasm_store_t *store)
         ngx_proxy_wasm_release_instance(ictx, 1);
     }
 
-    while (!ngx_queue_empty(&store->sweep)) {
-        dd("remove sweep");
-        q = ngx_queue_head(&store->sweep);
-        ictx = ngx_queue_data(q, ngx_proxy_wasm_instance_t, q);
-
-        ngx_queue_remove(&ictx->q);
-        ngx_proxy_wasm_instance_destroy(ictx);
-    }
-
     dd("exit");
 }
 
@@ -1362,6 +1353,8 @@ void
 ngx_proxy_wasm_release_instance(ngx_proxy_wasm_instance_t *ictx,
     unsigned sweep)
 {
+    ngx_queue_t  *q;
+
     if (sweep) {
         ictx->nrefs = 0;
 
@@ -1369,21 +1362,30 @@ ngx_proxy_wasm_release_instance(ngx_proxy_wasm_instance_t *ictx,
         ictx->nrefs--;
     }
 
-    dd("ictx: %p (nrefs: %ld, sweep: %d)",
-       ictx, ictx->nrefs, sweep);
+    dd("ictx: %p (nrefs: %ld, sweep: %d, trapped: %d)",
+       ictx, ictx->nrefs, sweep, ictx->instance->trapped);
 
     if (ictx->nrefs == 0) {
         if (ictx->store) {
             dd("remove from busy");
             ngx_queue_remove(&ictx->q); /* remove from busy/free */
 
-            if (sweep) {
+            if (sweep || ictx->instance->trapped) {
                 dd("insert in sweep");
                 ngx_queue_insert_tail(&ictx->store->sweep, &ictx->q);
 
             } else {
                 dd("insert in free");
                 ngx_queue_insert_tail(&ictx->store->free, &ictx->q);
+            }
+
+            while (!ngx_queue_empty(&ictx->store->sweep)) {
+                dd("sweep (destroy)");
+                q = ngx_queue_head(&ictx->store->sweep);
+                ictx = ngx_queue_data(q, ngx_proxy_wasm_instance_t, q);
+
+                ngx_queue_remove(&ictx->q);
+                ngx_proxy_wasm_instance_destroy(ictx);
             }
 
         } else {

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -398,7 +398,7 @@ ngx_wavm_ptr_t ngx_proxy_wasm_alloc(ngx_proxy_wasm_exec_t *pwexec, size_t size);
 void ngx_proxy_wasm_store_destroy(ngx_proxy_wasm_store_t *store);
 ngx_proxy_wasm_instance_t *ngx_proxy_wasm_get_instance(
     ngx_proxy_wasm_filter_t *filter, ngx_proxy_wasm_store_t *store,
-    ngx_log_t *log);
+    ngx_proxy_wasm_exec_t *pwexec, ngx_log_t *log);
 void ngx_proxy_wasm_release_instance(ngx_proxy_wasm_instance_t *ictx,
     unsigned sweep);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -721,7 +721,6 @@ ngx_proxy_wasm_properties_get_ngx(ngx_proxy_wasm_ctx_t *pwctx,
     hash = hash_str(name.data, name.len);
 
     rctx = (ngx_http_wasm_req_ctx_t *) pwctx->data;
-
     if (rctx == NULL || rctx->fake_request) {
         ngx_wavm_log_error(NGX_LOG_ERR, pwctx->log, NULL,
                            "cannot get ngx properties outside of a request");
@@ -861,8 +860,8 @@ static ngx_int_t
 ngx_proxy_wasm_properties_get_host(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value)
 {
-    host_props_node_t        *hpn;
     uint32_t                  hash;
+    host_props_node_t        *hpn;
 #ifdef NGX_WASM_HTTP
     ngx_http_wasm_req_ctx_t  *rctx = pwctx->data;
 
@@ -893,9 +892,9 @@ static ngx_int_t
 ngx_proxy_wasm_properties_set_host(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value)
 {
-    host_props_node_t        *hpn;
     uint32_t                  hash;
     unsigned                  new_entry = 1;
+    host_props_node_t        *hpn;
 #ifdef NGX_WASM_HTTP
     ngx_http_wasm_req_ctx_t  *rctx = pwctx->data;
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -212,7 +212,8 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
         return;
     }
 
-    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, filter->log);
+    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, pwexec,
+                                       filter->log);
     if (ictx == NULL) {
         ngx_wasm_log_error(NGX_LOG_ERR, log, 0,
                            "tick_handler: no instance");
@@ -245,6 +246,8 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
         pwexec->ev->handler = ngx_proxy_wasm_filter_tick_handler;
         pwexec->ev->data = pwexec;
         pwexec->ev->log = log;
+
+        dd("scheduling next tick in %ld", pwexec->tick_period);
 
         ngx_add_timer(pwexec->ev, pwexec->tick_period);
     }

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -199,6 +199,7 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
 #endif
     ngx_proxy_wasm_filter_t    *filter = pwexec->filter;
     ngx_proxy_wasm_instance_t  *ictx;
+    ngx_proxy_wasm_err_e        ecode;
 
     dd("enter");
 
@@ -226,16 +227,16 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
 #endif
     pwexec->in_tick = 1;
 
-    pwexec->ecode = ngx_proxy_wasm_run_step(pwexec, ictx,
-                                            NGX_PROXY_WASM_STEP_TICK);
-
-    pwexec->in_tick = 0;
+    ecode = ngx_proxy_wasm_run_step(pwexec, ictx, NGX_PROXY_WASM_STEP_TICK);
 
     ngx_proxy_wasm_release_instance(ictx, 0);
 
-    if (pwexec->ecode != NGX_PROXY_WASM_ERR_NONE) {
+    if (ecode != NGX_PROXY_WASM_ERR_NONE) {
+        pwexec->ecode = ecode;
         return;
     }
+
+    pwexec->in_tick = 0;
 
     if (!ngx_exiting) {
         pwexec->ev = ngx_calloc(sizeof(ngx_event_t), log);

--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -1461,7 +1461,7 @@ ngx_wavm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_wrt_err_t *e,
         wasm_byte_vec_delete(&trapmsg);
 
 #if (NGX_WASM_HAVE_V8 || NGX_WASM_HAVE_WASMER)
-        if (ctx->instance) {
+        if (ctx && ctx->instance) {
             wasm_trap_trace(e->trap, &trace);
 
             if (trace.size > 0) {

--- a/t/03-proxy_wasm/003-on_tick.t
+++ b/t/03-proxy_wasm/003-on_tick.t
@@ -152,3 +152,31 @@ qr/.*?(\[error\]|Uncaught RuntimeError: |\s+)tick_period already set.*
 [stub2]
 [stub3]
 --- must_die
+
+
+
+=== TEST 6: proxy_wasm - on_tick with trap
+Should recycle the tick instance
+Should not prevent http context/instance from starting
+--- skip_no_debug: 7
+--- wasm_modules: on_phases
+--- config
+    location /t {
+        proxy_wasm on_phases 'tick_period=200 on_tick=trap';
+        return 200;
+    }
+--- response_body
+--- grep_error_log eval: qr/\[(info|crit)].*?on_tick.*/
+--- grep_error_log_out eval
+qr/.*?
+\[info\] .*? on_tick 200.*
+\[crit\] .*? panicked at 'on_tick trap'.*
+.*?
+\[info\] .*? on_tick 200.*
+\[crit\] .*? panicked at 'on_tick trap'.*/
+--- error_log
+filter 1/1 resuming "on_request_headers" step
+filter 1/1 resuming "on_response_headers" step
+--- no_error_log
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -96,6 +96,7 @@ Should recycle the global instance when trapped.
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(2\/2\)\Z/,
 qr/\A\*\d+ .*? filter freeing trapped instance[^#*]*
+\*\d+ wasm freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -137,11 +137,11 @@ should use an instance per stream
 #0 on_vm_start[^#*]*
 #0 on_configure[^#*]*
 \*\d+ .*? filter new instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_body" step in "body_filter" phase[^#*]*
@@ -156,11 +156,11 @@ should use an instance per stream
 \*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
 \*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/,
 qr/\A\*\d+ .*? filter new instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_body" step in "body_filter" phase[^#*]*

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -80,8 +80,8 @@ qr/.*?testing in "RequestHeaders".*
 .*?testing in "Log".*
 .*?wasmx\.something: 5.*/
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -101,8 +101,8 @@ TODO: is this behavior correct?
 --- error_log eval
 qr/\[info\] .*? property not found: wasmx.nonexistent_property,/
 --- no_error_log
-[error]
 [emerg]
+[alert]
 
 
 
@@ -123,8 +123,8 @@ ok
 --- error_log eval
 qr/\[info\] .*? property not found: was,/
 --- no_error_log
-[crit]
 [emerg]
+[alert]
 
 
 
@@ -137,7 +137,7 @@ is global (single instance for root/request).
 --- load_nginx_modules: ngx_http_echo_module
 --- config
     location /t {
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;
@@ -167,7 +167,7 @@ HTTP 200 since the root and request instances are different.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;

--- a/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
@@ -58,9 +58,9 @@ qr/\A\[info\] .*? new: "2"
 \[info\] .*? old: "5"
 \[info\] .*? new: "6"/
 --- no_error_log
-[error]
-[crit]
 [emerg]
+[alert]
+[stub]
 
 
 
@@ -85,7 +85,7 @@ qr/\A\[info\] .*? new: "2"
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
+[emerg]
 
 
 
@@ -110,7 +110,7 @@ qr/\A\[info\] .*? new: "2"
     qr/\[info\] .*? new: ""/,
 ]
 --- no_error_log
-[error]
+[emerg]
 
 
 
@@ -132,9 +132,9 @@ Does not fail when the property is not found.
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
-[crit]
 [emerg]
+[alert]
+[stub]
 
 
 
@@ -149,7 +149,7 @@ isolation is global (single instance for root/request).
     set $my_var 123;
 
     location /t {
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \
@@ -186,7 +186,7 @@ ngx_http_* calls.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
@@ -61,8 +61,8 @@ qr/\A\[info\] .*? old: "1"
 \[info\] .*? old: "5"
 \[info\] .*? new: "6"/
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -134,8 +134,8 @@ GET /t?hello=world
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -238,7 +238,7 @@ HTTP 200 since the root and request instances are different.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=200 \
                               on_tick=set_property \
                               name=ngx.my_var \
                               set=456 \

--- a/t/04-openresty/ffi/103-proxy_wasm_attach.t
+++ b/t/04-openresty/ffi/103-proxy_wasm_attach.t
@@ -515,8 +515,8 @@ qr/\A[^#]*#0 on_vm_start[^#*]*
 #0 on_configure[^#*]*
 \*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#*]*
 \*\d+ .*? "hostcalls" filter new instance[^#*]*
-\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 #0 on_configure[^#*]*
+\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
@@ -527,8 +527,8 @@ qr/\A[^#]*#0 on_vm_start[^#*]*
 \*\d+ wasm freeing "hostcalls" instance[^#*]*\Z/,
 qr/\A\*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#*]*
 \*\d+ .*? "hostcalls" filter new instance[^#*]*
-\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 #0 on_configure[^#*]*
+\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*

--- a/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
@@ -68,6 +68,12 @@ impl RootContext for HttpHeadersRoot {
 
     fn on_tick(&mut self) {
         info!("on_tick {}", self.config.get("tick_period").unwrap());
+
+        #[allow(clippy::single_match)]
+        match self.config.get("on_tick").map(|s| s.as_str()).unwrap_or("") {
+            "trap" => panic!("on_tick trap"),
+            _ => (),
+        }
     }
 
     fn get_type(&self) -> Option<ContextType> {


### PR DESCRIPTION
* Allow for recycling the root instance (not managed by isolation modes)
* Allow for smoother recycling of http instances (including when the root instance has trapped)
* Also recycle trapped instances in the busy queue
* Less verbose context creation of fresh and/or recycled instances starting in atypical steps (e.g. on_response_headers).