### PR TITLE
chore(ci) bump and sync CC version among Dockerfiles and CI workflows

### DIFF
--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -22,7 +22,7 @@ jobs:
         label: [""]
         os: [ubuntu-latest]
         #os: [ubuntu-latest, macos-latest]
-        cc: [gcc-9]
+        cc: [gcc-12]
         ngx: [1.25.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [12.0.1]
@@ -35,7 +35,7 @@ jobs:
           # OpenResty + static ngx_wasm_module
           - label: dynamic_module
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             openresty: 1.21.4.2
             runtime: wasmtime
             wasmtime: 12.0.1
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        cc: [gcc-10]
+        cc: [gcc-12]
         ngx: [1.25.2]
         runtime: [wasmer, wasmtime, v8]
         wasmtime: [12.0.1]
@@ -77,7 +77,7 @@ jobs:
           # OpenResty
           - label: openresty
             os: ubuntu-22.04
-            cc: gcc-10
+            cc: gcc-12
             openresty: 1.21.4.2
             runtime: wasmer
             wasmer: 3.1.1
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cc: [clang-11]
+        cc: [clang-15]
         openresty: [1.21.4.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [12.0.1]
@@ -122,3 +122,34 @@ jobs:
       v8: ${{ matrix.v8 }}
       ssl: ${{ matrix.ssl }}
       debug: ${{ matrix.debug }}
+
+  build-large:
+    name: 'Build'
+    #if: ${{ false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        label: [""]
+        os: [ubuntu-latest]
+        cc: [clang-13, clang-14, gcc-10, gcc-11]
+        ngx: [1.25.2]
+        runtime: [wasmtime, wasmer, v8]
+        wasmtime: [12.0.1]
+        wasmer: [3.1.1]
+        v8: [11.4.183.23]
+        include:
+          - label: old_nginx
+            os: [ubuntu-latest]
+            cc: clang-15
+            ngx: 1.21.6
+            runtime: wasmtime
+            wasmtime: 12.0.1
+    uses: ./.github/workflows/job-build-tests.yml
+    with:
+      os: ${{ matrix.os }}
+      cc: ${{ matrix.cc }}
+      ngx: ${{ matrix.ngx }}
+      runtime: ${{ matrix.runtime }}
+      wasmtime: ${{ matrix.wasmtime }}
+      wasmer: ${{ matrix.wasmer }}
+      v8: ${{ matrix.v8 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         label: [""]
         os: [ubuntu-latest]
-        cc: [gcc-9]
+        cc: [gcc-12]
         ngx: [1.25.2]
         openresty: [""]
         runtime: [wasmer]
@@ -44,7 +44,7 @@ jobs:
           - runtime: wasmtime
             wasmtime: 12.0.1
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             ngx: 1.25.2
             ssl: ssl
             debug: debug
@@ -53,7 +53,7 @@ jobs:
           - runtime: v8
             v8: 11.4.183.23
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             ngx: 1.25.2
             ssl: ssl
             debug: debug
@@ -61,7 +61,7 @@ jobs:
           # Old Nginx
           - label: old_nginx
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             ngx: 1.21.6
             runtime: wasmer
             wasmer: 3.1.1
@@ -71,7 +71,7 @@ jobs:
           # Nginx + dynamic ngx_wasm_module + HUP
           - label: dynamic_nginx
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             ngx: 1.25.2
             runtime: wasmtime
             wasmtime: 12.0.1
@@ -81,7 +81,7 @@ jobs:
             module_type: dynamic
           # No SSL
           - os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             ngx: 1.25.2
             runtime: wasmer
             wasmer: 3.1.1
@@ -91,7 +91,7 @@ jobs:
           # OpenResty
           - label: openresty
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             openresty: 1.21.4.2
             runtime: wasmtime
             wasmtime: 12.0.1
@@ -101,7 +101,7 @@ jobs:
           # OpenResty + dynamic ngx_wasm_module
           - label: dynamic_openresty
             os: ubuntu-latest
-            cc: gcc-9
+            cc: gcc-12
             openresty: 1.21.4.2
             runtime: wasmtime
             wasmtime: 12.0.1
@@ -147,7 +147,7 @@ jobs:
       matrix:
         label: [""]
         os: [ubuntu-22.04]
-        cc: [gcc-10]
+        cc: [gcc-12]
         ngx: [1.25.2]
         openresty: [""]
         runtime: [wasmer]
@@ -161,7 +161,7 @@ jobs:
           - runtime: wasmtime
             wasmtime: 12.0.1
             os: ubuntu-22.04
-            cc: gcc-10
+            cc: gcc-12
             ngx: 1.25.2
             hup: no_hup
             debug: debug
@@ -169,14 +169,14 @@ jobs:
           - runtime: v8
             v8: 11.4.183.23
             os: ubuntu-22.04
-            cc: gcc-10
+            cc: gcc-12
             ngx: 1.25.2
             debug: debug
             hup: no_hup
           # OpenResty
           - label: openresty
             os: ubuntu-22.04
-            cc: gcc-10
+            cc: gcc-12
             openresty: 1.21.4.2
             ngx:
             runtime: wasmer
@@ -240,7 +240,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cc: [clang-11]
+        cc: [clang-15]
         openresty: [1.21.4.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [12.0.1]
@@ -251,7 +251,7 @@ jobs:
         include:
           # No SSL
           - os: ubuntu-latest
-            cc: clang-11
+            cc: clang-15
             ngx: 1.25.2
             runtime: wasmer
             wasmer: 3.1.1
@@ -272,39 +272,22 @@ jobs:
   build:
     name: 'Build'
     #if: ${{ false }}
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        label: [""]
         os: [ubuntu-latest]
-        cc: [clang-14, gcc-10]
+        cc: [clang-15, gcc-12]
         ngx: [1.25.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [12.0.1]
         wasmer: [3.1.1]
         v8: [11.4.183.23]
-        include:
-          - label: old_nginx
-            os: ubuntu-latest
-            cc: clang-14
-            ngx: 1.21.6
-            runtime: wasmtime
-            wasmtime: 12.0.1
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Setup cache - work/ dir'
-        uses: actions/cache@v3
-        if: ${{ !env.ACT }}
-        with:
-          path: |
-            work/downloads
-            work/runtimes
-            work/openssl
-          key: work-${{ runner.os }}-${{ matrix.cc }}-${{ matrix.ngx }}-${{ matrix.openresty }}-${{ matrix.runtime }}-${{ hashFiles('util/**/*.sh', 'util/**/*.pl', 'util/**/*.awk', '.github/**/*.yml', '.github/**/*.sh', '.github/**/*.js', 'rust-toolchain', 'Makefile') }}
-      - name: Setup Wasm runtime
-        run: ./util/runtime.sh -R ${{ matrix.runtime }} -V ${{ matrix[matrix.runtime] }}
-      - run: make setup
-      - run: make test-build
-        env:
-          NGX_WASM_RUNTIME: ${{ matrix.runtime }}
+    uses: ./.github/workflows/job-build-tests.yml
+    with:
+      os: ${{ matrix.os }}
+      cc: ${{ matrix.cc }}
+      ngx: ${{ matrix.ngx }}
+      runtime: ${{ matrix.runtime }}
+      wasmtime: ${{ matrix.wasmtime }}
+      wasmer: ${{ matrix.wasmer }}
+      v8: ${{ matrix.v8 }}

--- a/.github/workflows/job-build-tests.yml
+++ b/.github/workflows/job-build-tests.yml
@@ -1,0 +1,67 @@
+name: Build tests
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      cc:
+        required: true
+        type: string
+      ngx:
+        required: true
+        type: string
+      runtime:
+        required: true
+        type: string
+      wasmtime:
+        required: true
+        type: string
+      wasmer:
+        required: true
+        type: string
+      v8:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CC: ${{ inputs.cc }}
+  NGX_WASM_RUNTIME: ${{ inputs.runtime }}
+
+jobs:
+  build:
+    name: 'Build'
+    #if: ${{ false }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: 'Setup Ubuntu deps - gcc'
+        if: ${{ !env.ACT && contains(inputs.os, 'ubuntu') && contains(inputs.cc, 'gcc') }}
+        run: sudo apt-get update && sudo apt-get install -y ${CC} libstdc++-${CC#*-}-dev
+
+      - name: 'Setup Ubuntu deps - clang'
+        if: ${{ !env.ACT && contains(inputs.os, 'ubuntu') && contains(inputs.cc, 'clang') }}
+        run: sudo apt-get update && sudo apt-get install -y ${CC}
+
+      - name: 'Setup macOS deps'
+        if: ${{ !env.ACT && contains(inputs.os, 'macos') }}
+        run: brew install ninja openssh
+
+      - uses: actions/checkout@v3
+      - name: 'Setup cache - work/ dir'
+        uses: actions/cache@v3
+        if: ${{ !env.ACT }}
+        with:
+          path: |
+            work/downloads
+            work/runtimes
+            work/openssl
+          key: work-${{ runner.os }}-${{ inputs.cc }}-${{ inputs.ngx }}-${{ inputs.runtime }}-${{ hashFiles('util/**/*.sh', 'util/**/*.pl', 'util/**/*.awk', '.github/**/*.yml', '.github/**/*.sh', '.github/**/*.js', 'rust-toolchain', 'Makefile') }}
+      - name: Setup Wasm runtime
+        run: ./util/runtime.sh -R ${{ inputs.runtime }} -V ${{ inputs[inputs.runtime] }}
+      - run: make setup
+      - run: make test-build

--- a/.github/workflows/job-unit-tests.yml
+++ b/.github/workflows/job-unit-tests.yml
@@ -70,8 +70,8 @@ jobs:
       coveralls_name: ${{ steps.lcov.outputs.name }}
     steps:
       - name: 'Setup deps - apt-get'
-        if: ${{ inputs.cc == 'gcc-9' }}
-        run: sudo apt-get update && sudo apt-get install -y gcc-9 libstdc++-9-dev lcov
+        if: ${{ contains(inputs.os, 'ubuntu') }}
+        run: sudo apt-get update && sudo apt-get install -y ${CC} libstdc++-${CC#*-}-dev lcov
       - uses: actions/checkout@v3
       - name: 'Setup cache - rustup toolchain'
         if: ${{ !env.ACT }}
@@ -116,11 +116,11 @@ jobs:
       - run: make test
       - name: Run lcov
         id: lcov
-        if: ${{ !env.ACT && inputs.cc == 'gcc-9' && inputs.coverage }}
+        if: ${{ !env.ACT && inputs.coverage }}
         run: |
-          lcov --capture --directory work/buildroot --output-file lcov.info
-          lcov --remove lcov.info "*/ngx_wasm_module/src/common/debug/*" --output-file lcov.info
-          lcov --extract lcov.info "*/ngx_wasm_module/src/*" --output-file lcov.info
+          lcov --gcov-tool gcov-${CC#*-} --capture --directory work/buildroot --output-file lcov.info
+          lcov --gcov-tool gcov-${CC#*-} --remove lcov.info "*/ngx_wasm_module/src/common/debug/*" --output-file lcov.info
+          lcov --gcov-tool gcov-${CC#*-} --extract lcov.info "*/ngx_wasm_module/src/*" --output-file lcov.info
 
           name="unit"
           if [ -n "${{ inputs.openresty }}" ]; then
@@ -139,7 +139,7 @@ jobs:
           fi
           echo "name=$name" >> $GITHUB_OUTPUT
       - name: Coveralls Upload
-        if: ${{ !env.ACT && inputs.cc == 'gcc-9' && inputs.coverage }}
+        if: ${{ !env.ACT && inputs.coverage }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
+++ b/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
@@ -45,6 +45,8 @@ RUN apt-get install -y \
         gcovr \
         unzip \
         sudo && \
+    rustup target add wasm32-wasi && \
+    rustup target add wasm32-unknown-unknown && \
     curl -sLO https://golang.google.cn/dl/go${GOLANG_VERSION}.linux-$(cat /TG_ARCH).tar.gz && \
     sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-$(cat /TG_ARCH).tar.gz && \
     curl -sLO https://github.com/tinygo-org/tinygo/releases/download/v$TINYGO_VERSION/tinygo_${TINYGO_VERSION}_$(cat /TG_ARCH).deb && \

--- a/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
+++ b/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 COPY . /ngx_wasm_module
 
+ARG GCC_VERSION=12
+ARG CLANG_VERSION=15
 ARG GOLANG_VERSION=1.19.5
 ARG TINYGO_VERSION=0.27.0
 ARG DEBIAN_FRONTEND=noninteractive
@@ -11,12 +13,12 @@ RUN apt-get update && \
         ninja-build \
         python3 \
         cmake \
-        gcc-11 \
-        libstdc++-11-dev \
+        gcc-${GCC_VERSION} \
+        libstdc++-${GCC_VERSION}-dev \
         git \
         pkg-config \
         libglib2.0-dev \
-        clang \
+        clang-${CLANG_VERSION} \
         curl \
         binfmt-support \
         qemu-user-static
@@ -36,15 +38,17 @@ RUN /bin/bash -c 'echo $(uname -m) > /TG_ARCH || : ; \
 #
 # unzip: LuaRocks
 RUN apt-get install -y \
-        clang-tools \
+        clang-tools-${CLANG_VERSION} \
         libpcre3-dev \
         libssl-dev \
         zlib1g-dev \
         valgrind \
         nodejs \
         gcovr \
+        lcov \
         unzip \
         sudo && \
+    update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-${CLANG_VERSION} 100 && \
     rustup target add wasm32-wasi && \
     rustup target add wasm32-unknown-unknown && \
     curl -sLO https://golang.google.cn/dl/go${GOLANG_VERSION}.linux-$(cat /TG_ARCH).tar.gz && \

--- a/src/wasm/ngx_wasm_ops.c
+++ b/src/wasm/ngx_wasm_ops.c
@@ -126,7 +126,7 @@ ngx_wasm_ops_plan_load(ngx_wasm_ops_plan_t *plan, ngx_log_t *log)
     ngx_uint_t               *fid;
     ngx_array_t              *ids;
     ngx_wasm_op_t            *op;
-    ngx_wasm_ops_pipeline_t  *pipeline;
+    ngx_wasm_ops_pipeline_t  *pipeline = NULL;
 
     dd("enter");
 

--- a/src/wasm/wrt/ngx_wrt_v8.c
+++ b/src/wasm/wrt/ngx_wrt_v8.c
@@ -452,7 +452,9 @@ ngx_v8_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
     ngx_wrt_module_t *module, ngx_pool_t *pool, ngx_wrt_err_t *err)
 {
     size_t               i;
+#if (NGX_DEBUG)
     ngx_uint_t           nimports = 0;
+#endif
     ngx_wavm_hfunc_t    *import;
     ngx_v8_hfunc_ctx_t  *hctx = NULL;
     wasm_func_t         *func;
@@ -485,7 +487,9 @@ ngx_v8_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
                                       hctx, NULL);
 
         instance->imports[i] = wasm_func_as_extern(func);
+#if (NGX_DEBUG)
         nimports++;
+#endif
     }
 
     ngx_wasm_assert(nimports == module->nimports);

--- a/src/wasm/wrt/ngx_wrt_wasmer.c
+++ b/src/wasm/wrt/ngx_wrt_wasmer.c
@@ -515,7 +515,9 @@ ngx_wasmer_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
     ngx_wrt_module_t *module, ngx_pool_t *pool, ngx_wrt_err_t *err)
 {
     size_t                   i, j;
+#if (NGX_DEBUG)
     ngx_uint_t               nimports = 0;
+#endif
     ngx_wrt_import_t        *import;
     ngx_wasmer_hfunc_ctx_t  *hctx, *hctxs = NULL;
     wasm_func_t             *func;
@@ -558,7 +560,9 @@ ngx_wasmer_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
                     instance->env.data[i] = (wasm_extern_t *)
                         wasmer_named_extern_unwrap(
                             instance->wasi_imports.data[j]);
+#if (NGX_DEBUG)
                     nimports++;
+#endif
                     break;
                 }
             }
@@ -576,7 +580,9 @@ ngx_wasmer_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
                                           hctx, NULL);
 
             instance->env.data[i] = wasm_func_as_extern(func);
+#if (NGX_DEBUG)
             nimports++;
+#endif
             break;
 
         default:

--- a/util/_lib.sh
+++ b/util/_lib.sh
@@ -193,7 +193,7 @@ build_nginx() {
                        -analyze-headers \
                        --force-analyze-debug-code \
                        --html-title='$NGX - ngx_wasm_module [${build_name[@]}]' \
-                       --use-cc=clang \
+                       --use-cc=${CC:-clang} \
                        --status-bugs"
         NGX_BUILD_DEBUG=1
     fi


### PR DESCRIPTION
Dockerfiles and CI workflow use the latest version available in the runner OS.

Older versions of gcc and clang are tested in CI Large.