### PR TITLE
chore(ci) restore Codecov support alongside Coveralls

### DIFF
--- a/.github/workflows/job-clang-analyzer.yml
+++ b/.github/workflows/job-clang-analyzer.yml
@@ -46,7 +46,7 @@ jobs:
   analyzer:
     name: 'Clang analyzer'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - run: |
           sudo apt-get update

--- a/.github/workflows/job-unit-tests.yml
+++ b/.github/workflows/job-unit-tests.yml
@@ -146,6 +146,12 @@ jobs:
           flag-name: ${{ steps.lcov.outputs.name }}
           path-to-lcov: './lcov.info'
           parallel: true
+      - name: Codecov Upload
+        if: ${{ !env.ACT && inputs.coverage }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: './lcov.info'
       - uses: actions/upload-artifact@v2
         if: ${{ failure() && !env.ACT }}
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# https://docs.codecov.io/docs/codecovyml-reference
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+    after_n_builds: 9
+
+coverage:
+  precision: 4
+  round: down
+  range: "75...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%
+        base: auto
+        flags:
+          - unit
+        paths:
+          - src
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes

--- a/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
+++ b/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
@@ -105,6 +105,7 @@ Using a non-local resolver
 lua-resty-dns-resolver client timeout
 Behaves strangely on GHA Valgrind. Seems fine locally.
 Will run with TEST_NGINX_USE_VALGRIND_ALL.
+--- skip_valgrind: 5
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{


### PR DESCRIPTION
Codecov has a couple features that Coveralls lacks: better PR comments and PR diff comments of uncovered lines. It's also easier to maintain compared to the `carryforward` flags of Coveralls.