### PR TITLE
chore(ci) fix ubuntu 22.04 release docker image

### DIFF
--- a/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
+++ b/assets/release/Dockerfiles/Dockerfile.ubuntu-22.04
@@ -21,7 +21,8 @@ RUN apt-get update && \
         clang-${CLANG_VERSION} \
         curl \
         binfmt-support \
-        qemu-user-static
+        qemu-user-static && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100
 
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
 ENV PATH $CARGO_HOME/bin:$PATH


### PR DESCRIPTION
In the commit 1a0759b22545461431b8de288545e624735cb02f, the Dockerfile used to build the ubuntu 22.04 release image was changed to install `clang-15` instead of `clang` -- applying the intended bump.

It lacked, however, an `update-alternative` call making `clang` available as a link to `clang-15`.