### PR TITLE
fix(proxy-wasm) fix memory growth on low-isolation modes

### DIFF
--- a/src/common/lua/ngx_wasm_lua_ffi.c
+++ b/src/common/lua/ngx_wasm_lua_ffi.c
@@ -191,7 +191,10 @@ ngx_http_wasm_ffi_set_property(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    pwctx = ngx_http_proxy_wasm.get_context(rctx);
+    pwctx = ngx_proxy_wasm_ctx(NULL, 0,
+                               NGX_PROXY_WASM_ISOLATION_STREAM,
+                               &ngx_http_proxy_wasm,
+                               rctx);
     if (pwctx == NULL) {
         return NGX_ERROR;
     }
@@ -215,7 +218,10 @@ ngx_http_wasm_ffi_get_property(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    pwctx = ngx_http_proxy_wasm.get_context(rctx);
+    pwctx = ngx_proxy_wasm_ctx(NULL, 0,
+                               NGX_PROXY_WASM_ISOLATION_STREAM,
+                               &ngx_http_proxy_wasm,
+                               rctx);
     if (pwctx == NULL) {
         return NGX_ERROR;
     }

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -217,6 +217,7 @@ struct ngx_proxy_wasm_ctx_s {
     ngx_proxy_wasm_context_type_e      type;
     ngx_log_t                         *log;
     ngx_pool_t                        *pool;
+    ngx_pool_t                        *parent_pool;
     void                              *data;
 
     /* control */


### PR DESCRIPTION
We were observing linear memory growth when running requests in low-isolation modes.

The root cause comes from the fact that small allocations had instance-long lifetimes (including, for example, the arrays for `args` and `rets` for each Wasm call, causing the observable linear growth when running `wrk`).

Turns out that `ngx_pfree`, which was being used in the code to free `args` and `rets`, [does _not_ free small allocations](https://github.com/nginx/nginx/blob/027b68168867514665751a65780f050952bc48ec/src/core/ngx_palloc.c#L277-L294). It only frees large allocations; small allocations are only freed when the pool itself is destroyed.

I observed an initial improvement by moving args and rets allocations to the stack. I added this as a `perf()` commit here since I think this is still a worthwhile change, given these are usually very small arrays.

The general solution, though, is to use a request-lived pool for `pwctx`, so we don't hoard small request-specific allocations over the lifetime of an instance.

A third commit changes the setup of the `pwexec` pool so that it uses the `pwctx` pool under all isolation modes, like it does for logs. Wasm isolation mode should pertain only to the Wasm-accessible store, not to the temporary C-side data structures, which we now free on each request.

Given our new understanding of `ngx_pfree`, I think there are probably more opportunities in the codebase for replacing known-small data which is deterministically freed either with a lighter-weight `ngx_alloc`/`ngx_free` pair, or even with stack allocations, but I wanted to keep this PR straight-to-the-point and not go hunting for more changes.

Before and after memory graphs:

![image](https://github.com/Kong/ngx_wasm_module/assets/245621/557c79f2-4520-467e-8fb7-4cf898fcf36a)
![image](https://github.com/Kong/ngx_wasm_module/assets/245621/2f8421c8-4f00-49f2-b710-9e4e558715ce)
