### PR TITLE
refactor(proxy-wasm) better instance/ctx lifecycle management

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -329,6 +329,8 @@ ngx_proxy_wasm_ctx(ngx_uint_t *filter_ids, size_t nfilters,
             pwexec->pool = pool;
             pwexec->filter = filter;
             pwexec->parent = pwctx;
+            pwexec->root_id = filter->id;
+
             pwexec->log = ngx_pcalloc(pwexec->pool, sizeof(ngx_log_t));
             if (pwexec->log == NULL) {
                 return NULL;
@@ -346,14 +348,12 @@ ngx_proxy_wasm_ctx(ngx_uint_t *filter_ids, size_t nfilters,
             pwexec->log_ctx.pwexec = pwexec;
             pwexec->log_ctx.orig_log = log;
 
-            ictx = ngx_proxy_wasm_get_instance(filter, pwstore, log);
+            ictx = ngx_proxy_wasm_get_instance(filter, pwstore, pwexec, log);
             if (ictx == NULL) {
                 return NULL;
             }
 
             pwexec->ictx = ictx;
-            pwexec->id = ictx->next_id++;
-            pwexec->root_id = filter->id;
 
             ngx_wasm_assert(pwexec->index + 1 == pwctx->pwexecs.nelts);
 
@@ -467,7 +467,7 @@ ngx_proxy_wasm_action2rc(ngx_proxy_wasm_ctx_t *pwctx,
     filter = pwexec->filter;
     action = pwctx->action;
 
-    dd("action: %d", action);
+    dd("enter (pwexec: %p, action: %d)", pwexec, action);
 
     if (pwexec->ecode) {
         if (!pwexec->ecode_logged
@@ -602,7 +602,6 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     ngx_proxy_wasm_instance_t *ictx, ngx_proxy_wasm_step_e step)
 {
     ngx_int_t                 rc;
-    ngx_proxy_wasm_err_e      ecode;
     ngx_proxy_wasm_action_e   action = NGX_PROXY_WASM_ACTION_CONTINUE;
     ngx_proxy_wasm_ctx_t     *pwctx = pwexec->parent;
     ngx_proxy_wasm_filter_t  *filter = pwexec->filter;
@@ -649,12 +648,6 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
 #ifdef NGX_WASM_RESPONSE_TRAILERS
     case NGX_PROXY_WASM_STEP_RESP_TRAILERS:
 #endif
-        ecode = ngx_proxy_wasm_on_start(ictx, filter, 0);
-        if (ecode != NGX_PROXY_WASM_ERR_NONE) {
-            pwexec->ecode = ecode;
-            goto done;
-        }
-
         rc = filter->subsystem->resume(pwexec, step, &action);
         break;
     case NGX_PROXY_WASM_STEP_LOG:
@@ -1175,7 +1168,6 @@ ngx_proxy_wasm_init_abi(ngx_proxy_wasm_filter_t *filter)
 static ngx_int_t
 ngx_proxy_wasm_start_filter(ngx_proxy_wasm_filter_t *filter)
 {
-    ngx_proxy_wasm_err_e        ecode;
     ngx_proxy_wasm_instance_t  *ictx;
 
     ngx_wasm_assert(filter->loaded);
@@ -1188,21 +1180,9 @@ ngx_proxy_wasm_start_filter(ngx_proxy_wasm_filter_t *filter)
         return NGX_OK;
     }
 
-    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, filter->log);
+    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, NULL,
+                                       filter->log);
     if (ictx == NULL) {
-        return NGX_ERROR;
-    }
-
-    /*
-     * update instance log
-     * FFI-injected filters have a valid log while the instance's
-     * might be outdated.
-     */
-    ngx_wavm_instance_set_data(ictx->instance, ictx, filter->log);
-
-    ecode = ngx_proxy_wasm_on_start(ictx, filter, 1);
-    if (ecode != NGX_PROXY_WASM_ERR_NONE) {
-        filter->ecode = ecode;
         return NGX_ERROR;
     }
 
@@ -1214,12 +1194,16 @@ ngx_proxy_wasm_start_filter(ngx_proxy_wasm_filter_t *filter)
 
 ngx_proxy_wasm_instance_t *
 ngx_proxy_wasm_get_instance(ngx_proxy_wasm_filter_t *filter,
-    ngx_proxy_wasm_store_t *store, ngx_log_t *log)
+    ngx_proxy_wasm_store_t *store, ngx_proxy_wasm_exec_t *pwexec,
+    ngx_log_t *log)
 {
     ngx_queue_t                *q;
     ngx_pool_t                 *pool;
     ngx_wavm_module_t          *module = filter->module;
-    ngx_proxy_wasm_instance_t  *ictx = NULL;
+    ngx_proxy_wasm_instance_t  *ictx;
+    ngx_proxy_wasm_err_e        ecode;
+
+    dd("enter (pwexec: %p)", pwexec);
 
     if (store == NULL) {
         dd("no store, jump to create");
@@ -1248,7 +1232,7 @@ ngx_proxy_wasm_get_instance(ngx_proxy_wasm_filter_t *filter,
         }
 
         if (ictx->module == filter->module) {
-            dd("reuse instance");
+            dd("reuse busy instance");
             ngx_wasm_assert(ictx->nrefs);
             goto reuse;
         }
@@ -1260,16 +1244,28 @@ ngx_proxy_wasm_get_instance(ngx_proxy_wasm_filter_t *filter,
     {
         ictx = ngx_queue_data(q, ngx_proxy_wasm_instance_t, q);
 
+        if (ictx->instance->trapped) {
+            ngx_proxy_wasm_log_error(NGX_LOG_DEBUG, log, 0,
+                                     "\"%V\" filter freeing trapped instance "
+                                     "(ictx: %p, store: %p)",
+                                     filter->name, ictx, store);
+
+            q = ngx_queue_next(&ictx->q);
+            ngx_proxy_wasm_release_instance(ictx, 1);
+            continue;
+        }
+
         if (ictx->module == filter->module) {
+            dd("reuse free instance");
             ngx_wasm_assert(ictx->nrefs == 0);
             ngx_queue_remove(&ictx->q);
             goto reuse;
         }
     }
 
-    dd("create instance in store: %p", store);
-
 create:
+
+    dd("create instance in store: %p", store);
 
     ictx = ngx_pcalloc(pool, sizeof(ngx_proxy_wasm_instance_t));
     if (ictx == NULL) {
@@ -1300,10 +1296,6 @@ create:
 
     goto done;
 
-error:
-
-    return NULL;
-
 reuse:
 
     ngx_proxy_wasm_log_error(NGX_LOG_DEBUG, log, 0,
@@ -1311,15 +1303,56 @@ reuse:
                              "(ictx: %p, nrefs: %d, store: %p)",
                              filter->name, ictx, ictx->nrefs + 1, store);
 
+    goto done;
+
 done:
 
     if (store && !ictx->nrefs) {
         ngx_queue_insert_tail(&store->busy, &ictx->q);
     }
 
+    if (pwexec) {
+        if (pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID) {
+            ngx_wasm_assert(pwexec->id == 0);
+            pwexec->id = ictx->next_id++;
+        }
+
+        if (pwexec->ecode) {
+            /* recycled instance */
+            pwexec->ecode = NGX_PROXY_WASM_ERR_NONE;
+            pwexec->ecode_logged = 0;
+        }
+    }
+
     ictx->nrefs++;
+    ictx->pwexec = pwexec;
+
+    /**
+     * update instance log
+     * FFI-injected filters have a valid log while the instance's
+     * might be outdated.
+     */
+    ngx_wavm_instance_set_data(ictx->instance, ictx, log);
+
+    /* create wasm context (root/http) */
+
+    ecode = ngx_proxy_wasm_on_start(ictx, filter, pwexec == NULL);
+    if (ecode != NGX_PROXY_WASM_ERR_NONE) {
+        if (pwexec) {
+            pwexec->ecode = ecode;
+
+        } else {
+            filter->ecode = ecode;
+        }
+
+        goto error;
+    }
 
     return ictx;
+
+error:
+
+    return NULL;
 }
 
 
@@ -1418,6 +1451,8 @@ ngx_proxy_wasm_on_start(ngx_proxy_wasm_instance_t *ictx,
     ngx_proxy_wasm_exec_t  *rexec, *pwexec = ictx->pwexec;
     ngx_wavm_instance_t    *instance = ictx->instance;
     wasm_val_vec_t         *rets;
+
+    dd("enter (pwexec: %p, ictx: %p)", pwexec, ictx);
 
     rexec = ngx_proxy_wasm_root_lookup(ictx, filter->id);
     if (rexec == NULL) {

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -400,7 +400,7 @@ ngx_wavm_ptr_t ngx_proxy_wasm_alloc(ngx_proxy_wasm_exec_t *pwexec, size_t size);
 void ngx_proxy_wasm_store_destroy(ngx_proxy_wasm_store_t *store);
 ngx_proxy_wasm_instance_t *ngx_proxy_wasm_get_instance(
     ngx_proxy_wasm_filter_t *filter, ngx_proxy_wasm_store_t *store,
-    ngx_log_t *log);
+    ngx_proxy_wasm_exec_t *pwexec, ngx_log_t *log);
 void ngx_proxy_wasm_release_instance(ngx_proxy_wasm_instance_t *ictx,
     unsigned sweep);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -721,7 +721,6 @@ ngx_proxy_wasm_properties_get_ngx(ngx_proxy_wasm_ctx_t *pwctx,
     hash = hash_str(name.data, name.len);
 
     rctx = (ngx_http_wasm_req_ctx_t *) pwctx->data;
-
     if (rctx == NULL || rctx->fake_request) {
         ngx_wavm_log_error(NGX_LOG_ERR, pwctx->log, NULL,
                            "cannot get ngx properties outside of a request");
@@ -861,8 +860,8 @@ static ngx_int_t
 ngx_proxy_wasm_properties_get_host(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value)
 {
-    host_props_node_t        *hpn;
     uint32_t                  hash;
+    host_props_node_t        *hpn;
 #ifdef NGX_WASM_HTTP
     ngx_http_wasm_req_ctx_t  *rctx = pwctx->data;
 
@@ -893,9 +892,9 @@ static ngx_int_t
 ngx_proxy_wasm_properties_set_host(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value)
 {
-    host_props_node_t        *hpn;
     uint32_t                  hash;
     unsigned                  new_entry = 1;
+    host_props_node_t        *hpn;
 #ifdef NGX_WASM_HTTP
     ngx_http_wasm_req_ctx_t  *rctx = pwctx->data;
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -200,6 +200,7 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
 #endif
     ngx_proxy_wasm_filter_t    *filter = pwexec->filter;
     ngx_proxy_wasm_instance_t  *ictx;
+    ngx_proxy_wasm_err_e        ecode;
 
     dd("enter");
 
@@ -227,16 +228,16 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
 #endif
     pwexec->in_tick = 1;
 
-    pwexec->ecode = ngx_proxy_wasm_run_step(pwexec, ictx,
-                                            NGX_PROXY_WASM_STEP_TICK);
-
-    pwexec->in_tick = 0;
+    ecode = ngx_proxy_wasm_run_step(pwexec, ictx, NGX_PROXY_WASM_STEP_TICK);
 
     ngx_proxy_wasm_release_instance(ictx, 0);
 
-    if (pwexec->ecode != NGX_PROXY_WASM_ERR_NONE) {
+    if (ecode != NGX_PROXY_WASM_ERR_NONE) {
+        pwexec->ecode = ecode;
         return;
     }
+
+    pwexec->in_tick = 0;
 
     if (!ngx_exiting) {
         pwexec->ev = ngx_calloc(sizeof(ngx_event_t), log);

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -213,7 +213,8 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
         return;
     }
 
-    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, filter->log);
+    ictx = ngx_proxy_wasm_get_instance(filter, filter->store, pwexec,
+                                       filter->log);
     if (ictx == NULL) {
         ngx_wasm_log_error(NGX_LOG_ERR, log, 0,
                            "tick_handler: no instance");
@@ -246,6 +247,8 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
         pwexec->ev->handler = ngx_proxy_wasm_filter_tick_handler;
         pwexec->ev->data = pwexec;
         pwexec->ev->log = log;
+
+        dd("scheduling next tick in %ld", pwexec->tick_period);
 
         ngx_add_timer(pwexec->ev, pwexec->tick_period);
     }

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -265,6 +265,7 @@ ngx_http_wasm_create_main_conf(ngx_conf_t *cf)
     mcf->vm = ngx_wasm_main_vm(cf->cycle);
 
     ngx_queue_init(&mcf->plans);
+    ngx_proxy_wasm_init(cf, &mcf->store);
 
     return mcf;
 }
@@ -280,9 +281,6 @@ ngx_http_wasm_init_main_conf(ngx_conf_t *cf, void *conf)
     if (mcf->ops == NULL) {
         return NGX_CONF_ERROR;
     }
-
-    ngx_proxy_wasm_init(cf);
-    ngx_proxy_wasm_store_init(&mcf->store, cf->pool);
 
     return NGX_CONF_OK;
 }
@@ -445,8 +443,7 @@ ngx_http_wasm_exit_process(ngx_cycle_t *cycle)
 
     mcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_wasm_module);
     if (mcf) {
-        ngx_proxy_wasm_exit();
-        ngx_proxy_wasm_store_destroy(&mcf->store);
+        ngx_proxy_wasm_exit(&mcf->store);
 
         ngx_wasm_ops_destroy(mcf->ops);
     }

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -411,8 +411,8 @@ ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
         goto error;
     }
 
-    filter->pool = plan->pool;
     filter->log = vm->log;
+    filter->pool = store->pool;
     filter->store = store;
 
     if (config) {

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.h
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.h
@@ -19,7 +19,7 @@ ngx_http_proxy_wasm_get_rctx(ngx_wavm_instance_t *instance)
 
     pwexec = ngx_proxy_wasm_instance2pwexec(instance);
     pwctx = pwexec->parent;
-    if (!pwctx) {
+    if (pwctx == NULL) {
         return NULL;
     }
 

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -825,7 +825,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
         /* save step */
         step = pwexec->parent->step;
 
-        ecode = ngx_proxy_wasm_run_step(pwexec, pwexec->ictx,
+        ecode = ngx_proxy_wasm_run_step(pwexec,
                                         NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE);
         if (ecode != NGX_PROXY_WASM_ERR_NONE) {
             goto error;

--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -1345,12 +1345,12 @@ ngx_wavm_instance_destroy(ngx_wavm_instance_t *instance)
     ngx_wavm_func_t    *func;
     ngx_wavm_module_t  *module = instance->module;
 
-    ngx_log_debug5(NGX_LOG_DEBUG_WASM,
+    ngx_log_debug6(NGX_LOG_DEBUG_WASM,
                    instance->log ? instance->log : ngx_cycle->log, 0,
                    "wasm freeing \"%V\" instance in \"%V\" vm"
-                   " (vm: %p, module: %p, instance: %p)",
+                   " (vm: %p, module: %p, instance: %p, trapped: %d)",
                    &module->name, module->vm->name,
-                   module->vm, module, instance);
+                   module->vm, module, instance, instance->trapped);
 
     if (instance->funcs.nelts) {
         for (i = 0; i < instance->funcs.nelts; i++) {

--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -1461,7 +1461,7 @@ ngx_wavm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_wrt_err_t *e,
         wasm_byte_vec_delete(&trapmsg);
 
 #if (NGX_WASM_HAVE_V8 || NGX_WASM_HAVE_WASMER)
-        if (ctx->instance) {
+        if (ctx && ctx->instance) {
             wasm_trap_trace(e->trap, &trace);
 
             if (trace.size > 0) {

--- a/t/03-proxy_wasm/003-on_tick.t
+++ b/t/03-proxy_wasm/003-on_tick.t
@@ -152,3 +152,31 @@ qr/.*?(\[error\]|Uncaught RuntimeError: |\s+)tick_period already set.*
 [stub2]
 [stub3]
 --- must_die
+
+
+
+=== TEST 6: proxy_wasm - on_tick with trap
+Should recycle the tick instance
+Should not prevent http context/instance from starting
+--- skip_no_debug: 7
+--- wasm_modules: on_phases
+--- config
+    location /t {
+        proxy_wasm on_phases 'tick_period=200 on_tick=trap';
+        return 200;
+    }
+--- response_body
+--- grep_error_log eval: qr/\[(info|crit)].*?on_tick.*/
+--- grep_error_log_out eval
+qr/.*?
+\[info\] .*? on_tick 200.*
+\[crit\] .*? panicked at 'on_tick trap'.*
+.*?
+\[info\] .*? on_tick 200.*
+\[crit\] .*? panicked at 'on_tick trap'.*/
+--- error_log
+filter 1/1 resuming "on_request_headers" step
+filter 1/1 resuming "on_response_headers" step
+--- no_error_log
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/003-on_tick.t
+++ b/t/03-proxy_wasm/003-on_tick.t
@@ -166,14 +166,14 @@ Should not prevent http context/instance from starting
         return 200;
     }
 --- response_body
---- grep_error_log eval: qr/\[(info|crit)].*?on_tick.*/
+--- grep_error_log eval: qr/(\[crit\]|\[info].*?on_tick).*/
 --- grep_error_log_out eval
 qr/.*?
 \[info\] .*? on_tick 200.*
-\[crit\] .*? panicked at 'on_tick trap'.*
+\[crit\] .*? panicked at.*
 .*?
 \[info\] .*? on_tick 200.*
-\[crit\] .*? panicked at 'on_tick trap'.*/
+\[crit\] .*? panicked at.*/
 --- error_log
 filter 1/1 resuming "on_request_headers" step
 filter 1/1 resuming "on_response_headers" step

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -96,6 +96,7 @@ Should recycle the global instance when trapped.
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(2\/2\)\Z/,
 qr/\A\*\d+ .*? filter freeing trapped instance[^#*]*
+\*\d+ wasm freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -137,11 +137,11 @@ should use an instance per stream
 #0 on_vm_start[^#*]*
 #0 on_configure[^#*]*
 \*\d+ .*? filter new instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_body" step in "body_filter" phase[^#*]*
@@ -156,11 +156,11 @@ should use an instance per stream
 \*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
 \*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/,
 qr/\A\*\d+ .*? filter new instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
+#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
-#0 on_configure[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_body" step in "body_filter" phase[^#*]*

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -94,10 +94,8 @@ Should recycle the global instance when trapped.
 (.*?(Uncaught RuntimeError: )?unreachable|\s*wasm trap: wasm `unreachable` instruction executed)[^#*]*
 \*\d+ .*? filter chain failed resuming: previous error \(instance trapped\)[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(2\/2\)\Z/,
-qr/\A\*\d+ .*? filter freeing trapped instance[^#*]*
-\*\d+ wasm freeing "hostcalls" instance in "main" vm[^#*]*
-\*\d+ .*? filter new instance[^#*]*
+\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*\Z/,
+qr/\A\*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_response_headers" step in "header_filter" phase[^#*]*
@@ -110,6 +108,7 @@ qr/\A\*\d+ .*? filter freeing trapped instance[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 2\/2 finalizing context[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
+\*\d+ wasm freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(2\/2\)\Z/]
 --- no_error_log
 [emerg]
@@ -153,9 +152,9 @@ should use an instance per stream
 \*\d+ .*? filter 1\/2 finalizing context[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 2\/2 finalizing context[^#*]*
+\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
-\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/,
+\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*\Z/,
 qr/\A\*\d+ .*? filter new instance[^#*]*
 #0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
@@ -172,9 +171,9 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter 1\/2 finalizing context[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 2\/2 finalizing context[^#*]*
+\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
-\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/]
+\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*\Z/]
 --- no_error_log
 [error]
 [crit]
@@ -204,9 +203,9 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 (.*?(Uncaught RuntimeError: )?unreachable|\s*wasm trap: wasm `unreachable` instruction executed)[^#*]*
 \*\d+ .*? filter chain failed resuming: previous error \(instance trapped\)[^#*]*
+\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
-\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/,
+\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*\Z/,
 qr/\A\*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*
 \*\d+ .*? filter 1\/2 resuming "on_request_headers" step in "rewrite" phase[^#*]*
@@ -219,9 +218,9 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 \*\d+ .*? filter 1\/2 finalizing context[^#*]*
 \*\d+ .*? filter 2\/2 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 2\/2 finalizing context[^#*]*
+\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*
 \*\d+ .*? filter freeing context #\d+ \(1\/2\)[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*
-\*\d+ .*? freeing "hostcalls" instance in "main" vm[^#*]*\Z/]
+\*\d+ .*? filter freeing context #\d+ \(2\/2\)[^#*]*\Z/]
 --- no_error_log
 [emerg]
 [alert]

--- a/t/03-proxy_wasm/hfuncs/114-proxy_set_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/114-proxy_set_http_request_body.t
@@ -235,7 +235,7 @@ HelloWorld
     }
 
     location /log {
-        # cannot set request body
+        # not executed (subrequest)
         proxy_wasm hostcalls 'on=log \
                               test=/t/set_request_body';
         echo $request_body;
@@ -258,7 +258,6 @@ from_request_body
 --- grep_error_log_out eval
 qr/.*?host trap \(bad usage\): cannot set request body.*
 \[info\] .*? \*\d+ .*? filter chain failed resuming: previous error \(instance trapped\).*? subrequest: "\/response_headers".*
-\[info\] .*? \*\d+ .*? filter chain failed resuming: previous error \(instance trapped\).*? request: "GET \/t HTTP\/1\.1".*
 \z/
 --- no_error_log
 [alert]

--- a/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
@@ -131,13 +131,8 @@ qr/\[info\] .*? property not found: n,/
 
 
 === TEST 5: proxy_wasm - get_property() ngx.* - not available on: tick (isolation: global)
-
 on_tick runs on the root context, so it does not have access to
 ngx_http_* calls.
-
-HTTP 500 since instance recycling happens on next request, and isolation
-is global (single instance for root/request).
-
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -146,7 +141,6 @@ is global (single instance for root/request).
         echo_sleep 0.150;
         echo ok;
     }
---- error_code: 500
 --- ignore_response_body
 --- error_log eval
 [

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -80,8 +80,8 @@ qr/.*?testing in "RequestHeaders".*
 .*?testing in "Log".*
 .*?wasmx\.something: 5.*/
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -101,8 +101,8 @@ TODO: is this behavior correct?
 --- error_log eval
 qr/\[info\] .*? property not found: wasmx.nonexistent_property,/
 --- no_error_log
-[error]
 [emerg]
+[alert]
 
 
 
@@ -123,8 +123,8 @@ ok
 --- error_log eval
 qr/\[info\] .*? property not found: was,/
 --- no_error_log
-[crit]
 [emerg]
+[alert]
 
 
 
@@ -137,7 +137,7 @@ is global (single instance for root/request).
 --- load_nginx_modules: ngx_http_echo_module
 --- config
     location /t {
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;
@@ -167,7 +167,7 @@ HTTP 200 since the root and request instances are different.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -97,7 +97,8 @@ TODO: is this behavior correct?
                               name=wasmx.nonexistent_property';
         echo ok;
     }
---- ignore_response_body
+--- response_body
+ok
 --- error_log eval
 qr/\[info\] .*? property not found: wasmx.nonexistent_property,/
 --- no_error_log
@@ -129,10 +130,6 @@ qr/\[info\] .*? property not found: was,/
 
 
 === TEST 4: proxy_wasm - get_property() wasmx - not available on: tick (isolation: global)
-
-HTTP 500 since instance recycling happens on next request, and isolation
-is global (single instance for root/request).
-
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -143,7 +140,6 @@ is global (single instance for root/request).
         echo_sleep 0.150;
         echo ok;
     }
---- error_code: 500
 --- ignore_response_body
 --- error_log eval
 [
@@ -152,15 +148,10 @@ is global (single instance for root/request).
     qr/\[crit\] .*? panicked at/,
     qr/unexpected status: 10/,
 ]
---- no_error_log
-[emerg]
 
 
 
 === TEST 5: proxy_wasm - get_property() wasmx - not available on: tick (isolation: stream)
-
-HTTP 200 since the root and request instances are different.
-
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
@@ -58,9 +58,9 @@ qr/\A\[info\] .*? new: "2"
 \[info\] .*? old: "5"
 \[info\] .*? new: "6"/
 --- no_error_log
-[error]
-[crit]
 [emerg]
+[alert]
+[stub]
 
 
 
@@ -85,7 +85,7 @@ qr/\A\[info\] .*? new: "2"
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
+[emerg]
 
 
 
@@ -110,7 +110,7 @@ qr/\A\[info\] .*? new: "2"
     qr/\[info\] .*? new: ""/,
 ]
 --- no_error_log
-[error]
+[emerg]
 
 
 
@@ -132,9 +132,9 @@ Does not fail when the property is not found.
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
-[crit]
 [emerg]
+[alert]
+[stub]
 
 
 
@@ -149,7 +149,7 @@ isolation is global (single instance for root/request).
     set $my_var 123;
 
     location /t {
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \
@@ -186,7 +186,7 @@ ngx_http_* calls.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=100 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \

--- a/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_host.t
@@ -139,10 +139,8 @@ Does not fail when the property is not found.
 
 
 === TEST 5: proxy_wasm - set_property() wasmx - not available on: tick (isolation: global)
-
-HTTP 500 since instance recycling happens on next request, and
-isolation is global (single instance for root/request).
-
+on_tick runs on the root context, so it does not have access to
+ngx_http_* calls.
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -157,7 +155,6 @@ isolation is global (single instance for root/request).
         echo_sleep 0.150;
         echo ok;
     }
---- error_code: 500
 --- ignore_response_body
 --- error_log eval
 [
@@ -172,12 +169,8 @@ isolation is global (single instance for root/request).
 
 
 === TEST 6: proxy_wasm - set_property() wasmx - not available on: tick (isolation: stream)
-
-HTTP 200 since the root and request instances are different.
-
 on_tick runs on the root context, so it does not have access to
 ngx_http_* calls.
-
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
@@ -194,9 +194,7 @@ forward the NotFound status back to the caller.
 on_tick runs on the root context, so it does not have access to
 ngx_http_* calls.
 
-HTTP 500 since instance recycling happens on next
-request, and isolation is global (single instance for root/request)
-
+--- skip_eval: 5: $ENV{TEST_NGINX_USE_HUP} == 1
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -211,7 +209,6 @@ request, and isolation is global (single instance for root/request)
         echo_sleep 0.150;
         echo ok;
     }
---- error_code: 500
 --- ignore_response_body
 --- error_log eval
 [
@@ -230,6 +227,7 @@ ngx_http_* calls.
 
 HTTP 200 since the root and request instances are different.
 
+--- skip_eval: 5: $ENV{TEST_NGINX_USE_HUP} == 1
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_ngx.t
@@ -61,8 +61,8 @@ qr/\A\[info\] .*? old: "1"
 \[info\] .*? old: "5"
 \[info\] .*? new: "6"/
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -134,8 +134,8 @@ GET /t?hello=world
     qr/\[info\] .*? new: unset/,
 ]
 --- no_error_log
-[error]
-[crit]
+[emerg]
+[alert]
 
 
 
@@ -238,7 +238,7 @@ HTTP 200 since the root and request instances are different.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=10 \
+        proxy_wasm hostcalls 'tick_period=200 \
                               on_tick=set_property \
                               name=ngx.my_var \
                               set=456 \

--- a/t/04-openresty/ffi/103-proxy_wasm_attach.t
+++ b/t/04-openresty/ffi/103-proxy_wasm_attach.t
@@ -519,8 +519,8 @@ qr/\A[^#]*#0 on_vm_start[^#*]*
 #0 on_configure[^#*]*
 \*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#*]*
 \*\d+ .*? "hostcalls" filter new instance[^#*]*
-\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 #0 on_configure[^#*]*
+\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
@@ -531,8 +531,8 @@ qr/\A[^#]*#0 on_vm_start[^#*]*
 \*\d+ wasm freeing "hostcalls" instance[^#*]*\Z/,
 qr/\A\*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#*]*
 \*\d+ .*? "hostcalls" filter new instance[^#*]*
-\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 #0 on_configure[^#*]*
+\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_headers" step in "header_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_response_body" step in "body_filter" phase[^#*]*

--- a/t/04-openresty/ffi/103-proxy_wasm_attach.t
+++ b/t/04-openresty/ffi/103-proxy_wasm_attach.t
@@ -527,8 +527,8 @@ qr/\A[^#]*#0 on_vm_start[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_log" step in "log" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 1\/1 finalizing context[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(1\/1\)[^#*]*
-\*\d+ wasm freeing "hostcalls" instance[^#*]*\Z/,
+\*\d+ wasm freeing "hostcalls" instance[^#*]*
+\*\d+ .*? filter freeing context #\d+ \(1\/1\)[^#*]*\Z/,
 qr/\A\*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#*]*
 \*\d+ .*? "hostcalls" filter new instance[^#*]*
 #0 on_configure[^#*]*
@@ -539,8 +539,8 @@ qr/\A\*\d+ proxy_wasm initializing filter chain \(nfilters: 1, isolation: 2\)[^#
 \*\d+ .*? filter 1\/1 resuming "on_log" step in "log" phase[^#*]*
 \*\d+ .*? filter 1\/1 resuming "on_done" step in "done" phase[^#*]*
 \*\d+ .*? filter 1\/1 finalizing context[^#*]*
-\*\d+ .*? filter freeing context #\d+ \(1\/1\)[^#*]*
-\*\d+ wasm freeing "hostcalls" instance[^#*]*\Z/,
+\*\d+ wasm freeing "hostcalls" instance[^#*]*
+\*\d+ .*? filter freeing context #\d+ \(1\/1\)[^#*]*\Z/,
 ]
 
 

--- a/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
@@ -68,6 +68,12 @@ impl RootContext for HttpHeadersRoot {
 
     fn on_tick(&mut self) {
         info!("on_tick {}", self.config.get("tick_period").unwrap());
+
+        #[allow(clippy::single_match)]
+        match self.config.get("on_tick").map(|s| s.as_str()).unwrap_or("") {
+            "trap" => panic!("on_tick trap"),
+            _ => (),
+        }
     }
 
     fn get_type(&self) -> Option<ContextType> {


### PR DESCRIPTION
* Allow for recycling the root instance (which is not managed by isolation modes).
* Allow for smoother recycling of http instances (including when the root instance has trapped, e.g. during `on_tick`).
* Also recycle trapped instances in the busy queue.
* Less verbose context creation of fresh and/or recycled instances starting in atypical steps (e.g. `on_response_headers`).
* Sweep trapped instances sooner (during runtime instead of worker shutdown).
* Greatly simplify `on_context_create` supporting code and unifies it between root and http instances which now both use the same context creation code. This makes instance recycling much more robust in a number of tricky situations with low isolation modes.
