### PR TITLE
fix(proxy-wasm) do not accidentally reset filter list from FFI call

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -275,7 +275,7 @@ ngx_proxy_wasm_ctx(ngx_uint_t *filter_ids, size_t nfilters,
         return NULL;
     }
 
-    if (!pwctx->ready) {
+    if (!pwctx->ready && filter_ids) {
         pwctx->nfilters = nfilters;
         pwctx->isolation = isolation;
 
@@ -399,7 +399,9 @@ ngx_proxy_wasm_ctx_destroy(ngx_proxy_wasm_ctx_t *pwctx)
         ngx_proxy_wasm_release_instance(ictx, 0);
     }
 
-    ngx_proxy_wasm_store_destroy(&pwctx->store);
+    if (pwctx->ready) {
+        ngx_proxy_wasm_store_destroy(&pwctx->store);
+    }
 
 #if 0
     if (pwctx->authority.data) {


### PR DESCRIPTION
When calling `proxy_wasm.set_property` from Lua, we want a `pwctx` to be able to store a property. But we need to do that before `proxy_wasm.start`, so `pwctx->ready` didn't have a chance to get initialized yet.

Passing `NULL, 0` to `filter_ids` and `nfilters` when obtaining the `pwctx` from the `set_property` FFI call caused the `pwctx` to get initialized with an empty filter list, defeating the configuration previously set up by `proxy_wasm.attach`.

In this fix, we make the `NULL` value of `filter_ids` to mean "please don't do the `pwctx->ready` initialization". The other use of `ngx_proxy_wasm_ctx` in `ngx_wasm_ops.c` always passes a non-NULL value (even when the filter list is empty), because the `elts` pointer is allocated on `ngx_array_init`.

This issue caused an integration failure in Kong Gateway. This PR includes a regression test for our test suite, which reproduces the sequence observed in the Gateway; the test fails without the fix added to `ngx_proxy_wasm.c` and passes with the fix.