### PR TITLE
chore(util) do not remove test servroot with TEST_NGINX_RANDOMIZE=1

### DIFF
--- a/util/test.sh
+++ b/util/test.sh
@@ -140,6 +140,9 @@ fi
 if [[ "$TEST_NGINX_RANDOMIZE" == 1 ]]; then
     prove_opts="-j$(n_jobs)"
     echo "TEST_NGINX_RANDOMIZE=$TEST_NGINX_RANDOMIZE ($prove_opts)"
+
+else
+    rm -rf $TEST_NGINX_SERVROOT
 fi
 
 echo
@@ -154,8 +157,6 @@ if [ $(uname -s) = Darwin ]; then
 elif [ ! -x "$(command -v ldd)" ]; then
     ldd $TEST_NGINX_BINARY | grep wasm
 fi
-
-rm -rf $TEST_NGINX_SERVROOT
 
 echo
 exec prove -r $prove_opts $@


### PR DESCRIPTION
The servroot should only be cleaned when we are sure it will be overwritten anyway. This allows observing its contents for debugging purposes while running randomized test on the whole suite.