### PR TITLE
chore(deps) bump Wasmer to 3.3.0

### DIFF
--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -26,7 +26,7 @@ jobs:
         ngx: [1.25.3]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
         debug: [debug, no_debug]
         hup: [hup, no_hup]
@@ -69,7 +69,7 @@ jobs:
         ngx: [1.25.3]
         runtime: [wasmer, wasmtime, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
         hup: [hup, no_hup]
         debug: [debug]
@@ -80,7 +80,7 @@ jobs:
             cc: gcc-12
             openresty: 1.21.4.2
             runtime: wasmer
-            wasmer: 3.1.1
+            wasmer: 3.3.0
             debug: debug
             hup: no_hup
     uses: ./.github/workflows/job-valgrind-tests.yml
@@ -107,7 +107,7 @@ jobs:
         openresty: [1.21.4.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
         ssl: [no_ssl, ssl]
         debug: [debug, no_debug]
@@ -135,7 +135,7 @@ jobs:
         ngx: [1.25.3]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
         include:
           - label: old_nginx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         openresty: [""]
         runtime: [wasmer]
         wasmtime: [""]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [""]
         ssl: [ssl]
         debug: [debug, no_debug]
@@ -66,7 +66,7 @@ jobs:
             cc: gcc-12
             ngx: 1.21.6
             runtime: wasmer
-            wasmer: 3.1.1
+            wasmer: 3.3.0
             ssl: ssl
             debug: debug
             hup: no_hup
@@ -86,7 +86,7 @@ jobs:
             cc: gcc-12
             ngx: 1.25.3
             runtime: wasmer
-            wasmer: 3.1.1
+            wasmer: 3.3.0
             ssl: no_ssl
             debug: no_debug
             hup: no_hup
@@ -149,7 +149,7 @@ jobs:
       matrix:
         label: ["full"]
         runtime: [wasmer]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         os: [ubuntu-22.04]
         cc: [gcc-12]
         ngx: [1.25.3]
@@ -181,7 +181,7 @@ jobs:
           # OpenResty
           - label: openresty
             runtime: wasmer
-            wasmer: 3.1.1
+            wasmer: 3.3.0
             os: ubuntu-22.04
             cc: gcc-12
             openresty: 1.21.4.2
@@ -252,7 +252,7 @@ jobs:
         openresty: [1.21.4.2]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
         ssl: [ssl]
         debug: [debug, no_debug]
@@ -262,7 +262,7 @@ jobs:
             cc: clang-15
             ngx: 1.25.3
             runtime: wasmer
-            wasmer: 3.1.1
+            wasmer: 3.3.0
             ssl: no_ssl
             debug: debug
     uses: ./.github/workflows/job-clang-analyzer.yml
@@ -288,7 +288,7 @@ jobs:
         ngx: [1.25.3]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [14.0.3]
-        wasmer: [3.1.1]
+        wasmer: [3.3.0]
         v8: [11.4.183.23]
     uses: ./.github/workflows/job-build-tests.yml
     with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NGX ?= 1.25.3
 OPENSSL ?= 3.2.0
 WASMTIME ?= 14.0.3
-WASMER ?= 3.1.1
+WASMER ?= 3.3.0
 V8 ?= 11.4.183.23
 PCRE ?= 8.45
 ZLIB ?= 1.3

--- a/src/wasm/wrt/ngx_wrt.h
+++ b/src/wasm/wrt/ngx_wrt.h
@@ -119,7 +119,7 @@ void ngx_wasmtime_valvec2wasm(wasm_val_vec_t *out, wasmtime_val_t *vec,
 
 #if WASMER_VERSION_MAJOR != 3
 #   error Unsupported Wasmer version
-#elif WASMER_VERSION_MINOR > 1
+#elif WASMER_VERSION_MINOR > 3
 #   warning Untested Wasmer version
 #endif
 

--- a/src/wasm/wrt/ngx_wrt_wasmer.c
+++ b/src/wasm/wrt/ngx_wrt_wasmer.c
@@ -610,6 +610,14 @@ ngx_wasmer_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
 
     instance->ctxs = hctxs;
 
+    if (module->wasi
+        && !wasi_env_initialize_instance(store->wasi_env, store->store,
+                                         instance->instance))
+    {
+        dd("wasi_env_initialize_instance failed");
+        goto error;
+    }
+
     return NGX_OK;
 
 error:
@@ -696,11 +704,6 @@ ngx_wasmer_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
         ngx_wasm_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_MEMORY);
         ext->kind = NGX_WRT_EXTERN_MEMORY;
         instance->memory = wasm_extern_as_memory(ext->ext);
-
-        if (module->wasi) {
-            wasi_env_set_memory(instance->store->wasi_env, instance->memory);
-        }
-
         break;
 
     case WASM_EXTERN_GLOBAL:

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -35,22 +35,6 @@
    fun:_ZN10wasmparser6parser6Parser5parse17h*
 }
 {
-   <wasmer 3.3.0: wasi_env_new>
-   Memcheck:Leak
-   ...
-   fun:wasi_env_new
-}
-{
-   <wasmer 3.3.0: start_thread>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:calloc
-   ...
-   fun:_ZN3std3sys4unix6thread6Thread3new12thread_start17h*
-   fun:start_thread
-   fun:clone
-}
-{
    <v8 11.4.183.23: wasm_engine_new>
    Memcheck:Leak
    match-leak-kinds: possible

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -30,34 +30,25 @@
    fun:ngx_http_headers_more_filter
 }
 {
-   <wasmer 3.1.1: parse>
-   Memcheck:Cond
-   fun:_ZN10wasmparser6parser6Parser5parse17h5c54f0ee5315402aE
-   ...
-   fun:main
-}
-{
-   <wasmer 3.1.1: wasm_instance_new>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   ...
-   fun:_ZN6wasmer3sys8instance8Instance12new_by_index17h9b11b6b5fcb57319E
-   fun:wasm_instance_new
-}
-{
-   <wasmer 3.1.1: wasm_module_new>
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:calloc
-   ...
-   fun:_ZN6wasmer3sys6module6Module11from_binary17h0e63bedfc82f5d11E
-   fun:wasm_module_new
-}
-{
-   <wasmtime 14.0.3: parse>
+   <wasmparser::parse>
    Memcheck:Cond
    fun:_ZN10wasmparser6parser6Parser5parse17h*
+}
+{
+   <wasmer 3.3.0: wasi_env_new>
+   Memcheck:Leak
+   ...
+   fun:wasi_env_new
+}
+{
+   <wasmer 3.3.0: start_thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   ...
+   fun:_ZN3std3sys4unix6thread6Thread3new12thread_start17h*
+   fun:start_thread
+   fun:clone
 }
 {
    <v8 11.4.183.23: wasm_engine_new>
@@ -67,9 +58,4 @@
    ...
    fun:_ZN4wasm6Engine4makeEOSt10unique_ptrINS_6ConfigESt14default_deleteIS2_EE
    fun:wasm_engine_new
-}
-{
-   <ngx_wasm_rs: parse>
-   Memcheck:Cond
-   fun:_ZN10wasmparser6parser6Parser5parse17h9b8c5cdeb2164838E
 }


### PR DESCRIPTION
TODO
- [x] more time double-checking wasi_env leak in HUP mode
- [x] another leak detected locally:

```
==1340178== 1,024 (512 direct, 512 indirect) bytes in 16 blocks are definitely lost in loss record 57 of 82
==1340178==    at 0x48469B3: calloc (vg_replace_malloc.c:1554)
==1340178==    by 0x65B08A3: __cxa_thread_atexit_impl (cxa_thread_atexit_impl.c:106)
==1340178==    by 0x5C733C1: std:🧵:local::fast::Key<T>::try_initialize (in /home/chasum/code/ngx_wasm_module/work/runtimes/wasmer-3.3.0/lib/libwasmer.so)
==1340178==    by 0x5C756CF: std::sys_common::backtrace::__rust_begin_short_backtrace (in /home/chasum/code/ngx_wasm_module/work/runtimes/wasmer-3.3.0/lib/libwasmer.so)
==1340178==    by 0x5C8DD6D: core::ops::function::FnOnce::call_once{{vtable.shim}} (in /home/chasum/code/ngx_wasm_module/work/runtimes/wasmer-3.3.0/lib/libwasmer.so)
==1340178==    by 0x5E852F2: call_once<(), dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global> (boxed.rs:1940)
==1340178==    by 0x5E852F2: call_once<(), alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global>, alloc::alloc::Global> (boxed.rs:1940)
==1340178==    by 0x5E852F2: std::sys::unix:🧵:Thread:🆕:thread_start (thread.rs:108)
==1340178==    by 0x65FC9EA: start_thread (pthread_create.c:444)
==1340178==    by 0x6680653: clone (clone.S:100)
==1340178==
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   fun:__cxa_thread_atexit_impl
   fun:_ZN3std6thread5local4fast12Key$LT$T$GT$14try_initialize17h2bea1c855c84557aE.llvm.8405950610511606066
   fun:_ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h9c91faef54c14282E
   fun:_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hf6162bd9fccb4b6aE
   fun:call_once<(), dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global>
   fun:call_once<(), alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output=()>, alloc::alloc::Global>, alloc::alloc::Global>
   fun:_ZN3std3sys4unix6thread6Thread3new12thread_start17h62ca48b42d48a8fcE
   fun:start_thread
   fun:clone
}
```