### PR TITLE
docs(*) Add ref to AS rate limiting filter; update AS SDK ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,19 @@ http {
 
 Three "showcase filters" are provided as examples by this module:
 
+- [proxy-wasm-rust-filter-echo](https://github.com/wasmx-proxy/proxy-wasm-rust-filter-echo/):
+  An httpbin/echo filter.
 - [proxy-wasm-rust-rate-limiting](https://github.com/Kong/proxy-wasm-rust-rate-limiting):
   Kong Gateway inspired rate-limiting in Rust.
 - [proxy-wasm-go-rate-limiting](https://github.com/Kong/proxy-wasm-go-rate-limiting):
   Kong Gateway inspired rate-limiting in Go.
-- [proxy-wasm-rust-filter-echo](https://github.com/wasmx-proxy/proxy-wasm-rust-filter-echo/):
-  An httpbin/echo filter.
+- [proxy-wasm-assemblyscript-rate-limiting](https://github.com/Kong/proxy-wasm-assemblyscript-rate-limiting):
+  Kong Gateway inspired rate-limiting in AssemblyScript.
 
 More examples are available for each Proxy-Wasm SDK:
 
 - [AssemblyScript
-  examples](https://github.com/solo-io/proxy-runtime/tree/master/examples)
+  examples (temporary fork)](https://github.com/kong/proxy-wasm-assemblyscript-sdk/tree/master/examples)
 - [C++
   examples](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/tree/master/example)
 - [Go (TinyGo)

--- a/docs/PROXY_WASM.md
+++ b/docs/PROXY_WASM.md
@@ -656,8 +656,9 @@ ngx_wasm_module, most likely due to a Host incompatibility.
 - Functional filters written by the WasmX team:
     - [Kong/proxy-wasm-rust-rate-limiting](https://github.com/Kong/proxy-wasm-rust-rate-limiting)
     - [Kong/proxy-wasm-go-rate-limiting](https://github.com/Kong/proxy-wasm-go-rate-limiting)
+    - [Kong/proxy-wasm-assemblyscript-rate-limiting](https://github.com/Kong/proxy-wasm-assemblyscript-rate-limiting)
 - Proxy-Wasm SDK examples:
-    - [AssemblyScript examples](https://github.com/solo-io/proxy-runtime/tree/master/examples)
+    - [AssemblyScript examples (temporary fork)](https://github.com/kong/proxy-wasm-assemblyscript-sdk/tree/master/examples)
     - [C++ examples](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/tree/master/example)
     - [Go (TinyGo) examples](https://github.com/tetratelabs/proxy-wasm-go-sdk/tree/main/examples)
     - [Rust examples](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/tree/master/examples)


### PR DESCRIPTION
We are temporarily referencing a forked version of AssemblyScript SDK that addresses an incompatibility between the SDK and ngx_wasm_module.

See https://github.com/Kong/proxy-wasm-assembly-script-sdk/commit/06bd3974289d702437fc0545bb352ec589a6c09c