### PR TITLE
tests(*): match_error_log block and match_error_log_grep modifier

### DIFF
--- a/lib/resty/wasmx.lua
+++ b/lib/resty/wasmx.lua
@@ -15,9 +15,13 @@ ffi.cdef [[
         ngx_str_t       *config;
     } ngx_wasm_filter_t;
 
+    typedef intptr_t                      ngx_int_t;
     typedef unsigned char                 u_char;
     typedef struct ngx_wavm_t             ngx_wasm_vm_t;
     typedef struct ngx_wasm_ops_plan_t    ngx_wasm_plan_t;
+
+    typedef ngx_int_t (*ngx_wasm_host_prop_fn_t)(void *data, ngx_str_t *key,
+        ngx_str_t *value);
 
     ngx_wasm_vm_t *ngx_wasm_ffi_main_vm();
 ]]

--- a/lib/resty/wasmx/proxy_wasm.lua
+++ b/lib/resty/wasmx/proxy_wasm.lua
@@ -8,9 +8,11 @@ local C = ffi.C
 local ngx = ngx
 local error = error
 local type = type
+local pcall = pcall
 local ffi_gc = ffi.gc
 local ffi_new = ffi.new
 local ffi_str = ffi.string
+local tostring = tostring
 local subsystem = ngx.config.subsystem
 local get_request = wasmx.get_request
 local get_err_ptr = wasmx.get_err_ptr
@@ -38,23 +40,32 @@ local _M = {
 
 if subsystem == "http" then
     ffi.cdef [[
-        int ngx_http_wasm_ffi_plan_new(ngx_wasm_vm_t *vm,
-                                       ngx_wasm_filter_t *filters,
-                                       size_t n_filters,
-                                       ngx_wasm_plan_t **out,
-                                       u_char *err, size_t *errlen);
-        int ngx_http_wasm_ffi_plan_free(ngx_wasm_plan_t *plan);
-        int ngx_http_wasm_ffi_plan_load(ngx_wasm_plan_t *plan);
-        int ngx_http_wasm_ffi_plan_attach(ngx_http_request_t *r,
-                                          ngx_wasm_plan_t *plan,
-                                          unsigned int isolation);
-        int ngx_http_wasm_ffi_start(ngx_http_request_t *r);
-        int ngx_http_wasm_ffi_set_property(ngx_http_request_t *r,
-                                           ngx_str_t *key,
-                                           ngx_str_t *value);
-        int ngx_http_wasm_ffi_get_property(ngx_http_request_t *r,
-                                           ngx_str_t *key,
-                                           ngx_str_t *out);
+        ngx_int_t ngx_http_wasm_ffi_plan_new(ngx_wasm_vm_t *vm,
+                                             ngx_wasm_filter_t *filters,
+                                             size_t n_filters,
+                                             ngx_wasm_plan_t **out,
+                                             u_char *err, size_t *errlen);
+        ngx_int_t ngx_http_wasm_ffi_plan_free(ngx_wasm_plan_t *plan);
+        ngx_int_t ngx_http_wasm_ffi_plan_load(ngx_wasm_plan_t *plan);
+        ngx_int_t ngx_http_wasm_ffi_plan_attach(ngx_http_request_t *r,
+                                                ngx_wasm_plan_t *plan,
+                                                unsigned int isolation);
+        ngx_int_t ngx_http_wasm_ffi_start(ngx_http_request_t *r);
+        ngx_int_t ngx_http_wasm_ffi_set_property(ngx_http_request_t *r,
+                                                 ngx_str_t *key,
+                                                 ngx_str_t *value);
+        ngx_int_t ngx_http_wasm_ffi_get_property(ngx_http_request_t *r,
+                                                 ngx_str_t *key,
+                                                 ngx_str_t *out);
+        ngx_int_t ngx_http_wasm_ffi_set_host_property(ngx_http_request_t *r,
+                                                      ngx_str_t *key,
+                                                      ngx_str_t *value,
+                                                      unsigned is_const,
+                                                      unsigned retrieve);
+        ngx_int_t ngx_http_wasm_ffi_set_property_setter(ngx_http_request_t *r,
+                                                        ngx_wasm_host_prop_fn_t fn);
+        ngx_int_t ngx_http_wasm_ffi_set_property_getter(ngx_http_request_t *r,
+                                                        ngx_wasm_host_prop_fn_t fn);
     ]]
 
 else
@@ -65,6 +76,86 @@ end
 
 local ffi_ops_type = ffi.typeof("ngx_wasm_plan_t *")
 local ffi_pops_type = ffi.typeof("ngx_wasm_plan_t *[1]")
+
+
+local lua_prop_setter
+local lua_prop_getter
+local c_prop_setter
+local c_prop_getter
+
+
+do
+    -- LuaJIT C callbacks are a limited resource:
+    -- We can't create one of these on each request,
+    -- so we prepare these wrappers, which in turn call a Lua function.
+
+    local function store_c_value(r, ckey, cvalue, lvalue, is_const)
+        if lvalue ~= nil then
+            local value = tostring(lvalue)
+            cvalue.data = value
+            cvalue.len = #value
+
+        else
+            cvalue.data = nil
+            cvalue.len = 0
+        end
+
+        return C.ngx_http_wasm_ffi_set_host_property(r, ckey, cvalue,
+                                                     is_const and 1 or 0,
+                                                     1)
+    end
+
+    c_prop_setter = ffi.cast("ngx_wasm_host_prop_fn_t", function(r, ckey,
+                                                                 cvalue)
+        local lkey = ffi_str(ckey.data, ckey.len)
+        local lval
+        if cvalue.data ~= nil then
+            lval = ffi_str(cvalue.data, cvalue.len)
+        end
+
+        local pok, ok, lvalue, is_const = pcall(lua_prop_setter, lkey, lval)
+        if not pok then
+            ngx.log(ngx.ERR, "error setting property from Lua: ", ok)
+            return FFI_ERROR
+        end
+
+        if not ok then
+            local err = lvalue or "unknown error"
+            ngx.log(ngx.ERR, "error setting property: ", err)
+            return FFI_ERROR
+        end
+
+        return store_c_value(r, ckey, cvalue, lvalue, is_const)
+    end)
+
+
+    c_prop_getter = ffi.cast("ngx_wasm_host_prop_fn_t", function(r, ckey,
+                                                                 cvalue)
+        local lkey = ffi_str(ckey.data, ckey.len)
+
+        local pok, ok, lvalue, is_const = pcall(lua_prop_getter, lkey)
+        if not pok then
+            ngx.log(ngx.ERR, "error getting property from Lua: ", ok)
+            return FFI_ERROR
+        end
+
+        if not ok then
+            if lvalue then
+                ngx.log(ngx.ERR, "error setting property: ", lvalue)
+                return FFI_ERROR
+            end
+
+            return FFI_DECLINED
+        end
+
+        local rc = store_c_value(r, ckey, cvalue, lvalue, is_const)
+        if rc == FFI_OK and lvalue == nil then
+            return FFI_DECLINED
+        end
+
+        return rc
+    end)
+end
 
 
 function _M.new(filters)
@@ -229,7 +320,7 @@ function _M.set_property(key, value)
         error("key must be a string", 2)
     end
 
-    if type(value) ~= "string" then
+    if value ~= nil and type(value) ~= "string" then
         error("value must be a string", 2)
     end
 
@@ -239,7 +330,7 @@ function _M.set_property(key, value)
     end
 
     local ckey = ffi_new("ngx_str_t", { data = key, len = #key })
-    local cvalue = ffi_new("ngx_str_t", { data = value, len = #value })
+    local cvalue = ffi_new("ngx_str_t", { data = value, len = value and #value or 0 })
 
     local rc = C.ngx_http_wasm_ffi_set_property(r, ckey, cvalue)
     if rc == FFI_ERROR then
@@ -277,6 +368,75 @@ function _M.get_property(key)
     end
 
     return ffi_str(cvalue.data, cvalue.len)
+end
+
+
+---
+-- Define a setter function for host-managed properties.
+--
+-- @param setter The setter function is the handler for updating properties.
+-- Its type signature is `function(string, string): boolean, string`,
+-- where the inputs are the property key and value and the results are:
+-- * `truthy` - success setting the property
+-- * `truthy, value` - success, cache property value (useful if hosts
+--   sets only a setter but not a getter)
+-- * `truthy, value, truthy` - success, constant property value: further
+--   requests to the same property during a request are cached by
+--   ngx_wasm_module and do not invoke the Lua getter.
+-- * `falsy, err` - failure, and an optional error message
+-- @return true on success setting the getter, or nil and an error message.
+function _M.set_property_setter(setter)
+    if type(setter) ~= "function" then
+        error("setter must be a function", 2)
+    end
+
+    local r = get_request()
+    if not r then
+        error("no request found", 2)
+    end
+
+    lua_prop_setter = setter
+
+    local rc = C.ngx_http_wasm_ffi_set_property_setter(r, c_prop_setter)
+    if rc == FFI_OK then
+        return true
+    end
+
+    return nil, "could not set property setter"
+end
+
+
+---
+-- Define a getter function for host-managed properties.
+--
+-- @param getter The getter function is the handler for resolving properties.
+-- Its type signature is `function(string): boolean, string, boolean`,
+-- where the input is the property key and the results are:
+-- * `truthy, value` - success, property value
+-- * `truthy, value, truthy` - success, constant property value: further
+--   requests to the same property during a request are cached by
+--   ngx_wasm_module and do not invoke the Lua getter.
+-- * `falsy` - property not found
+-- * `falsy, err` - failure, error message
+-- @return true on success setting the getter, or nil and an error message.
+function _M.set_property_getter(getter)
+    if type(getter) ~= "function" then
+        error("getter must be a function", 2)
+    end
+
+    local r = get_request()
+    if not r then
+        error("no request found", 2)
+    end
+
+    lua_prop_getter = getter
+
+    local rc = C.ngx_http_wasm_ffi_set_property_getter(r, c_prop_getter)
+    if rc == FFI_OK then
+        return true
+    end
+
+    return nil, "could not set property getter"
 end
 
 

--- a/src/common/lua/ngx_wasm_lua_ffi.c
+++ b/src/common/lua/ngx_wasm_lua_ffi.c
@@ -190,8 +190,8 @@ get_pwctx(ngx_http_request_t *r)
     }
 
     return ngx_proxy_wasm_ctx(NULL, 0,
-                                NGX_PROXY_WASM_ISOLATION_STREAM,
-                                &ngx_http_proxy_wasm, rctx);
+                              NGX_PROXY_WASM_ISOLATION_STREAM,
+                              &ngx_http_proxy_wasm, rctx);
 }
 
 

--- a/src/common/lua/ngx_wasm_lua_ffi.c
+++ b/src/common/lua/ngx_wasm_lua_ffi.c
@@ -180,6 +180,21 @@ ngx_http_wasm_ffi_start(ngx_http_request_t *r)
 }
 
 
+static ngx_inline ngx_proxy_wasm_ctx_t *
+get_pwctx(ngx_http_request_t *r)
+{
+    ngx_http_wasm_req_ctx_t  *rctx;
+
+    if (ngx_http_wasm_rctx(r, &rctx) != NGX_OK) {
+        return NULL;
+    }
+
+    return ngx_proxy_wasm_ctx(NULL, 0,
+                                NGX_PROXY_WASM_ISOLATION_STREAM,
+                                &ngx_http_proxy_wasm, rctx);
+}
+
+
 ngx_int_t
 ngx_http_wasm_ffi_set_property(ngx_http_request_t *r,
     ngx_str_t *key, ngx_str_t *value)
@@ -225,5 +240,48 @@ ngx_http_wasm_ffi_get_property(ngx_http_request_t *r,
     }
 
     return ngx_proxy_wasm_properties_get(pwctx, key, value);
+}
+
+
+ngx_int_t
+ngx_http_wasm_ffi_set_host_property(ngx_http_request_t *r,
+    ngx_str_t *key, ngx_str_t *value, unsigned is_const, unsigned retrieve)
+{
+    ngx_proxy_wasm_ctx_t  *pwctx = get_pwctx(r);
+
+    if (pwctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    return ngx_proxy_wasm_properties_set_host(pwctx, key, value, is_const,
+                                              retrieve);
+}
+
+
+ngx_int_t
+ngx_http_wasm_ffi_set_property_setter(ngx_http_request_t *r,
+    ngx_wasm_host_prop_fn_t fn)
+{
+    ngx_proxy_wasm_ctx_t  *pwctx = get_pwctx(r);
+
+    if (pwctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    return ngx_proxy_wasm_properties_set_host_prop_setter(pwctx, fn, r);
+}
+
+
+ngx_int_t
+ngx_http_wasm_ffi_set_property_getter(ngx_http_request_t *r,
+    ngx_wasm_host_prop_fn_t fn)
+{
+    ngx_proxy_wasm_ctx_t  *pwctx = get_pwctx(r);
+
+    if (pwctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    return ngx_proxy_wasm_properties_set_host_prop_getter(pwctx, fn, r);
 }
 #endif

--- a/src/common/lua/ngx_wasm_lua_ffi.h
+++ b/src/common/lua/ngx_wasm_lua_ffi.h
@@ -33,6 +33,12 @@ ngx_int_t ngx_http_wasm_ffi_set_property(ngx_http_request_t *r,
     ngx_str_t *key, ngx_str_t *value);
 ngx_int_t ngx_http_wasm_ffi_get_property(ngx_http_request_t *r,
     ngx_str_t *key, ngx_str_t *value);
+ngx_int_t ngx_http_wasm_ffi_set_host_property(ngx_http_request_t *r,
+    ngx_str_t *key, ngx_str_t *value, unsigned is_const, unsigned retrieve);
+ngx_int_t ngx_http_wasm_ffi_set_property_setter(ngx_http_request_t *r,
+    ngx_wasm_host_prop_fn_t fn);
+ngx_int_t ngx_http_wasm_ffi_set_property_getter(ngx_http_request_t *r,
+    ngx_wasm_host_prop_fn_t fn);
 #endif
 
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -166,6 +166,9 @@ typedef struct ngx_http_proxy_wasm_dispatch_s  ngx_http_proxy_wasm_dispatch_t;
 
 typedef ngx_str_t  ngx_proxy_wasm_marshalled_map_t;
 
+typedef ngx_int_t (*ngx_wasm_host_prop_fn_t)(void *data, ngx_str_t *key,
+    ngx_str_t *value);
+
 
 typedef struct {
     ngx_queue_t                        busy;
@@ -245,10 +248,14 @@ struct ngx_proxy_wasm_ctx_s {
     ngx_uint_t                         call_code;
     ngx_uint_t                         response_code;
 
-    /* host properties rbtree */
+    /* host properties */
 
     ngx_rbtree_t                       host_props_tree;
     ngx_rbtree_node_t                  host_props_sentinel;
+    ngx_wasm_host_prop_fn_t            host_prop_getter;
+    ngx_wasm_host_prop_fn_t            host_prop_setter;
+    void                              *host_prop_getter_data;
+    void                              *host_prop_setter_data;
 
     /* flags */
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.h
@@ -9,6 +9,12 @@ ngx_int_t ngx_proxy_wasm_properties_get(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value);
 ngx_int_t ngx_proxy_wasm_properties_set(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_str_t *path, ngx_str_t *value);
+ngx_int_t ngx_proxy_wasm_properties_set_host(ngx_proxy_wasm_ctx_t *pwctx,
+    ngx_str_t *path, ngx_str_t *value, unsigned is_const, unsigned retrieve);
+ngx_int_t ngx_proxy_wasm_properties_set_host_prop_setter(
+    ngx_proxy_wasm_ctx_t *pwctx, ngx_wasm_host_prop_fn_t fn, void *data);
+ngx_int_t ngx_proxy_wasm_properties_set_host_prop_getter(
+    ngx_proxy_wasm_ctx_t *pwctx, ngx_wasm_host_prop_fn_t fn, void *data);
 
 
 #endif /* _NGX_PROXY_WASM_PROPERTIES_H_INCLUDED_ */

--- a/t/04-openresty/ffi/304-proxy_wasm_set_property_getter.t
+++ b/t/04-openresty/ffi/304-proxy_wasm_set_property_getter.t
@@ -88,13 +88,17 @@ ok
     }
 --- response_body
 ok
---- error_log eval
+--- match_error_log_grep eval: qr/(hostcalls\] on_response_body|my_property)/
+--- match_error_log eval
 [
-    qr/\[info\] .*? \[hostcalls\] on_response_body/,
-    qr/\[info\] .*? wasmx.my_property: my_value/,
+    "[hostcalls] on_response_body",
+    "wasmx.my_property: my_value",
+    "[hostcalls] on_response_body",
+    "wasmx.my_property: my_value",
 ]
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -135,13 +139,17 @@ ok
     }
 --- response_body
 ok
---- error_log eval
+--- match_error_log_grep eval: qr/(hostcalls\] on_response_body|my_property)/
+--- match_error_log eval
 [
-    qr/\[info\] .*? \[hostcalls\] on_response_body/,
-    qr/\[info\] .*? wasmx.my_property: my_value/,
+    "[info]", "[hostcalls] on_response_body",
+    "[info]", "wasmx.my_property: my_value",
+    "[info]", "[hostcalls] on_response_body",
+    "[info]", "wasmx.my_property: my_value",
 ]
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -525,29 +533,29 @@ ok
     }
 --- response_body
 ok
---- grep_error_log eval: qr/.*wasmx.*property.*/
---- grep_error_log_out eval
-qr/^[^\n]*?\[info\] [^\n]*? getting wasmx.const_property, counter: 1[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "1"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property, counter: 2[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "2"[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "1"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property, counter: 3[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "3"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.nil_const_property, counter: 4[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property, counter: 5[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property, counter: 6[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.empty_const_property, counter: 7[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property, counter: 8[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
-[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property, counter: 9[^\n]*?
-[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?$/
+--- match_error_log_grep eval: qr/.*wasmx.*property.*/
+--- match_error_log
+getting wasmx.const_property, counter: 1
+wasmx.const_property: string "1"
+getting wasmx.dyn_property, counter: 2
+wasmx.dyn_property: string "2"
+wasmx.const_property: string "1"
+getting wasmx.dyn_property, counter: 3
+wasmx.dyn_property: string "3"
+getting wasmx.nil_const_property, counter: 4
+wasmx.nil_const_property: nil "nil"
+getting wasmx.nil_dyn_property, counter: 5
+wasmx.nil_dyn_property: nil "nil"
+wasmx.nil_const_property: nil "nil"
+getting wasmx.nil_dyn_property, counter: 6
+wasmx.nil_dyn_property: nil "nil"
+getting wasmx.empty_const_property, counter: 7
+wasmx.empty_const_property: string ""
+getting wasmx.empty_dyn_property, counter: 8
+wasmx.empty_dyn_property: string ""
+wasmx.empty_const_property: string ""
+getting wasmx.empty_dyn_property, counter: 9
+wasmx.empty_dyn_property: string ""
 --- no_error_log
 [error]
 [crit]

--- a/t/04-openresty/ffi/304-proxy_wasm_set_property_getter.t
+++ b/t/04-openresty/ffi/304-proxy_wasm_set_property_getter.t
@@ -1,0 +1,597 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasm::Lua;
+
+skip_no_openresty();
+
+plan tests => repeat_each() * (blocks() * 5);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set_property_getter() - setting host properties getter fails on init_worker_by_lua
+--- wasm_modules: on_phases
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "on_phases" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+
+        local function getter(key)
+            if key == "my_key" then
+                return true, "my_value"
+            end
+            return false
+        end
+
+        assert(proxy_wasm.set_property_getter(getter))
+    }
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[error\] .*? cannot set host properties getter outside of a request/,
+    qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: could not set property getter/,
+]
+--- no_error_log
+[crit]
+
+
+
+=== TEST 2: set_property_getter() - setting host properties getter works on rewrite_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: my_value/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: set_property_getter() - setting host properties getter works on access_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: my_value/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: set_property_getter() - setting host properties getter works on header_filter_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        header_filter_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: my_value/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: set_property_getter() - setting host properties getter works on body_filter_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        body_filter_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: my_value/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: set_property_getter() - setting host properties getter works on log_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+
+        proxy_wasm hostcalls 'on=log \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_log/,
+    qr/\[info\] .*? wasmx.my_property: my_value/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: set_property_getter() - setting property getter at startup doesn't reset filter list
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls", config = "on=log " ..
+                                           "test=/t/log/property " ..
+                                           "name=wasmx.startup_property" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                if key == "wasmx.startup_property" then
+                    return true, "foo"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_log/,
+    qr/\[info\] .*?hostcalls.*? wasmx.startup_property: foo/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: set_property_getter() - getter returning false produces property not found
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.missing_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? property not found: wasmx.missing_property/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: set_property_getter() - getter returning nil produces property not found
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.missing_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                if key == "wasmx.my_property" then
+                    return true, "my_value"
+                end
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? property not found: wasmx.missing_property/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: set_property_getter() - getter returning true on 3rd value caches result
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local counter = 0
+
+            local function getter(key)
+                counter = counter + 1
+
+                ngx.log(ngx.INFO, "getting ", key, ", counter: ",
+                        tostring(counter))
+
+                if key == "wasmx.dyn_property" then
+                    return true, tostring(counter)
+
+                elseif key == "wasmx.const_property" then
+                    return true, tostring(counter), true
+
+                elseif key == "wasmx.nil_dyn_property" then
+                    return true, nil
+
+                elseif key == "wasmx.nil_const_property" then
+                    return true, nil, true
+
+                elseif key == "wasmx.empty_dyn_property" then
+                    return true, ""
+
+                elseif key == "wasmx.empty_const_property" then
+                    return true, "", true
+                end
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local function log_property(k)
+                local v = proxy_wasm.get_property(k)
+                ngx.log(ngx.INFO, k, ": ", type(v), " \"", v, "\"")
+            end
+
+            -- four get_property operations,
+            -- but it will hit the getter three times
+            -- because the second call to get wasmx.const_property
+            -- hits the cache
+            log_property("wasmx.const_property") -- returns 1
+            log_property("wasmx.dyn_property") -- returns 2
+            log_property("wasmx.const_property") -- returns 1
+            log_property("wasmx.dyn_property") -- returns 3
+
+            log_property("wasmx.nil_const_property") -- returns nil
+            log_property("wasmx.nil_dyn_property") -- returns nil
+            log_property("wasmx.nil_const_property") -- returns nil
+            log_property("wasmx.nil_dyn_property") -- returns nil
+
+            log_property("wasmx.empty_const_property") -- returns ""
+            log_property("wasmx.empty_dyn_property") -- returns ""
+            log_property("wasmx.empty_const_property") -- returns ""
+            log_property("wasmx.empty_dyn_property") -- returns ""
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/.*wasmx.*property.*/
+--- grep_error_log_out eval
+qr/^[^\n]*?\[info\] [^\n]*? getting wasmx.const_property, counter: 1[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "1"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property, counter: 2[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "2"[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "1"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property, counter: 3[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "3"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.nil_const_property, counter: 4[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property, counter: 5[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property, counter: 6[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.empty_const_property, counter: 7[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property, counter: 8[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property, counter: 9[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?$/
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 11: set_property_getter() - errors in getter are caught by pcall in Lua library and don't crash the worker
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function getter(key)
+                error("crash!")
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[error\] .*? error getting property from Lua: rewrite_by_lua\(nginx.conf:[0-9]+\):[0-9]+: crash\!/,
+]
+--- no_error_log
+[emerg]

--- a/t/04-openresty/ffi/305-proxy_wasm_set_property_setter.t
+++ b/t/04-openresty/ffi/305-proxy_wasm_set_property_setter.t
@@ -1,0 +1,616 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasm::Lua;
+
+skip_no_openresty();
+
+plan tests => repeat_each() * (blocks() * 5);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set_property_setter() - setting host properties setter fails on init_worker_by_lua
+--- wasm_modules: on_phases
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "on_phases" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+
+        local tbl = {}
+
+        local function setter(key, value)
+            tbl[key] = value
+            return true
+        end
+
+        assert(proxy_wasm.set_property_setter(setter))
+    }
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[error\] .*? cannot set host properties setter outside of a request/,
+    qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: could not set property setter/,
+]
+--- no_error_log
+[crit]
+
+
+
+=== TEST 2: set_property_setter() - setting host properties setter works on rewrite_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local tbl = {}
+
+            local function setter(key, value)
+                local new_value = value:upper()
+                tbl[key] = new_value
+                return true, new_value
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: MY_VALUE/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: set_property_setter() - setting host properties setter works on access_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local tbl = {}
+
+            local function setter(key, value)
+                local new_value = value:upper()
+                tbl[key] = new_value
+                return true, new_value
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: MY_VALUE/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: set_property_setter() - setting host properties setter works on header_filter_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        header_filter_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local tbl = {}
+
+            local function setter(key, value)
+                local new_value = value:upper()
+                tbl[key] = new_value
+                return true, new_value
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: MY_VALUE/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: set_property_setter() - setting host properties setter works on body_filter_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        body_filter_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local tbl = {}
+
+            local function setter(key, value)
+                local new_value = value:upper()
+                tbl[key] = new_value
+                return true, new_value
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[info\] .*? wasmx.my_property: MY_VALUE/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: set_property_setter() - setting host properties setter works on log_by_lua
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+
+        proxy_wasm hostcalls 'on=log \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local tbl = {}
+
+            local function setter(key, value)
+                local new_value = value:upper()
+                tbl[key] = new_value
+                return true, new_value
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_log/,
+    qr/\[info\] .*? wasmx.my_property: MY_VALUE/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: set_property_setter() - setting property setter at startup doesn't reset filter list
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls", config = "on=log " ..
+                                           "test=/t/log/property " ..
+                                           "name=wasmx.my_property" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm_request_headers_in_access on;
+
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function setter(key, value)
+                if key == "wasmx.my_property" then
+                    return true, "foo"
+                end
+                return false
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            assert(proxy_wasm.start())
+
+            ngx.say("ok")
+        }
+
+        body_filter_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            assert(proxy_wasm.set_property("wasmx.my_property", "bar"))
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_log/,
+    qr/\[info\] .*?hostcalls.*? wasmx.my_property: foo/,
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: set_property_setter() - setter returning falsy logs custom message or "unknown error"
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    proxy_wasm hostcalls 'on=log \
+                          test=/t/log/property \
+                          name=wasmx.fail1_property';
+
+    location /t {
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local function setter(key)
+                if key == "wasmx.fail1_property" then
+                    return nil, "first wasmx property custom error"
+
+                elseif key == "wasmx.fail2_property" then
+                    return false, "second wasmx property custom error"
+
+                elseif key == "wasmx.fail3_property" then
+                    return nil
+
+                elseif key == "wasmx.fail4_property" then
+                    return false
+                end
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            local msg = "result:"
+            for i = 1, 4 do
+                local key = "wasmx.fail" .. i .. "_property"
+                local ok, err = proxy_wasm.set_property(key, "wat")
+                if not ok then
+                    msg = msg .. "\n" .. err
+                end
+            end
+
+            assert(proxy_wasm.start())
+            ngx.say(msg)
+        }
+    }
+--- response_body
+result:
+unknown error
+unknown error
+unknown error
+unknown error
+--- grep_error_log eval: qr/.*property.*/
+--- grep_error_log_out eval
+qr/^[^\n]*?\[error\] [^\n]*? error setting property: first wasmx property custom error[^\n]*?
+[^\n]*?\[error\] [^\n]*? error setting property: second wasmx property custom error[^\n]*?
+[^\n]*?\[error\] [^\n]*? error setting property: unknown error[^\n]*?
+[^\n]*?\[error\] [^\n]*? error setting property: unknown error[^\n]*?
+[^\n]*?\[info\] [^\n]*? property not found: wasmx.fail1_property[^\n]*?$/
+--- no_error_log
+[crit]
+[alert]
+
+
+
+=== TEST 9: set_property_setter() - setter returning true on 3rd value caches result
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        access_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local counter = 0
+
+            local tbl = {}
+
+            local function setter(key, value)
+                counter = counter + 1
+
+                if value and #value > 0 then
+                    value = value:upper() .. " " .. tostring(counter)
+                end
+
+                tbl[key] = value
+
+                ngx.log(ngx.INFO, "setting ", key, " to ", value, ", counter: " .. counter)
+
+                return true, value, (key:match("const") and true or false)
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            local function getter(key)
+                counter = counter + 1
+
+                ngx.log(ngx.INFO, "getting ", key, " via getter, counter: ", counter)
+
+                local value = tbl[key]
+
+                if value and #value > 0 then
+                    value = value .. " " .. tostring(counter)
+                end
+
+                return true, value
+            end
+
+            assert(proxy_wasm.set_property_getter(getter))
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+
+        log_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+
+            local function log_property(k)
+                local v = proxy_wasm.get_property(k)
+                ngx.log(ngx.INFO, k, ": ", type(v), " \"", v, "\"")
+            end
+
+            -- two set_property operations, each will hit the setter.
+            -- four get_property operations,
+            -- but only wasmx.dyn_property will hit the getter
+            -- because the setter to wasmx.const_property cached the result.
+            proxy_wasm.set_property("wasmx.const_property", "hello") -- sets "HELLO 1"
+            log_property("wasmx.const_property") -- returns "HELLO 1"
+            proxy_wasm.set_property("wasmx.dyn_property", "hi") -- sets "HI 2"
+            log_property("wasmx.dyn_property") -- returns "HI 2 3"
+            log_property("wasmx.const_property") -- returns "HELLO 1"
+            log_property("wasmx.dyn_property") -- returns "HI 2 4"
+
+            proxy_wasm.set_property("wasmx.nil_const_property", nil) -- sets nil
+            log_property("wasmx.nil_const_property") -- returns nil
+            proxy_wasm.set_property("wasmx.nil_dyn_property", nil) -- sets nil
+            log_property("wasmx.nil_dyn_property") -- returns nil
+            log_property("wasmx.nil_const_property") -- returns nil
+            log_property("wasmx.nil_dyn_property") -- returns nil
+
+            proxy_wasm.set_property("wasmx.empty_const_property", "") -- sets ""
+            log_property("wasmx.empty_const_property") -- returns ""
+            proxy_wasm.set_property("wasmx.empty_dyn_property", "") -- sets ""
+            log_property("wasmx.empty_dyn_property") -- returns ""
+            log_property("wasmx.empty_const_property") -- returns ""
+            log_property("wasmx.empty_dyn_property") -- returns ""
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/.*wasmx.*property.*/
+--- grep_error_log_out eval
+qr/^[^\n]*?\[info\] [^\n]*? setting wasmx.const_property to HELLO 1, counter: 1[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "HELLO 1"[^\n]*?
+[^\n]*?\[info\] [^\n]*? setting wasmx.dyn_property to HI 2, counter: 2[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property via getter, counter: 3[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "HI 2 3"[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.const_property: string "HELLO 1"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.dyn_property via getter, counter: 4[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.dyn_property: string "HI 2 4"[^\n]*?
+[^\n]*?\[info\] [^\n]*? setting wasmx.nil_const_property to nil, counter: 5[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? setting wasmx.nil_dyn_property to nil, counter: 6[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property via getter, counter: 7[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_const_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.nil_dyn_property via getter, counter: 8[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.nil_dyn_property: nil "nil"[^\n]*?
+[^\n]*?\[info\] [^\n]*? setting wasmx.empty_const_property to , counter: 9[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? setting wasmx.empty_dyn_property to , counter: 10[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property via getter, counter: 11[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_const_property: string ""[^\n]*?
+[^\n]*?\[info\] [^\n]*? getting wasmx.empty_dyn_property via getter, counter: 12[^\n]*?
+[^\n]*?\[info\] [^\n]*? wasmx.empty_dyn_property: string ""[^\n]*?$/
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 10: set_property_setter() - errors in setter are caught by pcall in Lua library and don't crash the worker
+--- wasm_modules: hostcalls
+--- http_config
+    init_worker_by_lua_block {
+        local proxy_wasm = require "resty.wasmx.proxy_wasm"
+        local filters = {
+            { name = "hostcalls" },
+        }
+
+        _G.c_plan = assert(proxy_wasm.new(filters))
+        assert(proxy_wasm.load(_G.c_plan))
+    }
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=response_body \
+                              test=/t/log/property \
+                              name=wasmx.my_property';
+
+        rewrite_by_lua_block {
+            local proxy_wasm = require "resty.wasmx.proxy_wasm"
+            assert(proxy_wasm.attach(_G.c_plan))
+
+            local tbl = {}
+
+            local function setter(key, value)
+                error("crash!")
+            end
+
+            assert(proxy_wasm.set_property_setter(setter))
+
+            local ok, err = proxy_wasm.set_property("wasmx.my_property", "my_value")
+            assert((not ok) and err == "unknown error")
+
+            assert(proxy_wasm.start())
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_response_body/,
+    qr/\[error\] .*? error setting property from Lua: rewrite_by_lua\(nginx.conf:[0-9]+\):[0-9]+: crash\!/,
+]
+--- no_error_log
+[emerg]

--- a/t/TestWasm.pm
+++ b/t/TestWasm.pm
@@ -2,7 +2,7 @@ package t::TestWasm;
 
 use strict;
 use Test::Nginx::Socket::Lua -Base;
-use Test::Nginx::Util qw(gen_rand_port);
+use Test::Nginx::Util qw(gen_rand_port $RunTestHelper);
 use List::Util qw(max);
 use Cwd qw(cwd);
 use Config;
@@ -33,6 +33,10 @@ our @EXPORT = qw(
     skip_valgrind
 );
 
+our $TestNginxRunTestHelper = $RunTestHelper;
+
+$RunTestHelper = \&run_test_helper;
+
 $ENV{TEST_NGINX_USE_HUP} ||= 0;
 $ENV{TEST_NGINX_USE_VALGRIND} ||= 0;
 $ENV{TEST_NGINX_USE_VALGRIND_ALL} ||= 0;
@@ -41,6 +45,13 @@ $ENV{TEST_NGINX_DATA_DIR} = "$pwd/t/data";
 $ENV{TEST_NGINX_CRATES_DIR} = $crates;
 $ENV{TEST_NGINX_UNIX_SOCKET} = html_dir() . "/nginx.sock";
 $ENV{TEST_NGINX_SERVER_PORT2} = gen_rand_port(1000);
+
+my %colors = (
+    UNEXPECTED => "\033[1;31m",
+    ERROR => "\033[1;33;41m",
+    FOUND => "\033[32m",
+    MATCH => "\033[1;41m"
+);
 
 sub skip_valgrind (@) {
     my ($skip) = @_;
@@ -253,6 +264,195 @@ add_block_preprocessor(sub {
         $block->set_value("timeout", $timeout);
     }
 });
+
+sub error_log_data () {
+    open my $in, $Test::Nginx::Util::ErrLogFile or
+        return undef;
+
+    my @lines = <$in>;
+
+    close $in;
+    return \@lines;
+}
+
+sub push_err($$$) {
+    my ($err_out, $str, $color) = @_;
+
+    if ($color ne "") {
+        push(@$err_out, $color);
+    }
+    push(@$err_out, $str);
+    if ($color ne "") {
+        push(@$err_out, "\033[0m");
+    }
+}
+
+sub run_test_helper ($$$) {
+    my ($block, $dry_run, $repeated_req_idx) = @_;
+    my $name = $block->name;
+
+    $TestNginxRunTestHelper->(@_);
+
+    if (defined $block->match_error_log) {
+        my $match_error_log = $block->match_error_log;
+
+        if (ref $match_error_log
+            && ref $match_error_log eq 'ARRAY'
+            && ref $match_error_log->[0]
+            && ref $match_error_log->[0] eq 'ARRAY'
+        ) {
+            $match_error_log = $match_error_log->[$repeated_req_idx];
+        }
+
+        my @substrings;
+        if (ref $match_error_log eq 'ARRAY') {
+            @substrings = @$match_error_log;
+        } else {
+            @substrings = split("\n", $match_error_log);
+        }
+        my $numSubstrings = @substrings;
+
+        my $match_pat;
+        my $match_pats = $block->match_error_log_grep;
+        if (!defined $match_pats) {
+            bail_out("$name - No --- match_error_log_grep defined but --- match_error_log is defined");
+        }
+
+        if (ref $match_pats && ref $match_pats eq 'ARRAY') {
+            $match_pat = $match_pats->[$repeated_req_idx];
+
+        } else {
+            $match_pat = $match_pats;
+        }
+
+        SKIP: {
+            skip "$name - error_log - tests skipped due to $dry_run", 1 if $dry_run;
+
+            my $lines;
+
+            $lines ||= error_log_data();
+
+            my @err_out = ();
+
+            my $i = 0;
+            my $failed = 0;
+            my $newline = 1;
+            my @missing = ();
+            for my $line (@$lines) {
+                if ($newline == 0 ||
+                    (ref $match_pat &&
+                     $line =~ /$match_pat/ ||
+                     $line =~ /\Q$match_pat\E/)
+                ) {
+                    if ($i >= $numSubstrings) {
+                        push_err(\@err_out, $line, "");
+                        if ($newline == 1) {
+                            push_err(\@err_out, "^---- no match declared for the line above.", $colors{"ERROR"});
+                            push_err(\@err_out, "\n", "");
+                        }
+                        $newline = 1;
+                        next;
+                    }
+
+                    my $expected_at = index($line, $substrings[$i]);
+
+                    my $earliest_i = -1;
+                    my $earliest_at = 2**32;
+                    for (my $j = 0; $j < $numSubstrings; $j++) {
+                        my $at = index($line, $substrings[$j]);
+                        if ($at != -1) {
+                            if ($at < $earliest_at) {
+                                $earliest_at = $at;
+                                $earliest_i = $j;
+                            }
+                        }
+                    }
+
+
+                    if ($earliest_i != -1) {
+                        my $earliest_len = length($substrings[$earliest_i]);
+                        my $expected_len = length($substrings[$i]);
+
+                        if ($expected_at != -1 && $earliest_at + $earliest_len >= $expected_at) {
+                            $earliest_i = $i;
+                            $earliest_len = $expected_len;
+                        }
+
+                        my $rest_at = $earliest_at + $earliest_len;
+
+                        push_err(\@err_out, substr($line, 0, $earliest_at), "");
+                        my $color;
+                        if ($earliest_i == $i) {
+                            $color = $colors{"FOUND"};
+                            $i++;
+                        } else {
+                            $color = $colors{"UNEXPECTED"};
+                            $failed = 1;
+                            push(@missing, $substrings[$i]);
+                            $i++;
+                        }
+                        push_err(\@err_out, substr($line, $earliest_at, $earliest_len), $color);
+
+                        $line = substr($line, $rest_at);
+                        if (length($line) > 0) {
+                            $newline = 0;
+                            redo;
+                        }
+
+                    } else {
+                        if ($newline) {
+                            $failed = 1;
+
+                            push(@missing, $substrings[$i]);
+                            $i++;
+                        }
+                    }
+
+                    push_err(\@err_out, $line, "");
+                    for my $p (@missing) {
+                        push_err(\@err_out, "^---- expected ", $colors{"ERROR"});
+                        push_err(\@err_out, $p, $colors{"MATCH"});
+                        push_err(\@err_out, " in line above.", $colors{"ERROR"});
+                        push_err(\@err_out, "\n", "");
+                    }
+                    @missing = ();
+                    $newline = 1;
+                }
+            }
+
+            # fail if we didn't find them all
+            if ($i < $numSubstrings) {
+                $failed = 1;
+                for (my $j = $i; $j < $numSubstrings; $j++) {
+                    push_err(\@err_out, "---- missing a match for ", $colors{"ERROR"});
+                    push_err(\@err_out, $substrings[$j], $colors{"MATCH"});
+                    push_err(\@err_out, "\n", "");
+                }
+            }
+
+            if ($failed == 1) {
+                fail("$name - match_error_log:\n" . join("", @err_out));
+            } else {
+                pass("$name - all substrings were matched in order in error.log");
+            }
+
+            # fail if we didn't find them all
+            if ($i < $numSubstrings) {
+
+                my $ord = ordinate($i);
+                my $missing = $substrings[$i];
+                SKIP: {
+                    skip "$name - error_log - tests skipped due to $dry_run", 1 if $dry_run;
+                }
+            } else {
+            }
+        }
+    } else {
+        if (defined $block->match_error_log_grep) {
+            bail_out("$name - No --- match_error_log defined but --- match_error_log_grep is defined");
+        }
+    }
+}
 
 no_long_string();
 


### PR DESCRIPTION
Many of our tests are too lenient on checking the ordering and number of occurrences of expected log messages. `grep_error_log_out` makes it possible to avoid the problems of `error_log_out`, but it is tricky to get it right.

For example, [this entry](https://github.com/Kong/ngx_wasm_module/blob/main/t/03-proxy_wasm/004-on_http_phases.t#L689-L700) is still too lenient, because the `.*` entries between lines can consume additional lines and miss unordered repeats.

Getting more robust entries using `grep_error_log_out` is possible, [at the cost of readability](https://github.com/Kong/ngx_wasm_module/blob/main/t/04-openresty/ffi/103-proxy_wasm_attach.t#L581-L605) — but even this example is still not enough (spot the use of `.*`?)... [This comes closer](https://github.com/Kong/ngx_wasm_module/pull/431/files#diff-b0bc3e75b5d8811ad572fd605a392cc12d18648037e6560ef345897122d36d66R530) ...but are we sure it's right?

This PR introduces **a new block handler, `match_error_log`**, where you give it an array of plain substrings (not regexes), and the test passes if and only if all occurrences of the given substrings in the error log match the given list in the exact order, including repeats.

This makes it easy to write more solid tests:

* unexpected repeats are caught
* entries out of order are caught
* regex mistakes due to special characters are avoided

The subset of relevant lines to be checked can be filtered by a regex using `match_error_log_grep`. If not given, the entire error.log is checked. Filtering makes it easier to test for things like `["[info]", "my message", "[info]", "another message"]` (ensuring there are no other `[info]` entries in between), but then the usual concerns about crafting careful regexes in `match_error_log_grep` to avoid undesired lines applies.

This PR includes the implementation commit, intended to be cherry-picked, and an example commit showcasing the use with and without the filtering.
