### PR TITLE
tests(*) switch Valgrind tests from opt-out to opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,17 +147,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        label: [""]
+        label: ["full"]
+        runtime: [wasmer]
+        wasmer: [3.1.1]
         os: [ubuntu-22.04]
         cc: [gcc-12]
         ngx: [1.25.3]
         openresty: [""]
-        runtime: [wasmer]
         wasmtime: [""]
-        wasmer: [3.1.1]
         v8: [""]
         hup: [no_hup, hup]
         debug: [debug]
+        path: [""]
         include:
           # Wasmtime
           - runtime: wasmtime
@@ -167,6 +168,7 @@ jobs:
             ngx: 1.25.3
             hup: no_hup
             debug: debug
+            path: t/01-wasm
           # V8
           - runtime: v8
             v8: 11.4.183.23
@@ -175,16 +177,18 @@ jobs:
             ngx: 1.25.3
             debug: debug
             hup: no_hup
+            path: t/01-wasm
           # OpenResty
           - label: openresty
+            runtime: wasmer
+            wasmer: 3.1.1
             os: ubuntu-22.04
             cc: gcc-12
             openresty: 1.21.4.2
             ngx:
-            runtime: wasmer
-            wasmer: 3.1.1
             debug: debug
             hup: no_hup
+            path: t/04-openresty
     uses: ./.github/workflows/job-valgrind-tests.yml
     with:
       os: ${{ matrix.os }}
@@ -197,6 +201,7 @@ jobs:
       v8: ${{ matrix.v8 }}
       hup: ${{ matrix.hup }}
       debug: ${{ matrix.debug }}
+      path: ${{ matrix.path }}
     secrets: inherit
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
       hup: ${{ matrix.hup }}
       debug: ${{ matrix.debug }}
       path: ${{ matrix.path }}
+      coverage: true
     secrets: inherit
 
   lint:

--- a/.github/workflows/job-unit-tests.yml
+++ b/.github/workflows/job-unit-tests.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: './lcov.info'
+          flags: unit
       - run: rm -f t/servroot/html/nginx.sock
         if: ${{ failure() && !env.ACT }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/job-valgrind-tests.yml
+++ b/.github/workflows/job-valgrind-tests.yml
@@ -49,6 +49,7 @@ env:
   CC: ${{ inputs.cc }}
   NGX: ${{ inputs.ngx }}
   NGX_BUILD_OPENRESTY: ${{ inputs.openresty }}
+  NGX_BUILD_GCOV: ${{ inputs.coverage && 1 || 0 }}
   NGX_BUILD_DEBUG: ${{ inputs.debug == 'debug' && 1 || 0 }}
   NGX_BUILD_CC_OPT: '-O2'
   NGX_BUILD_NOPOOL: 1
@@ -67,7 +68,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: 150
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y valgrind
+      - name: 'Setup deps - apt-get'
+        if: ${{ contains(inputs.os, 'ubuntu') }}
+        run: sudo apt-get update && sudo apt-get install -y valgrind ${CC} libstdc++-${CC#*-}-dev lcov
       - uses: actions/checkout@v3
       - name: 'Setup cache - rustup toolchain'
         uses: actions/cache@v3
@@ -123,6 +126,19 @@ jobs:
             cat valgrind.log >&2
             exit 1
           fi
+      - name: Run lcov
+        if: ${{ !env.ACT && inputs.coverage }}
+        run: |
+          lcov --gcov-tool gcov-${CC#*-} --capture --directory work/buildroot --output-file lcov.info
+          lcov --gcov-tool gcov-${CC#*-} --remove lcov.info "*/ngx_wasm_module/src/common/debug/*" --output-file lcov.info
+          lcov --gcov-tool gcov-${CC#*-} --extract lcov.info "*/ngx_wasm_module/src/*" --output-file lcov.info
+      - name: Codecov Upload
+        if: ${{ !env.ACT && inputs.coverage }}
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: './lcov.info'
+          flags: valgrind
       - run: rm -f t/servroot/html/nginx.sock
         if: ${{ failure() && !env.ACT }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/job-valgrind-tests.yml
+++ b/.github/workflows/job-valgrind-tests.yml
@@ -33,6 +33,13 @@ on:
       hup:
         required: true
         type: string
+      path:
+        required: false
+        type: string
+      coverage:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -46,8 +53,9 @@ env:
   NGX_BUILD_CC_OPT: '-O2'
   NGX_BUILD_NOPOOL: 1
   TEST_NGINX_USE_VALGRIND: 1
+  TEST_NGINX_USE_VALGRIND_ALL: 0
   TEST_NGINX_USE_HUP: ${{ inputs.hup == 'hup' && 1 || 0 }}
-  TEST_NGINX_RANDOMIZE: 1
+  TEST_NGINX_RANDOMIZE: ${{ github.run_attempt == '1' && 1 || 0 }}
   TEST_NGINX_NO_CLEAN: 1
   TEST_NGINX_TIMEOUT: 120
   TEST_NGINX_EXTERNAL_TIMEOUT: 120s
@@ -105,7 +113,10 @@ jobs:
           ghcr_password: ${{ secrets.TOKEN_GITHUB }}
       - run: make setup
       - run: make
-      - run: make test 2>&1 | tee valgrind.out
+      - name: Run tests
+        run: |
+           IN_PATH="${{ inputs.path }}"
+           ./util/test.sh ${IN_PATH:-t/} 2>&1 | tee valgrind.out
       - run: |
           awk -f ./util/parse-valgrind.awk valgrind.out > valgrind.log
           if [[ -s valgrind.log ]]; then

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -21,6 +21,7 @@ environments yet and may still need refinements; reports are very much welcome.
     - [Run building tests](#run-building-tests)
     - [Run individual tests](#run-individual-tests)
     - [Debug a test case](#debug-a-test-case)
+    - [Valgrind test cases](#valgrind-test-cases)
 - [CI](#ci)
     - [Running the CI locally](#running-the-ci-locally)
 - [Sources](#sources)
@@ -451,6 +452,22 @@ $ gdb -ex 'b ngx_wasm_symbol' -ex 'r -g "daemon off;"' work/buildroot/nginx
 
 Here, `daemon off` is one way of ensuring that the master process does not fork
 into a daemon, so that the debugging session remains uninterrupted.
+
+[Back to TOC](#table-of-contents)
+
+### Valgrind test cases
+
+When the environment variable `TEST_NGINX_USE_VALGRIND=1` is set, the test suite
+will run in Valgrind mode and check for memory-related issues. Only test cases
+with the `--- valgrind` block will be run.
+
+Only some tests are enabled in Valgrind mode so as to make the test suites run
+in a reasonable amount of time. As a rule of thumb, only enable test cases to
+run in Valgrind mode (i.e. `--- valgrind` block) when the tested code path
+includes C-level ngx_wasm_module code with potential for memory allocations or
+invalid memory reads/writes. Avoid enabling too many test cases with the same
+code path: many different unit tests may all end-up taking the same code paths
+from a memory-checking perspective.
 
 [Back to TOC](#table-of-contents)
 

--- a/t/01-wasm/001-wasm_block.t
+++ b/t/01-wasm/001-wasm_block.t
@@ -4,13 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: wasm{} - empty block
+--- valgrind
 --- main_config
     wasm {}
 --- error_log

--- a/t/01-wasm/002-shm_queue_sanity.t
+++ b/t/01-wasm/002-shm_queue_sanity.t
@@ -6,16 +6,15 @@ use t::TestWasm;
 
 workers(2);
 master_on();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: queue - with minimum size
---- skip_no_debug: 5
+--- valgrind
+--- skip_no_debug
 --- main_config
     wasm {
         shm_queue test 12288;

--- a/t/01-wasm/003-shm_kv_sanity.t
+++ b/t/01-wasm/003-shm_kv_sanity.t
@@ -6,16 +6,15 @@ use t::TestWasm;
 
 workers(2);
 master_on();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: kv - with minimum size
---- skip_no_debug: 5
+--- valgrind
+--- skip_no_debug
 --- main_config
     wasm {
         shm_kv test 12288;
@@ -30,7 +29,7 @@ __DATA__
 
 
 === TEST 2: kv - with default namespace
---- skip_no_debug: 5
+--- skip_no_debug
 --- main_config
     wasm {
         shm_kv * 12288;

--- a/t/01-wasm/004-runtime_blocks.t
+++ b/t/01-wasm/004-runtime_blocks.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -42,6 +41,7 @@ qr/setting flag: "debug_info=on"/
 
 
 === TEST 3: wasmtime{} - multiple flag directives
+--- valgrind
 --- skip_eval: 5: $::nginxV !~ m/wasmtime/
 --- main_config
     wasm {

--- a/t/01-wasm/directives/001-module_directive.t
+++ b/t/01-wasm/directives/001-module_directive.t
@@ -6,15 +6,14 @@ use t::TestWasm;
 
 our $nginxV = $t::TestWasm::nginxV;
 
-plan tests => repeat_each() * (blocks() * 4);
+no_shuffle();
 
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: module directive - valid .wasm module
-Too slow for Valgrind
---- skip_valgrind: 4
 --- main_config eval
 qq{
     wasm {
@@ -49,7 +48,7 @@ qr/\[info\] .*? \[wasm\] loading "a" module <vm: "main", runtime: ".*?">/
 
 
 === TEST 3: module directive - multiple valid modules
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;

--- a/t/01-wasm/directives/002-compiler_directive.t
+++ b/t/01-wasm/directives/002-compiler_directive.t
@@ -4,12 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
 our $nginxV = $t::TestWasm::nginxV;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/directives/003-shm_directives.t
+++ b/t/01-wasm/directives/003-shm_directives.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: shm directive - kv sanity
+--- valgrind
 --- main_config
     wasm {
         shm_kv my_kv_1 1m;
@@ -27,6 +25,7 @@ __DATA__
 
 
 === TEST 2: shm directive - queue sanity
+--- valgrind
 --- main_config
     wasm {
         shm_queue my_queue_1 1m;

--- a/t/01-wasm/directives/004-resolver_directive.t
+++ b/t/01-wasm/directives/004-resolver_directive.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: resolver directive - sanity
+--- valgrind
 --- main_config
     wasm {
         resolver 8.8.8.8;

--- a/t/01-wasm/directives/005-socket_directives.t
+++ b/t/01-wasm/directives/005-socket_directives.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/directives/006-backtraces_directive.t
+++ b/t/01-wasm/directives/006-backtraces_directive.t
@@ -4,13 +4,10 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
+our $n = 30;
 our $nginxV = $t::TestWasm::nginxV;
 
-our $n = 30;
-plan tests => repeat_each() * (blocks() * $n);
-
+plan_tests($n);
 run_tests();
 
 __DATA__
@@ -135,6 +132,7 @@ for my $i (24..$::n) {
 
 
 === TEST 4: backtraces directive - wasmtime 'cranelift', backtraces 'off', WASMTIME_BACKTRACE_DETAILS=1
+--- valgrind
 --- skip_eval: 30: $::nginxV !~ m/wasmtime/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -278,6 +276,7 @@ for my $i (17..$::n) {
 
 
 === TEST 7: backtraces directive - wasmer 'singlepass', backtraces 'on'
+--- valgrind
 --- skip_eval: 30: $::nginxV !~ m/wasmer/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -415,6 +414,7 @@ for my $i (18..$::n) {
 
 
 === TEST 10: backtraces directive - v8 'auto', backtraces 'on'
+--- valgrind
 --- skip_eval: 30: $::nginxV !~ m/v8/
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval

--- a/t/01-wasm/directives/007-flag_directive.t
+++ b/t/01-wasm/directives/007-flag_directive.t
@@ -37,8 +37,7 @@ our $unknownFlagsConf = "
     }
 ";
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/directives/008-flag_directive_wasmtime.t
+++ b/t/01-wasm/directives/008-flag_directive_wasmtime.t
@@ -4,12 +4,8 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
 our $nginxV = $t::TestWasm::nginxV;
 our $osname = $t::TestWasm::osname;
-
-plan tests => repeat_each() * (blocks() * 4);
 
 add_cleanup_handler(sub {
     my @jit_dumps = glob("$::pwd/jit-*.dump");
@@ -20,6 +16,7 @@ add_cleanup_handler(sub {
     }
 });
 
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/directives/009-flag_directive_wasmer.t
+++ b/t/01-wasm/directives/009-flag_directive_wasmer.t
@@ -4,12 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
 our $nginxV = $t::TestWasm::nginxV;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/directives/010-flag_directive_v8.t
+++ b/t/01-wasm/directives/010-flag_directive_v8.t
@@ -4,12 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
 our $nginxV = $t::TestWasm::nginxV;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/001-log.t
+++ b/t/01-wasm/hfuncs/001-log.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 3);
-
 add_block_preprocessor(sub {
     my $block = shift;
     my $main_config = <<_EOC_;
@@ -21,11 +17,13 @@ _EOC_
     }
 });
 
+plan_tests(3);
 run_tests();
 
 __DATA__
 
 === TEST 1: log: logs in 'log' phase
+--- valgrind
 --- config
     location /t {
         wasm_call log ngx_rust_tests log_notice_hello;

--- a/t/01-wasm/hfuncs/wasi/000-non_host_wasi.t
+++ b/t/01-wasm/hfuncs/wasi/000-non_host_wasi.t
@@ -6,8 +6,7 @@ use t::TestWasm;
 
 our $nginxV = $t::TestWasm::nginxV;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/001-random_get.t
+++ b/t/01-wasm/hfuncs/wasi/001-random_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/002-environ_sizes_get.t
+++ b/t/01-wasm/hfuncs/wasi/002-environ_sizes_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/003-environ_get.t
+++ b/t/01-wasm/hfuncs/wasi/003-environ_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/004-clock_time_get.t
+++ b/t/01-wasm/hfuncs/wasi/004-clock_time_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/005-args_sizes_get.t
+++ b/t/01-wasm/hfuncs/wasi/005-args_sizes_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/006-args_get.t
+++ b/t/01-wasm/hfuncs/wasi/006-args_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/007-fd_write.t
+++ b/t/01-wasm/hfuncs/wasi/007-fd_write.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/008-fd_close.t
+++ b/t/01-wasm/hfuncs/wasi/008-fd_close.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/009-fd_fdstat_get.t
+++ b/t/01-wasm/hfuncs/wasi/009-fd_fdstat_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/010-fd_prestat_get.t
+++ b/t/01-wasm/hfuncs/wasi/010-fd_prestat_get.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/011-fd_prestat_dir_name.t
+++ b/t/01-wasm/hfuncs/wasi/011-fd_prestat_dir_name.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/012-fd_read.t
+++ b/t/01-wasm/hfuncs/wasi/012-fd_read.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/013-fd_seek.t
+++ b/t/01-wasm/hfuncs/wasi/013-fd_seek.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/01-wasm/hfuncs/wasi/014-path_open.t
+++ b/t/01-wasm/hfuncs/wasi/014-path_open.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/02-http/001-sanity.t
+++ b/t/02-http/001-sanity.t
@@ -4,13 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1:
+--- valgrind
 --- config
     location /t {
         root html;

--- a/t/02-http/002-wasm_oob.t
+++ b/t/02-http/002-wasm_oob.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/02-http/003-produced_response_headers.t
+++ b/t/02-http/003-produced_response_headers.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 7);
-
 add_block_preprocessor(sub {
     my $block = shift;
 
@@ -17,6 +13,7 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(7);
 run_tests();
 
 __DATA__
@@ -24,7 +21,8 @@ __DATA__
 === TEST 1: produce default response headers
 should produce some of the default headers otherwise
 injected too late by ngx_http_header_filter
---- skip_no_debug: 7
+--- valgrind
+--- skip_no_debug
 --- wasm_modules: ngx_rust_tests
 --- config
     location /t {
@@ -94,7 +92,7 @@ hello say
 
 
 === TEST 5: produce 'Last-Modified' response header
---- skip_no_debug: 7
+--- skip_no_debug
 --- wasm_modules: ngx_rust_tests
 --- config
     location /t {

--- a/t/02-http/100-filters_coverage.t
+++ b/t/02-http/100-filters_coverage.t
@@ -6,8 +6,7 @@ use t::TestWasm;
 
 skip_no_debug();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/02-http/directives/001-wasm_call_directive.t
+++ b/t/02-http/directives/001-wasm_call_directive.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -196,7 +195,6 @@ qr/\[error\] .*? no "nonexist" function in "a" module/
 
 
 === TEST 11: wasm_call directive - catch runtime error sanity
---- valgrind_track_register_updates
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -224,7 +222,7 @@ qr/(\[error\] .*? integer divide by zero|wasm trap: integer divide by zero|Uncau
 
 
 === TEST 12: wasm_call directive - sanity 'rewrite' phase in location{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -248,7 +246,7 @@ wasm ops calling "a.nop" in "rewrite" phase
 
 
 === TEST 13: wasm_call directive - sanity 'content' phase in location{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config
     wasm {
@@ -273,7 +271,7 @@ wasm ops calling "a.nop" in "content" phase
 
 
 === TEST 14: wasm_call directive - sanity 'log' phase in location{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -297,7 +295,7 @@ wasm ops calling "a.nop" in "log" phase
 
 
 === TEST 15: wasm_call directive - multiple calls in location{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -322,7 +320,7 @@ wasm ops calling "a.nop" in "log" phase
 
 
 === TEST 16: wasm_call directive - multiple calls in server{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -348,7 +346,7 @@ wasm ops calling "a.nop" in "log" phase
 
 
 === TEST 17: wasm_call directive - multiple calls in http{} block
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -374,7 +372,7 @@ wasm ops calling "a.nop" in "log" phase
 
 
 === TEST 18: wasm_call directive - mixed server{} and location{} blocks
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -401,7 +399,7 @@ wasm ops calling "a.nocall" in "log" phase
 
 
 === TEST 19: wasm_call directive - multiple modules/calls/phases/blocks
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config
     wasm {
         module moduleA $TEST_NGINX_HTML_DIR/a.wat;

--- a/t/02-http/directives/002-resolver_add_directive.t
+++ b/t/02-http/directives/002-resolver_add_directive.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/02-http/hfuncs/001-resp_get_status.t
+++ b/t/02-http/hfuncs/001-resp_get_status.t
@@ -4,8 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
 add_block_preprocessor(sub {
     my $block = shift;
     my $main_config = <<_EOC_;
@@ -19,6 +17,7 @@ _EOC_
     }
 });
 
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/02-http/hfuncs/002-resp_set_status.t
+++ b/t/02-http/hfuncs/002-resp_set_status.t
@@ -4,8 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
 add_block_preprocessor(sub {
     my $block = shift;
     my $main_config = <<_EOC_;
@@ -19,6 +17,7 @@ _EOC_
     }
 });
 
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/02-http/hfuncs/003-say.t
+++ b/t/02-http/hfuncs/003-say.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/02-http/hfuncs/004-local_response.t
+++ b/t/02-http/hfuncs/004-local_response.t
@@ -10,8 +10,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/001-on_root_phases.t
+++ b/t/03-proxy_wasm/001-on_root_phases.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/002-on_root_phases_failures.t
+++ b/t/03-proxy_wasm/002-on_root_phases_failures.t
@@ -4,11 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-my $n = 4;
-plan tests => repeat_each() * (blocks() * $n);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -17,7 +13,7 @@ __DATA__
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: $n: $ENV{TEST_NGINX_USE_HUP} == 1
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -43,7 +39,7 @@ qq{
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: $n: $ENV{TEST_NGINX_USE_HUP} == 1
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -70,7 +66,7 @@ qq{
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: $n: $ENV{TEST_NGINX_USE_HUP} == 1
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {
@@ -96,7 +92,7 @@ qq{
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
---- skip_eval: $n: $ENV{TEST_NGINX_USE_HUP} == 1
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
 --- main_config eval
 qq{
     wasm {

--- a/t/03-proxy_wasm/003-on_tick.t
+++ b/t/03-proxy_wasm/003-on_tick.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 7);
-
+plan_tests(7);
 run_tests();
 
 __DATA__
@@ -13,6 +12,7 @@ __DATA__
 === TEST 1: proxy_wasm - on_tick
 Tick is triggered even without hitting the configured location
 since it runs at root level context.
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config
     wasm {
@@ -158,7 +158,8 @@ qr/.*?(\[error\]|Uncaught RuntimeError: |\s+)tick_period already set.*
 === TEST 6: proxy_wasm - on_tick with trap
 Should recycle the tick instance
 Should not prevent http context/instance from starting
---- skip_no_debug: 7
+--- valgrind
+--- skip_no_debug
 --- wasm_modules: on_phases
 --- config
     location /t {

--- a/t/03-proxy_wasm/004-on_http_phases.t
+++ b/t/03-proxy_wasm/004-on_http_phases.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -31,6 +30,7 @@ qr/\[info\] .*? on_request_headers, 3 headers/
 
 
 === TEST 2: proxy_wasm - on_request_body gets number of bytes in body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config
@@ -519,7 +519,7 @@ on_log
 
 === TEST 22: proxy_wasm - as a chained subrequest
 should invoke wasm ops "done" phase to destroy proxy-wasm ctxid in "content" phase
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config
@@ -552,7 +552,7 @@ on_log
 
 
 === TEST 23: proxy_wasm - as a chained subrequest (logged)
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config
@@ -639,7 +639,7 @@ on_log
 
 === TEST 25: proxy_wasm - chained filters in same location{} block
 should run each filter after the other within each phase
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config

--- a/t/03-proxy_wasm/005-on_http_phases_failures.t
+++ b/t/03-proxy_wasm/005-on_http_phases_failures.t
@@ -5,10 +5,7 @@ use lib '.';
 use t::TestWasm;
 use Test::Nginx::Socket skip_all => 'HTTP trailers support is not ready yet';
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/006-on_http_next_action.t
+++ b/t/03-proxy_wasm/006-on_http_next_action.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -5,16 +5,15 @@ use lib '.';
 use t::TestWasm;
 
 skip_no_debug();
-skip_valgrind('wasmtime');
 
-plan tests => repeat_each() * (blocks() * 8);
-
+plan_tests(8);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - default isolation mode (none)
 should use a global instance reused across streams
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -71,6 +70,7 @@ qr/\A\*\d+ .*? filter reusing instance[^#*]*
 
 === TEST 2: proxy_wasm - trap with none isolation mode
 Should recycle the global instance when trapped.
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -118,6 +118,7 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 
 === TEST 3: proxy_wasm - stream isolation mode
 should use an instance per stream
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     proxy_wasm_isolation stream;
@@ -181,6 +182,7 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 
 
 === TEST 4: proxy_wasm - trap with stream isolation mode
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -314,6 +316,7 @@ on_request_headers A: 123000 + 1
 on_request_headers B: 123000 + 1
 on_log A: 123001
 on_log B: 123001
+--- valgrind
 --- wasm_modules: instance_lifecycle
 --- config
     proxy_wasm_isolation filter;

--- a/t/03-proxy_wasm/008-proxy_wasm_oob.t
+++ b/t/03-proxy_wasm/008-proxy_wasm_oob.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 3);
-
+plan_tests(3);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/100-flag_req_headers_in_access.t
+++ b/t/03-proxy_wasm/100-flag_req_headers_in_access.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -32,7 +31,7 @@ qr/\[info\] .*? on_request_headers, 3 headers/
 
 
 === TEST 2: proxy_wasm - on_request_headers in access - dispatch_http_call()
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -61,7 +60,7 @@ qr/proxy_wasm pausing in \"access\" phase/
 
 
 === TEST 3: proxy_wasm - on_request_headers in rewrite - dispatch_http_call()
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/directives/001-proxy_wasm_directive.t
+++ b/t/03-proxy_wasm/directives/001-proxy_wasm_directive.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
@@ -204,7 +201,7 @@ qr/\[emerg\] .*? \[proxy-wasm\] failed loading "a" filter \(incompatible ABI ver
 
 
 === TEST 9: proxy_wasm directive - single entry in location{} block
---- skip_no_debug: 6
+--- skip_no_debug
 --- wasm_modules: on_tick
 --- config
     location /t {
@@ -226,7 +223,7 @@ qr/\[emerg\] .*? \[proxy-wasm\] failed loading "a" filter \(incompatible ABI ver
 === TEST 10: proxy_wasm directive - duplicate entries in location{} block
 should be accepted
 should create two instances of the same module
---- skip_no_debug: 6
+--- skip_no_debug
 --- wasm_modules: on_tick
 --- config
     location /t {

--- a/t/03-proxy_wasm/directives/002-proxy_wasm_isolation_directive.t
+++ b/t/03-proxy_wasm/directives/002-proxy_wasm_isolation_directive.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/directives/003-proxy_wasm_lua_resolver_directive.t
+++ b/t/03-proxy_wasm/directives/003-proxy_wasm_lua_resolver_directive.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/000-nyi.t
+++ b/t/03-proxy_wasm/hfuncs/000-nyi.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/001-get_vm_configuration.t
+++ b/t/03-proxy_wasm/hfuncs/001-get_vm_configuration.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -31,6 +28,7 @@ cannot parse vm config
 
 
 === TEST 2: proxy_wasm - get_vm_configuration() on_vm_start, with config
+--- valgrind
 --- main_config eval
 qq{
     wasm {

--- a/t/03-proxy_wasm/hfuncs/100-proxy_log.t
+++ b/t/03-proxy_wasm/hfuncs/100-proxy_log.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 9);
-
+plan_tests(9);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/101-proxy_get_current_time.t
+++ b/t/03-proxy_wasm/hfuncs/101-proxy_get_current_time.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/102-proxy_send_local_response.t
+++ b/t/03-proxy_wasm/hfuncs/102-proxy_send_local_response.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
@@ -193,6 +190,7 @@ Hello world
 
 
 === TEST 9: proxy_wasm - send_local_response() response headers with body
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/103-proxy_get_http_request_headers.t
+++ b/t/03-proxy_wasm/hfuncs/103-proxy_get_http_request_headers.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
@@ -59,6 +56,7 @@ Hello: world
 
 === TEST 3: proxy_wasm - get_http_request_headers() many headers
 should produce a response with 20+ headers
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/104-proxy_get_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/104-proxy_get_http_response_headers.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
 add_block_preprocessor(sub {
     my $block = shift;
 
@@ -17,6 +13,7 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -69,6 +66,7 @@ resp Date: .*? GMT.*/
 
 
 === TEST 2: proxy_wasm - get_http_response_headers() includes added headers
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/105-proxy_get_http_request_header.t
+++ b/t/03-proxy_wasm/hfuncs/105-proxy_get_http_request_header.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 8);
-
+plan_tests(8);
 run_tests();
 
 __DATA__
@@ -100,6 +97,7 @@ GET /t/echo/header/:path
 
 === TEST 5: proxy_wasm - get_http_request_header() retrieves ':path' from r->uri (parsed)
 URI component should be normalized
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -121,6 +119,7 @@ GET //t/echo//header/:path
 
 === TEST 6: proxy_wasm - get_http_request_header() retrieves ':path' with r->args (querystring)
 Path should include querystring
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -288,6 +287,7 @@ qq{
 
 === TEST 12: proxy_wasm - get_http_request_header() many headers
 Covers large list manipulation
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/106-proxy_get_http_response_header.t
+++ b/t/03-proxy_wasm/hfuncs/106-proxy_get_http_response_header.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - get_http_response_header() retrieves case insensitive header
+--- valgrind
 --- load_nginx_modules: ngx_http_headers_more_filter_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/107-proxy_add_http_request_header.t
+++ b/t/03-proxy_wasm/hfuncs/107-proxy_add_http_request_header.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 6);
-
 add_block_preprocessor(sub {
     my $block = shift;
 
@@ -17,6 +13,7 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/108-proxy_add_http_response_header.t
+++ b/t/03-proxy_wasm/hfuncs/108-proxy_add_http_response_header.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
 add_block_preprocessor(sub {
     my $block = shift;
 
@@ -17,12 +13,14 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - add_http_response_header() adds a new non-builtin header
 should add a response header visible in the second filter
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -248,6 +246,7 @@ qr/\[error\] .*? \[wasm\] attempt to set invalid Content-Length response header:
 
 === TEST 10: proxy_wasm - add_http_response_header() cannot add invalid Content-Length header
 should log an error but not produce a trap
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/109-proxy_set_http_request_headers.t
+++ b/t/03-proxy_wasm/hfuncs/109-proxy_set_http_request_headers.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -39,6 +36,7 @@ Welcome: wasm
 === TEST 2: proxy_wasm - set_http_request_headers() sets special request headers
 should set request headers, even if they receive special treatment
 should set special keys headers (e.g. :path)
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -68,6 +66,7 @@ request header ":path: /updated"
 
 
 === TEST 3: proxy_wasm - set_http_request_headers() cannot set invalid special request headers
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -84,6 +83,7 @@ qr/\[error\] .*? \[wasm\] cannot set read-only ":scheme" header/
 
 
 === TEST 4: proxy_wasm - set_http_request_headers() sets headers when many headers exist
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/110-proxy_set_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/110-proxy_set_http_response_headers.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -50,6 +47,7 @@ resp Welcome: wasm.*/
 
 
 === TEST 2: proxy_wasm - set_http_response_headers() sets special response headers
+--- valgrind
 --- load_nginx_modules: ngx_http_headers_more_filter_module
 --- wasm_modules: ngx_rust_tests hostcalls
 --- config
@@ -87,6 +85,7 @@ resp Server: proxy-wasm.*/
 
 === TEST 3: proxy_wasm - set_http_response_headers() cannot set invalid Connection header
 should log an error but not produce a trap
+--- valgrind
 --- wasm_modules: ngx_rust_tests hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/111-proxy_set_http_request_header.t
+++ b/t/03-proxy_wasm/hfuncs/111-proxy_set_http_request_header.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - set_http_request_header() sets a new non-builtin header
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -57,6 +55,7 @@ qr/.*? on_request_headers, 2 headers.*
 
 
 === TEST 3: proxy_wasm - set_http_request_header() sets a non-builtin headers when many headers exist
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {

--- a/t/03-proxy_wasm/hfuncs/112-proxy_set_http_response_header.t
+++ b/t/03-proxy_wasm/hfuncs/112-proxy_set_http_response_header.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -87,6 +84,7 @@ on_response_headers, 5 headers.*
 
 
 === TEST 4: proxy_wasm - set_http_response_header() sets the same non-builtin header multiple times
+--- valgrind
 --- load_nginx_modules: ngx_http_headers_more_filter_module
 --- wasm_modules: hostcalls
 --- config
@@ -147,6 +145,7 @@ resp hello: wasm.*/
 
 
 === TEST 6: proxy_wasm - set_http_response_header() sets Connection header (close)
+--- valgrind
 --- wasm_modules: hostcalls
 --- config
     location /t {
@@ -256,6 +255,7 @@ qr/.*? on_response_headers, 5 headers.*
 
 
 === TEST 10: proxy_wasm - set_http_response_header() removes Last-Modified header when no value
+--- valgrind
 --- load_nginx_modules: ngx_http_headers_more_filter_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/113-proxy_get_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/113-proxy_get_http_request_body.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - get_http_request_body() retrieves request body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -90,6 +88,7 @@ qr/\[info\] .*? \[wasm\] request body:/
 
 
 === TEST 5: proxy_wasm - get_http_request_body() from a subrequest with body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/114-proxy_set_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/114-proxy_set_http_request_body.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -100,6 +97,7 @@ Hello world
 
 
 === TEST 5: proxy_wasm - set_http_request_body() with offset argument
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -158,6 +156,7 @@ LAST
 
 
 === TEST 6: proxy_wasm - set_http_request_body() with max argument
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/115-proxy_get_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/115-proxy_get_http_response_body.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -37,6 +34,7 @@ on_response_body, 0 bytes, eof: true.*/
 
 
 === TEST 2: proxy_wasm - get_http_response_body() retrieves chunked response body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -102,6 +100,7 @@ on_response_body, 0 bytes, eof: true.*
 
 
 === TEST 5: proxy_wasm - get_http_response_body() truncates body if longer than max_size
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/116-proxy_set_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/116-proxy_set_http_response_body.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 7);
-
+plan_tests(7);
 run_tests();
 
 __DATA__
@@ -149,6 +146,7 @@ on_response_body, 0 bytes, eof: true.*/
 
 
 === TEST 5: proxy_wasm - set_http_response_body() with offset argument
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -217,6 +215,7 @@ on_response_body, 0 bytes, eof: true.*/
 
 
 === TEST 6: proxy_wasm - set_http_response_body() with max argument
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
+++ b/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
@@ -4,10 +4,6 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
 our $request_properties = join(',', qw(
     request.path
     request.url_path
@@ -25,11 +21,13 @@ our $request_properties = join(',', qw(
     request.total_size
 ));
 
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - get_property() - request properties on: request_headers
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval
@@ -210,6 +208,7 @@ qr/$checks/
 
 
 === TEST 5: proxy_wasm - get_property() - response properties on: response_headers, response_body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/118-proxy_properties_get_nyi.t
+++ b/t/03-proxy_wasm/hfuncs/118-proxy_properties_get_nyi.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
@@ -4,15 +4,12 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
 our $nginx_variables = join(',', qw(
     ngx.pid
     ngx.hostname
 ));
 
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -22,6 +19,7 @@ __DATA__
 All get_property calls for Nginx variables return strings, so this should print
 the $pid as ASCII numbers.
 
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config eval

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - get_property() wasmx - property on: request_headers, request_body, response_headers, response_body, log
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/121-proxy_properties_set.t
+++ b/t/03-proxy_wasm/hfuncs/121-proxy_properties_set.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - set_property() - non-changeable property: request_headers
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config eval

--- a/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_ngx.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - set_property() ngx.* - indexed variable on: request_headers, request_body, response_headers, response_body, log
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -67,6 +65,7 @@ qr/\A\[info\] .*? old: "1"
 
 
 === TEST 2: proxy_wasm - set_property() ngx.* - indexed variable with set_handler on: request_headers
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm - set_property() wasmx - host property on: request_headers, request_body, response_headers, response_body, log
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -65,6 +63,7 @@ qr/\A\[info\] .*? new: "2"
 
 
 === TEST 2: proxy_wasm - set_property() wasmx - unset a host property on: request_headers
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -90,6 +89,7 @@ qr/\A\[info\] .*? new: "2"
 
 
 === TEST 3: proxy_wasm - set_property() wasmx - set a host property to an empty string
+--- valgrind
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config

--- a/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
@@ -7,10 +7,7 @@ use t::TestWasm;
 our $ExtResolver = $t::TestWasm::extresolver;
 our $ExtTimeout = $t::TestWasm::exttimeout;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -341,6 +338,7 @@ Hello back
 
 === TEST 18: proxy_wasm - dispatch_http_call() sanity unix domain socket
 :authority set to "localhost"
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config eval
@@ -382,6 +380,7 @@ Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
+--- valgrind
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -475,6 +474,7 @@ qq{
 
 
 === TEST 22: proxy_wasm - dispatch_http_call() resolver error (host not found)
+--- valgrind
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -522,6 +522,7 @@ ok
 
 
 === TEST 24: proxy_wasm - dispatch_http_call() sanity IP + port (IPv6)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -657,7 +658,7 @@ K: 11.*
 
 
 === TEST 28: proxy_wasm - dispatch_http_call() empty response body (HTTP 204)
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -686,7 +687,7 @@ tcp socket closing
 
 
 === TEST 29: proxy_wasm - dispatch_http_call() empty response body (Content-Length: 0)
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module ngx_http_headers_more_filter_module
 --- wasm_modules: hostcalls
 --- config
@@ -714,7 +715,7 @@ tcp socket closing
 
 
 === TEST 30: proxy_wasm - dispatch_http_call() no response body (HEAD)
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -792,6 +793,7 @@ Content-Length: 0.*
 
 
 === TEST 33: proxy_wasm - dispatch_http_call() large response
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -818,7 +820,8 @@ Content-Length: 0.*
 
 
 === TEST 34: proxy_wasm - dispatch_http_call() small wasm_socket_buffer_size
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -846,6 +849,7 @@ tcp socket trying to receive data (max: 1)
 
 
 === TEST 35: proxy_wasm - dispatch_http_call() small wasm_socket_large_buffers
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -873,7 +877,8 @@ Hello world
 
 
 === TEST 36: proxy_wasm - dispatch_http_call() too small wasm_socket_large_buffers
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -901,7 +906,8 @@ tcp socket - upstream response headers too large, increase wasm_socket_large_buf
 
 
 === TEST 37: proxy_wasm - dispatch_http_call() too small wasm_socket_large_buffers size
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -929,6 +935,7 @@ tcp socket - upstream response headers too large, increase wasm_socket_large_buf
 
 
 === TEST 38: proxy_wasm - dispatch_http_call() not enough wasm_socket_large_buffers
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- tcp_listen: 12345
@@ -960,7 +967,8 @@ sub {
 
 
 === TEST 39: proxy_wasm - dispatch_http_call() scarce wasm_socket_large_buffers
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -988,6 +996,7 @@ tcp socket trying to receive data (max: 1023)
 
 
 === TEST 40: proxy_wasm - dispatch_http_call() TCP reader error
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- tcp_listen: 12345
@@ -1012,7 +1021,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser 
 
 
 === TEST 41: proxy_wasm - dispatch_http_call() re-entrant after status line
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -1040,6 +1049,7 @@ tcp socket trying to receive data (max: 1017)
 
 
 === TEST 42: proxy_wasm - dispatch_http_call() trap in dispatch handler
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -1140,6 +1150,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser 
 
 === TEST 45: proxy_wasm - dispatch_http_call() can be chained by different filters
 So long as these filters do not produce content.
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -1172,6 +1183,7 @@ qr/^\*\d+ .*? on_http_call_response \(id: \d+[^*]*
 
 
 === TEST 46: proxy_wasm - dispatch_http_call() supports get_http_call_response_headers()
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -1239,6 +1251,7 @@ qr/^\*\d+ .*? on_http_call_response \(id: \d+, status: 200[^*]*
 
 
 === TEST 48: proxy_wasm - dispatch_http_call() with dispatched request body
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -1292,7 +1305,7 @@ helloworl
 
 
 === TEST 50: proxy_wasm - dispatch_http_call() cannot override hard-coded request headers
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/131-proxy_dispatch_http_timeouts.t
+++ b/t/03-proxy_wasm/hfuncs/131-proxy_dispatch_http_timeouts.t
@@ -14,10 +14,7 @@ use t::TestWasm;
 our $ExtResolver = $t::TestWasm::extresolver;
 our $ExtTimeout = $t::TestWasm::exttimeout;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/132-proxy_dispatch_http_ssl.t
+++ b/t/03-proxy_wasm/hfuncs/132-proxy_dispatch_http_ssl.t
@@ -8,9 +8,6 @@ our $ExtResolver = $t::TestWasm::extresolver;
 our $ExtTimeout = $t::TestWasm::exttimeout;
 
 skip_no_ssl();
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
 
 add_block_preprocessor(sub {
     my $block = shift;
@@ -20,6 +17,7 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -101,7 +99,8 @@ ok
 
 
 === TEST 3: proxy_wasm - dispatch_https_call() sanity verify on, over TCP/IP
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -143,7 +142,8 @@ qr/verifying tls certificate for "hostname:\d+" \(sni: "hostname"\)/
 
 
 === TEST 4: proxy_wasm - dispatch_https_call() sanity verify on, over unix domain socket
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -220,7 +220,8 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls cer
 
 
 === TEST 6: proxy_wasm - dispatch_https_call() sanity check_host on
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -449,7 +450,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls cer
 
 
 === TEST 14: proxy_wasm - dispatch_https_call() SNI derived from host over TCP/IP
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -491,7 +492,7 @@ ok
 
 === TEST 15: proxy_wasm - dispatch_https_call() fail SNI derived from host with literal IPv4
 SNI cannot be an IP address.
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -526,7 +527,7 @@ qr/could not derive tls sni from host \("127\.0\.0\.1:\d+"\)/
 
 === TEST 16: proxy_wasm - dispatch_https_call() fail SNI derived from host with literal IPv6
 SNI cannot be an IP address.
---- skip_no_debug: 4
+--- skip_no_debug
 --- wasm_modules: hostcalls
 --- config
     listen              [::]:$TEST_NGINX_SERVER_PORT ssl;
@@ -555,7 +556,7 @@ qr/could not derive tls sni from host \("\[0:0:0:0:0:0:0:1\]:\d+"\)/
 
 
 === TEST 17: proxy_wasm - dispatch_https_call() SNI override with :authority over TCP/IP (debug)
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -637,7 +638,7 @@ ok
 
 === TEST 19: proxy_wasm - dispatch_https_call() SNI override with :authority over unix domain socket (debug)
 Unix sockets need to set :authority as SNI
---- skip_no_debug: 4
+--- skip_no_debug
 --- main_config eval
 qq{
     wasm {
@@ -721,6 +722,7 @@ ok
 
 
 === TEST 21: proxy_wasm - dispatch_https_call() sanity on_tick, verify off, warn on
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{
@@ -761,7 +763,7 @@ qq{
 
 
 === TEST 22: proxy_wasm - dispatch_https_call() sanity on_tick, verify on, check_host on
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{

--- a/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
@@ -40,6 +37,7 @@ called 2 times
 
 
 === TEST 2: proxy_wasm - dispatch_http_call() on dispatch response (2 subsequent calls)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -102,6 +100,7 @@ qr/on_root_http_call_response \(id: 0, status: 200, headers: 5, body_bytes: 12, 
 
 
 === TEST 4: proxy_wasm - dispatch_http_call() on_tick (10 calls)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/03-proxy_wasm/hfuncs/200-buffers_and_maps_bad_args.t
+++ b/t/03-proxy_wasm/hfuncs/200-buffers_and_maps_bad_args.t
@@ -4,8 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/002-set_tick_period.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/002-set_tick_period.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/100-proxy_log.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/100-proxy_log.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/113-proxy_get_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/113-proxy_get_http_request_body.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/114-proxy_set_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/114-proxy_set_http_request_body.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/115-proxy_get_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/115-proxy_get_http_response_body.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/116-proxy_set_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/116-proxy_set_http_response_body.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/130-proxy_dispatch_http.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/contexts/131-proxy_get_http_dispatch_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/131-proxy_get_http_dispatch_response_body.t
@@ -6,10 +6,8 @@ use t::TestWasm;
 
 skip_hup();
 skip_no_debug();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/shm/001-kv_get_set.t
+++ b/t/03-proxy_wasm/hfuncs/shm/001-kv_get_set.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 12);
-
+plan_tests(12);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm key/value shm - get existing and non-existing value
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: kv1 1m
@@ -83,6 +81,7 @@ ok
 
 
 === TEST 3: proxy_wasm key/value shm - set empty value vs delete value
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: kv1 1m
@@ -126,6 +125,7 @@ ok
 
 
 === TEST 4: proxy_wasm key/value shm - set empty value vs delete value (eviction=lru)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: kv1 1m eviction=lru
@@ -165,9 +165,6 @@ ok
 [crit]
 [emerg]
 [alert]
-[stub1]
-[stub2]
-[stub3]
 
 
 
@@ -200,6 +197,9 @@ ok
 [crit]
 [emerg]
 [alert]
+[stub]
+[stub]
+[stub]
 
 
 
@@ -260,6 +260,7 @@ ok
 
 
 === TEST 7: proxy_wasm key/value shm - set reusing node storage
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: kv1 1m

--- a/t/03-proxy_wasm/hfuncs/shm/002-kv_misuse.t
+++ b/t/03-proxy_wasm/hfuncs/shm/002-kv_misuse.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/shm/003-kv_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/shm/003-kv_edge_cases.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/shm/004-kv_eviction.t
+++ b/t/03-proxy_wasm/hfuncs/shm/004-kv_eviction.t
@@ -4,16 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 25);
-
+plan_tests(25);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm key/value shm eviction - evicts most recent data in the queue
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 12288
@@ -85,7 +82,8 @@ qr/\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 2: proxy_wasm key/value shm eviction - a large allocation may evict multiple entries
---- skip_no_debug: 25
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 12288
@@ -165,7 +163,7 @@ qr/\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 3: proxy_wasm key/value shm eviction - getting keeps data alive in the LRU queue
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 12288
@@ -337,7 +335,7 @@ qr/\[crit\] .*? \[wasm\] "test" shm store: no memory; cannot allocate pair with 
 
 
 === TEST 6: proxy_wasm key/value shm eviction - LRU: may over-deallocate
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 16384 eviction=lru
@@ -417,7 +415,7 @@ qr/^[^"]*\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 7: proxy_wasm key/value shm eviction - SLRU: minimizes deallocation
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 16384 eviction=slru
@@ -494,7 +492,7 @@ qr/^[^"]*\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 8: proxy_wasm key/value shm eviction - SLRU: deallocates larger items if needed
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 16384 eviction=slru
@@ -571,7 +569,7 @@ qr/^[^"]*\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 9: proxy_wasm key/value shm eviction - SLRU: deallocates smaller items if no other choice
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 12288 eviction=slru
@@ -646,7 +644,7 @@ qr/^[^"]*\[debug\] [^"]* wasm "test" shm store: initialized
 
 
 === TEST 10: proxy_wasm key/value shm eviction - SLRU: deallocates the largest available "smaller slab"
---- skip_no_debug: 25
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_kv: test 16384 eviction=slru

--- a/t/03-proxy_wasm/hfuncs/shm/100-queue_push_pop.t
+++ b/t/03-proxy_wasm/hfuncs/shm/100-queue_push_pop.t
@@ -4,15 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 10);
-
+plan_tests(10);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm queue shm - push and pop a value
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_queue: test 1m

--- a/t/03-proxy_wasm/hfuncs/shm/101-queue_misuse.t
+++ b/t/03-proxy_wasm/hfuncs/shm/101-queue_misuse.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/hfuncs/shm/102-queue_push_edge_case.t
+++ b/t/03-proxy_wasm/hfuncs/shm/102-queue_push_edge_case.t
@@ -4,16 +4,13 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm queue shm - push when data_size == buffer_size
---- skip_no_debug: 6
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_queue: test 262144
@@ -37,6 +34,7 @@ circular_write: wrapping around
 
 
 === TEST 2: proxy_wasm queue shm - push when data size == buffer_size + 1
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_queue: test 262144

--- a/t/03-proxy_wasm/hfuncs/shm/103-queue_pop_edge_case.t
+++ b/t/03-proxy_wasm/hfuncs/shm/103-queue_pop_edge_case.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 10);
-
+plan_tests(10);
 run_tests();
 
 __DATA__
@@ -41,7 +38,7 @@ circular_write: wrapping around
 
 
 === TEST 2: proxy_wasm queue shm - pop when data size == buffer_size
---- skip_no_debug: 10
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- shm_queue: test 256k

--- a/t/03-proxy_wasm/sdks/001-rust_sdk.t
+++ b/t/03-proxy_wasm/sdks/001-rust_sdk.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/001-helloworld.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/001-helloworld.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/002-http_headers.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/002-http_headers.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/003-postpone_requests.t.off
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/003-postpone_requests.t.off
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/004-foreign_call_on_tick.t.off
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/004-foreign_call_on_tick.t.off
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/005-dispatch_call_on_tick.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/005-dispatch_call_on_tick.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/006-http_auth_random.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/006-http_auth_random.t
@@ -7,13 +7,9 @@ use t::TestWasm;
 our $ExtResolver = $t::TestWasm::extresolver;
 our $ExtTimeout = $t::TestWasm::exttimeout;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-repeat_each(1);
-
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/007-http_body.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/007-http_body.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/008-json_validation.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/008-json_validation.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/009-http_routing.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/009-http_routing.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/010-shared_data.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/010-shared_data.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/011-shared_queue.t.off
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/011-shared_queue.t.off
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/012-metrics.t.off
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/012-metrics.t.off
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/013-vm_plugin_configuration.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/013-vm_plugin_configuration.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/002-go_sdk/014-multiple_dispatches.t.off
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/014-multiple_dispatches.t.off
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
 skip_no_go_sdk();
 
-plan tests => repeat_each() * (blocks() * 7);
-
+plan_tests(7);
 run_tests();
 
 __DATA__

--- a/t/03-proxy_wasm/sdks/003-assemblyscript_sdk.t
+++ b/t/03-proxy_wasm/sdks/003-assemblyscript_sdk.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
 skip_no_assemblyscript_sdk();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/001-sanity.t
+++ b/t/04-openresty/001-sanity.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -28,6 +27,7 @@ __DATA__
 
 
 === TEST 2: ngx_wasm_module sanity
+--- valgrind
 --- main_config
     wasm {}
 --- config

--- a/t/04-openresty/002-dynamic_module.t
+++ b/t/04-openresty/002-dynamic_module.t
@@ -8,8 +8,7 @@ our $dyn = $ENV{NGX_BUILD_DYNAMIC_MODULE} || 0;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/001-get_main_vm.t
+++ b/t/04-openresty/ffi/001-get_main_vm.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/100-proxy_wasm_new.t
+++ b/t/04-openresty/ffi/100-proxy_wasm_new.t
@@ -8,8 +8,7 @@ our $nginxV = $t::TestWasm::nginxV;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/101-proxy_wasm_load.t
+++ b/t/04-openresty/ffi/101-proxy_wasm_load.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/102-proxy_wasm_start.t
+++ b/t/04-openresty/ffi/102-proxy_wasm_start.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/103-proxy_wasm_attach.t
+++ b/t/04-openresty/ffi/103-proxy_wasm_attach.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
@@ -313,7 +312,7 @@ qr/^[^#]*#0 on_vm_start[^#]*
 
 
 === TEST 8: attach() - plan is garbage collected after execution
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config

--- a/t/04-openresty/ffi/200-proxy_wasm_and_lua_sanity.t
+++ b/t/04-openresty/ffi/200-proxy_wasm_and_lua_sanity.t
@@ -6,13 +6,13 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 6);
-
+plan_tests(6);
 run_tests();
 
 __DATA__
 
 === TEST 1: proxy_wasm FFI - request headers manipulation alongside Lua VM
+--- valgrind
 --- wasm_modules: hostcalls
 --- http_config
     init_worker_by_lua_block {
@@ -191,6 +191,7 @@ Hello world
 
 
 === TEST 5: proxy_wasm FFI - HTTP dispatch alongside Lua VM (echo dispatch response)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config
@@ -322,6 +323,7 @@ qr/\A\*\d+ .*? filter 1\/1 resuming "on_request_headers" step in "rewrite" phase
 
 
 === TEST 7: proxy_wasm FFI - HTTP dispatch alongside Lua VM (trap on response)
+--- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config
@@ -389,7 +391,8 @@ Run 1 filter chain in /t, but produce content through /error
 At r->pool cleanup, the done step is invoked the /t chain, and the chain is
 freed. /error does not concern itself with any chain.
 
---- skip_no_debug: 6
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config
@@ -446,7 +449,8 @@ Run 2 filters chains:
 At r->pool cleanup, the done step is invoked for both chains, and both chains
 are freed.
 
---- skip_no_debug: 6
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config

--- a/t/04-openresty/ffi/300-proxy_wasm_properties_get_ngx.t
+++ b/t/04-openresty/ffi/300-proxy_wasm_properties_get_ngx.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/301-proxy_wasm_properties_get_host.t
+++ b/t/04-openresty/ffi/301-proxy_wasm_properties_get_host.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
+++ b/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
+++ b/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/304-proxy_wasm_set_host_properties_handlers.t
+++ b/t/04-openresty/ffi/304-proxy_wasm_set_host_properties_handlers.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm::Lua;
 
-skip_valgrind();
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/305-proxy_wasm_host_properties_getter.t
+++ b/t/04-openresty/ffi/305-proxy_wasm_host_properties_getter.t
@@ -4,11 +4,9 @@ use strict;
 use lib '.';
 use t::TestWasm::Lua;
 
-skip_valgrind();
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/ffi/306-proxy_wasm_host_properties_setter.t
+++ b/t/04-openresty/ffi/306-proxy_wasm_host_properties_setter.t
@@ -6,8 +6,7 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -328,6 +327,7 @@ property not found: wasmx.fail1_property
 
 === TEST 7: host properties setter - setter returning true
 With and without 3rd return value (caches result)
+--- valgrind
 --- wasm_modules: hostcalls
 --- http_config
     init_worker_by_lua_block {

--- a/t/04-openresty/lua-bridge/001-sanity.t
+++ b/t/04-openresty/lua-bridge/001-sanity.t
@@ -6,8 +6,6 @@ use t::TestWasm::Lua;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 4);
-
 add_block_preprocessor(sub {
     my $block = shift;
     if (!defined $block->wasm_modules) {
@@ -15,6 +13,7 @@ add_block_preprocessor(sub {
     }
 });
 
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
+++ b/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
@@ -9,8 +9,7 @@ our $ExtTimeout = $t::TestWasm::exttimeout;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -20,7 +19,7 @@ Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
---- skip_no_debug: 5
+--- skip_no_debug
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -47,7 +46,7 @@ Succeeds on:
 
 
 === TEST 2: proxy_wasm - proxy_wasm_lua_resolver, sanity (on_tick)
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{
@@ -237,7 +236,7 @@ Succeeds on:
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
 --- skip_eval: 5: $t::TestWasm::nginxV !~ m/--with-debug/ || defined $ENV{GITHUB_ACTIONS}
---- skip_no_debug: 5
+--- skip_no_debug
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -263,7 +262,7 @@ Succeeds on:
 
 
 === TEST 8: Lua bridge - proxy_wasm_lua_resolver, existing client
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config
@@ -309,8 +308,7 @@ Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
---- skip_valgrind: 5
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config eval
@@ -349,7 +347,7 @@ qr/\[debug\] .*? wasm lua resolver using existing dns_client/
 
 
 === TEST 10: Lua bridge - proxy_wasm_lua_resolver, SRV record
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config
@@ -473,7 +471,7 @@ qr/\[error\] .*? lua entry thread aborted: .*? wasm lua failed resolving "foo": 
 
 === TEST 13: Lua bridge - proxy_wasm_lua_resolver, failed before query
 Failure before the Lua thread gets a chance to yield (immediate resolver failure)
---- skip_no_debug: 5
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config

--- a/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
+++ b/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
@@ -16,8 +16,7 @@ our $ExtTimeout = $t::TestWasm::exttimeout;
 
 skip_no_openresty();
 
-plan tests => repeat_each() * (blocks() * 5);
-
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -27,7 +26,7 @@ Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
---- skip_no_debug: 5
+--- skip_no_debug
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -57,7 +56,6 @@ Succeeds on:
 lua-resty-dns-resolver client timeout
 Behaves strangely on GHA Valgrind. Seems fine locally.
 Will run with TEST_NGINX_USE_VALGRIND_ALL.
---- skip_valgrind: 5
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- http_config eval
@@ -105,7 +103,6 @@ Using a non-local resolver
 lua-resty-dns-resolver client timeout
 Behaves strangely on GHA Valgrind. Seems fine locally.
 Will run with TEST_NGINX_USE_VALGRIND_ALL.
---- skip_valgrind: 5
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
 qq{

--- a/t/05-others/001-socket_buffer_reuse.t
+++ b/t/05-others/001-socket_buffer_reuse.t
@@ -4,14 +4,14 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: buffer reuse - wasm_socket_buffer_reuse on
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -50,7 +50,7 @@ wasm reuse free buf memory \d+ >= 2,.*/
 
 === TEST 2: buffer reuse - wasm_socket_buffer_reuse off
 ngx_wasm_socket buffers not reused (buffers of size 2)
---- skip_no_debug: 4
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -91,7 +91,8 @@ qr/wasm reuse free buf memory \d+ >= \d+/
 
 
 === TEST 3: buffer reuse - wasm_socket_buffer_reuse on, realloc
---- skip_no_debug: 4
+--- valgrind
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/05-others/002-resolver_add_sanity.t
+++ b/t/05-others/002-resolver_add_sanity.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind('wasmtime');
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/05-others/010-client_connection_abort.t
+++ b/t/05-others/010-client_connection_abort.t
@@ -6,15 +6,14 @@ use t::TestWasm;
 
 skip_hup();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: client connection abort - wasm_call
 Nginx response filters are not invoked on the produced HTTP 499 response.
---- skip_no_debug: 4
+--- skip_no_debug
 --- wasm_modules: ngx_rust_tests
 --- tcp_listen: $TEST_NGINX_UNIX_SOCKET
 --- tcp_reply eval

--- a/t/05-others/011-upstream_connection_abort.t
+++ b/t/05-others/011-upstream_connection_abort.t
@@ -5,18 +5,15 @@ use lib '.';
 use t::TestWasm;
 
 skip_hup();
-skip_valgrind();
 
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__
 
 === TEST 1: upstream connection abort - wasm_call
 Calls on aborted upstream connections execute response phases on the produced
-HTTP 502 response.
---- skip_no_debug: 4
+--- skip_no_debug
 --- wasm_modules: ngx_rust_tests
 --- tcp_listen: $TEST_NGINX_UNIX_SOCKET
 --- tcp_shutdown: 2

--- a/t/10-build/001-build_options.t
+++ b/t/10-build/001-build_options.t
@@ -4,10 +4,12 @@ use strict;
 use lib '.';
 use t::TestBuild;
 
+skip_valgrind();
+
 our $buildroot = $t::TestBuild::buildroot;
 our $openssl_ver = get_variable_from_makefile("OPENSSL");
 
-plan tests => 5 * blocks();
+plan tests => blocks() * 5;
 
 run_tests();
 

--- a/t/10-build/002-runtime_linking.t
+++ b/t/10-build/002-runtime_linking.t
@@ -4,9 +4,11 @@ use strict;
 use lib '.';
 use t::TestBuild;
 
+skip_valgrind();
+
 our $buildroot = $t::TestBuild::buildroot;
 
-plan tests => 4 * blocks();
+plan tests => blocks() * 4;
 
 run_tests();
 

--- a/t/10-build/003-dynamic_module.t
+++ b/t/10-build/003-dynamic_module.t
@@ -4,9 +4,11 @@ use strict;
 use lib '.';
 use t::TestBuild;
 
+skip_valgrind();
+
 our $buildroot = $t::TestBuild::buildroot;
 
-plan tests => 4 * blocks();
+plan tests => blocks() * 4;
 
 run_tests();
 

--- a/t/10-build/004-ngx_wasm_rs_linking.t
+++ b/t/10-build/004-ngx_wasm_rs_linking.t
@@ -4,9 +4,11 @@ use strict;
 use lib '.';
 use t::TestBuild;
 
+skip_valgrind();
+
 our $buildroot = $t::TestBuild::buildroot;
 
-plan tests => 6 * blocks();
+plan tests => blocks() * 6;
 
 run_tests();
 

--- a/t/11-bench/001-bench_hash.t
+++ b/t/11-bench/001-bench_hash.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/11-bench/002-bench_fannkuch_redux.t
+++ b/t/11-bench/002-bench_fannkuch_redux.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/11-bench/003-bench_proxy_wasm.t
+++ b/t/11-bench/003-bench_proxy_wasm.t
@@ -4,10 +4,7 @@ use strict;
 use lib '.';
 use t::TestWasm;
 
-skip_valgrind();
-
-plan tests => repeat_each() * (blocks() * 4);
-
+plan_tests(4);
 run_tests();
 
 __DATA__

--- a/t/TestBuild.pm
+++ b/t/TestBuild.pm
@@ -16,8 +16,9 @@ our $buildroot = $ENV{NGX_BUILD_DIR_BUILDROOT};
 
 our @EXPORT = qw(
     $buildroot
-    run_tests
+    skip_valgrind
     get_variable_from_makefile
+    run_tests
 );
 
 my $dry_run = 0;
@@ -38,8 +39,10 @@ chomp $out;
 
 $ENV{NGX_WASM_RUNTIME_DIR} = $out;
 
-sub bail_out (@) {
-    Test::More::BAIL_OUT(@_);
+sub skip_valgrind {
+    if ($ENV{TEST_NGINX_USE_VALGRIND}) {
+        plan skip_all => "skipped with Valgrind";
+    }
 }
 
 sub get_variable_from_makefile($) {
@@ -180,6 +183,10 @@ sub grep_something ($$$) {
             }
         }
     }
+}
+
+sub bail_out (@) {
+    Test::More::BAIL_OUT(@_);
 }
 
 sub run_test ($) {

--- a/t/TestWasm/Lua.pm
+++ b/t/TestWasm/Lua.pm
@@ -14,7 +14,7 @@ sub skip_no_openresty {
     my $build_name = (split /\n/, $nginxV)[0];
 
     if ($build_name !~ m/nginx version: openresty/) {
-        plan skip_all => "skipped (not an OpenResty binary)";
+        plan skip_all => "not an OpenResty binary";
     }
 }
 


### PR DESCRIPTION
Remove `--- skip_valgrind` block and helper in favor of an opt-in mode for Valgrind test cases.