### PR TITLE
fix(wasi) do not use instance pool on fd_write

### DIFF
--- a/src/wasm/wasi/ngx_wasi_host.c
+++ b/src/wasm/wasi/ngx_wasi_host.c
@@ -258,7 +258,7 @@ ngx_wasi_hfuncs_fd_write(ngx_wavm_instance_t *instance,
 
     /* second pass: build string from iov buffers */
 
-    msg_data = ngx_pcalloc(instance->pool, msg_size);
+    msg_data = ngx_alloc(msg_size, instance->log);
     if (msg_data == NULL) {
         rets[0] = (wasm_val_t) WASM_I32_VAL(WASI_ERRNO_EFAULT);
         return NGX_WAVM_OK;
@@ -290,6 +290,8 @@ ngx_wasi_hfuncs_fd_write(ngx_wavm_instance_t *instance,
         ngx_log_error(level, instance->log_ctx.orig_log, 0, "%*s",
                       msg_size, msg_data);
     }
+
+    ngx_free(msg_data);
 
     rets[0] = (wasm_val_t) WASM_I32_VAL(WASI_ERRNO_SUCCESS);
     return NGX_WAVM_OK;


### PR DESCRIPTION
Avoid using the long-lived instance pool for a temporary buffer on fd_write. Since we allocate and deallocate deterministically within the same function (and to avoid a cross-concern dependency on proxy-wasm to get pwctx), we simply use `ngx_alloc` and `ngx_free` to produce a temporary buffer.