### PR TITLE
chore(sdk) separate build and install of .wasm examples

### DIFF
--- a/util/sdks/assemblyscript.sh
+++ b/util/sdks/assemblyscript.sh
@@ -70,7 +70,8 @@ build_assemblyscript_sdk() {
 
     if [[ -f "$DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/.hash" \
           && $(cat "$DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/.hash") == $(echo $hash_src)
-          && -z "$clean" ]];
+          && -z "$clean" ]] && \
+       find $DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK -name '*.wasm' | grep -q .
     then
         notice "AssemblyScript examples already built"
         exit
@@ -87,6 +88,16 @@ build_assemblyscript_sdk() {
         pushd $example
             npm install
             npm run asbuild
+        popd
+    done
+}
+
+install_assemblyscript_sdk_examples() {
+    for example in $DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/examples/*; do
+        name=$(basename $example)
+        name=$(echo $name | sed 's/-/_/g')
+
+        pushd $example
             cp build/debug.wasm $DIR_TESTS_LIB_WASM/assemblyscript_$name.wasm
         popd
     done
@@ -103,4 +114,5 @@ if [ "$mode" = "download" ]; then
 
 else
     build_assemblyscript_sdk "$version" "$clean"
+    install_assemblyscript_sdk_examples
 fi

--- a/util/sdks/go.sh
+++ b/util/sdks/go.sh
@@ -66,10 +66,11 @@ build_go_sdk() {
     if [[ -d "$DIR_PATCHED_PROXY_WASM_GO_SDK" \
           && -f "$DIR_PATCHED_PROXY_WASM_GO_SDK/.hash" \
           && $(cat "$DIR_PATCHED_PROXY_WASM_GO_SDK/.hash") == $(echo $hash_src)
-          && -z "$clean" ]];
+          && -z "$clean" ]] && \
+       find $DIR_PATCHED_PROXY_WASM_GO_SDK -name '*.wasm' | grep -q .
     then
         notice "Go examples already built"
-        exit
+        return
     fi
 
     rm -rf $DIR_PATCHED_PROXY_WASM_GO_SDK
@@ -105,7 +106,11 @@ EOF
         notice "compiling Go examples..."
 
         make build.examples || exit 0
+    popd
+}
 
+install_go_sdk_examples() {
+    pushd $DIR_PATCHED_PROXY_WASM_GO_SDK
         cd examples
 
         find . -name "*.wasm" | while read f; do
@@ -128,4 +133,5 @@ if [ "$mode" = "download" ]; then
 
 else
     build_go_sdk "$version" "$clean"
+    install_go_sdk_examples
 fi


### PR DESCRIPTION
The SDK installer scripts are not installing the example filters into their target locations when it detects that the sources haven't changed via the hash file. This patch splits the build and install steps to fix this behavior.

The checks are still not as ideal (we're still not checking the sources and targets for each example individually, so if we get a compilation failure halfway through the build we're still going to end up in an inconsistent state), but it is a step in the right direction:

* check that some .wasm files are actually present when deciding to skip the build
* always install .wasm files into the target location, even when build is skipped