### PR TITLE
chore(ci) fix large CI workflow file

### DIFF
--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -139,7 +139,7 @@ jobs:
         v8: [11.4.183.23]
         include:
           - label: old_nginx
-            os: [ubuntu-latest]
+            os: ubuntu-latest
             cc: clang-15
             ngx: 1.21.6
             runtime: wasmtime


### PR DESCRIPTION
[This](https://github.com/Kong/ngx_wasm_module/actions/runs/7160665577) successful run demonstrates the fix. 