### PR TITLE
feat(http) support sending local response in header_filter

### DIFF
--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -72,6 +72,8 @@ struct ngx_http_wasm_req_ctx_s {
     unsigned                           entered_content_phase:1; /* entered content handler */
     unsigned                           exited_content_phase:1;  /* executed content handler at least once */
     unsigned                           entered_header_filter:1; /* entered header_filter handler */
+    unsigned                           entered_body_filter:1;   /* entered body_filter handler */
+    unsigned                           flushed_local_resp:1;    /* local response can be flushed only once */
 
     unsigned                           in_wev:1;                /* in wev_handler */
     unsigned                           resp_content_chosen:1;   /* content handler has an output to produce */

--- a/src/http/ngx_http_wasm_local_response.c
+++ b/src/http/ngx_http_wasm_local_response.c
@@ -47,7 +47,7 @@ ngx_http_wasm_stash_local_response(ngx_http_wasm_req_ctx_t *rctx,
 
     dd("enter");
 
-    if (rctx->entered_header_filter) {
+    if (rctx->entered_body_filter) {
         return NGX_ABORT;
     }
 
@@ -188,6 +188,10 @@ ngx_http_wasm_flush_local_response(ngx_http_wasm_req_ctx_t *rctx)
         return NGX_DECLINED;
     }
 
+    if (rctx->flushed_local_resp) {
+        return NGX_ERROR;
+    }
+
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "wasm flushing local_response");
 
@@ -198,9 +202,9 @@ ngx_http_wasm_flush_local_response(ngx_http_wasm_req_ctx_t *rctx)
 
     r->headers_out.status = rctx->local_resp_status;
 
-    if (r->err_status) {
-        r->err_status = 0;
-    }
+    r->err_status = rctx->entered_header_filter
+                    ? rctx->local_resp_status
+                    : 0;
 
     if (rctx->local_resp_reason.len) {
         r->headers_out.status_line.data = rctx->local_resp_reason.data;
@@ -231,9 +235,10 @@ ngx_http_wasm_flush_local_response(ngx_http_wasm_req_ctx_t *rctx)
         return NGX_ERROR;
     }
 
-    rc = ngx_http_wasm_send_chain_link(r, rctx->local_resp_body);
-
     rctx->local_resp_status = 0;
+    rctx->flushed_local_resp = 1;
+
+    rc = ngx_http_wasm_send_chain_link(r, rctx->local_resp_body);
 
     return rc;
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -139,6 +139,19 @@ impl HttpContext for TestHttp {
 
     fn on_http_response_body(&mut self, len: usize, eof: bool) -> Action {
         info!("[hostcalls] on_response_body, {} bytes, eof: {}", len, eof);
+
+        if let Some(max) = self.body_max {
+            self.body_seen += len;
+            if self.body_seen > max {
+                self.set_http_response_body(max, 0, "".as_bytes());
+                if max == 0 {
+                    return Action::Pause;
+                } else {
+                    return Action::Continue;
+                }
+            }
+        }
+
         self.exec_tests(TestPhase::ResponseBody)
     }
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -173,6 +173,8 @@ impl RootContext for TestRoot {
             config: self.config.clone(),
             on_phases: phases,
             ncalls: 0,
+            body_max: None,
+            body_seen: 0,
         }))
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
@@ -150,22 +150,26 @@ pub(crate) fn test_set_property(ctx: &(dyn TestContext + 'static)) {
     info!("new: {}", show_property(ctx, &path));
 }
 
-pub(crate) fn test_send_status(ctx: &TestHttp, status: u32) {
-    ctx.send_http_response(status, vec![], None)
+pub(crate) fn test_send_status(ctx: &mut TestHttp, status: u32) {
+    ctx.send_http_response(status, vec![
+        ("Content-Length", "0"),
+    ], None);
+    ctx.body_max = Some(0);
 }
 
 pub(crate) fn test_send_headers(ctx: &TestHttp) {
     ctx.send_http_response(200, vec![("Powered-By", "proxy-wasm")], None)
 }
 
-pub(crate) fn test_send_body(ctx: &TestHttp) {
+pub(crate) fn test_send_body(ctx: &mut TestHttp) {
     //let path = ctx.get_http_request_header(":path").unwrap();
     ctx.send_http_response(
         200,
         vec![("Content-Length", "0")], // must be overriden to body.len() by host
         Some("Hello world".as_bytes()),
         //Some(format!("Hello world ({})", path).as_bytes()),
-    )
+    );
+    ctx.body_max = Some(12);
 }
 
 pub(crate) fn test_send_twice(ctx: &TestHttp) {
@@ -333,6 +337,7 @@ pub(crate) fn test_set_response_body(ctx: &mut TestHttp) {
         .map_or(body.len(), |v| v.parse::<usize>().unwrap());
 
     ctx.set_http_response_body(offset, len, body.as_bytes());
+    ctx.body_max = Some(len);
 
     ctx.config.insert(key.clone(), key);
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -9,6 +9,8 @@ pub struct TestHttp {
     pub on_phases: Vec<TestPhase>,
     pub config: HashMap<String, String>,
     pub ncalls: usize,
+    pub body_max: Option<usize>,
+    pub body_seen: usize,
 }
 
 impl TestHttp {
@@ -75,6 +77,7 @@ impl TestHttp {
             /* send_local_response */
             "/t/send_local_response/status/204" => test_send_status(self, 204),
             "/t/send_local_response/status/300" => test_send_status(self, 300),
+            "/t/send_local_response/status/403" => test_send_status(self, 403),
             "/t/send_local_response/status/1000" => test_send_status(self, 1000),
             "/t/send_local_response/headers" => test_send_headers(self),
             "/t/send_local_response/body" => test_send_body(self),


### PR DESCRIPTION
Marked it as `feat` rather than `fix` because it can be seen as expanding our proxy-wasm support coverage.

Keeping this at Draft stage because, while the changes here do resolve the issues I was experiencing in the filter I was testing, the test failure in `t/02-http/hfuncs/004-local_response.t` is real: looks like setting `r->err_status` as I'm doing here does preserve the status code of the local response produced during `on_http_response_headers`, but it ends up also overriding the custom "reason" string, so that's no good. Any thoughts on alternative solutions for this are welcome!