### PR TITLE
chore(tests) fix test cases for Wasmer in HUP mode

### DIFF
--- a/t/03-proxy_wasm/007-on_http_instance_isolation.t
+++ b/t/03-proxy_wasm/007-on_http_instance_isolation.t
@@ -7,6 +7,7 @@ use t::TestWasm;
 skip_no_debug();
 
 plan_tests(8);
+no_shuffle();
 run_tests();
 
 __DATA__
@@ -71,7 +72,6 @@ qr/\A\*\d+ .*? filter reusing instance[^#*]*
 === TEST 2: proxy_wasm - trap with none isolation mode
 Should recycle the global instance when trapped.
 --- valgrind
---- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
     proxy_wasm_isolation none;
@@ -118,6 +118,7 @@ qr/\A\*\d+ .*? filter new instance[^#*]*
 
 === TEST 3: proxy_wasm - stream isolation mode
 should use an instance per stream
+req0 might free an instance from the previous test in HUP mode.
 --- valgrind
 --- wasm_modules: hostcalls
 --- config
@@ -133,10 +134,10 @@ should use an instance per stream
 --- ignore_response_body
 --- grep_error_log eval: qr/(\*\d+.*?(resuming|new instance|reusing|finalizing|freeing|trap in)|#\d+ on_(configure|vm_start)).*/
 --- grep_error_log_out eval
-[qr/#0 on_vm_start[^#*]*
+[qr/(\*\d+ .*? freeing "hostcalls" instance in "main" vm \(.*?\)[^#*]*)?#0 on_vm_start[^#*]*
 #0 on_configure[^#*]*
 #0 on_vm_start[^#*]*
-#0 on_configure[^#*]*
+#0 on_configure[^#*]*(\*\d+ .*? freeing "hostcalls" instance in "main" vm \(.*?\)[^#*]*)?
 \*\d+ .*? filter new instance[^#*]*
 #0 on_configure[^#*]*
 \*\d+ .*? filter reusing instance[^#*]*

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -132,7 +132,7 @@ qr/\[info\] .*? property not found: was,/
 --- load_nginx_modules: ngx_http_echo_module
 --- config
     location /t {
-        proxy_wasm hostcalls 'tick_period=100 \
+        proxy_wasm hostcalls 'tick_period=500 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;
@@ -156,7 +156,7 @@ qr/\[info\] .*? property not found: was,/
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=100 \
+        proxy_wasm hostcalls 'tick_period=500 \
                               on_tick=log_property \
                               name=wasmx.my_var';
         echo_sleep 0.150;

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
@@ -147,7 +147,7 @@ ngx_http_* calls.
     set $my_var 123;
 
     location /t {
-        proxy_wasm hostcalls 'tick_period=100 \
+        proxy_wasm hostcalls 'tick_period=500 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \
@@ -179,7 +179,7 @@ ngx_http_* calls.
     location /t {
         proxy_wasm_isolation stream;
 
-        proxy_wasm hostcalls 'tick_period=100 \
+        proxy_wasm hostcalls 'tick_period=500 \
                               on_tick=set_property \
                               name=wasmx.my_var \
                               show_old=false \


### PR DESCRIPTION
Different compilers load the hostcalls filter faster or slower by an order of magnitude (30ms vs 300ms), and cause the old worker "free instance" log to happen sooner or later in req0, especially now that we update the time at module loading.