### PR TITLE
feat(proxy-wasm) support 'send_local_response' during on_response_headers

### DIFF
--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -66,15 +66,19 @@ struct ngx_http_wasm_req_ctx_s {
 
     /* flags */
 
+    unsigned                           local_resp_flushed:1;    /* local response can only be flushed once */
     unsigned                           sock_buffer_reuse:1;     /* convenience alias to loc->socket_buffer_reuse */
     unsigned                           req_keepalive:1;         /* r->keepalive copy */
     unsigned                           reset_resp_shims:1;
     unsigned                           entered_content_phase:1; /* entered content handler */
     unsigned                           exited_content_phase:1;  /* executed content handler at least once */
     unsigned                           entered_header_filter:1; /* entered header_filter handler */
+    unsigned                           entered_body_filter:1;   /* entered body_filter handler */
+    unsigned                           entered_log_phase:1;     /* entered log phase */
 
     unsigned                           in_wev:1;                /* in wev_handler */
     unsigned                           resp_content_chosen:1;   /* content handler has an output to produce */
+    unsigned                           resp_chunk_override:1;   /* override response chunk in body_filter handler */
     unsigned                           resp_buffering:1;        /* enable response buffering */
     unsigned                           resp_content_sent:1;     /* has started sending output (may have yielded) */
     unsigned                           resp_finalized:1;        /* finalized connection (ourselves) */
@@ -116,6 +120,8 @@ typedef struct {
 /* http */
 ngx_int_t ngx_http_wasm_rctx(ngx_http_request_t *r,
     ngx_http_wasm_req_ctx_t **out);
+ngx_int_t ngx_http_wasm_set_local_response_body(ngx_http_wasm_req_ctx_t *rctx,
+    u_char *body, size_t body_len);
 ngx_int_t ngx_http_wasm_stash_local_response(ngx_http_wasm_req_ctx_t *rctx,
     ngx_int_t status, u_char *reason, size_t reason_len, ngx_array_t *headers,
     u_char *body, size_t body_len);
@@ -154,6 +160,8 @@ ngx_uint_t ngx_http_wasm_count_shim_headers(ngx_http_wasm_req_ctx_t *rctx);
 /* payloads */
 ngx_int_t ngx_http_wasm_set_req_body(ngx_http_wasm_req_ctx_t *rctx,
     ngx_str_t *body, size_t at, size_t max);
+void ngx_http_wasm_set_resp_status(ngx_http_wasm_req_ctx_t *rctx,
+    ngx_int_t status, u_char *reason, size_t reason_len);
 ngx_int_t ngx_http_wasm_set_resp_body(ngx_http_wasm_req_ctx_t *rctx,
     ngx_str_t *body, size_t at, size_t max);
 ngx_int_t ngx_http_wasm_prepend_req_body(ngx_http_wasm_req_ctx_t *rctx,

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -954,6 +954,8 @@ ngx_http_wasm_log_handler(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
+    rctx->entered_log_phase = 1;
+
     rc = ngx_wasm_ops_resume(&rctx->opctx, NGX_HTTP_LOG_PHASE);
 
 #if (NGX_HTTP_WASM_DONE_IN_LOG)

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -98,6 +98,7 @@ ngx_wasm_chain_clear(ngx_chain_t *in, size_t offset, unsigned *eof,
             pos += len;
         }
 
+        buf->flush = 0;
         buf->last_buf = 0;
         buf->last_in_chain = 0;
     }
@@ -273,6 +274,7 @@ ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
         nl = cl;
         cl = cl->next;
         nl->next = *free;
+
         if (*free) {
             *free = nl;
         }

--- a/t/03-proxy_wasm/006-on_http_next_action.t
+++ b/t/03-proxy_wasm/006-on_http_next_action.t
@@ -53,27 +53,28 @@ pausing after "RequestBody"
 
 
 === TEST 3: proxy_wasm - on_response_headers -> Pause
-NYI
+Expects local response set in headers phase.
 --- wasm_modules: on_phases
 --- config
     location /t {
         proxy_wasm on_phases 'pause_on=response_headers';
         return 200;
     }
---- error_code: 500
---- response_body_like: 500 Internal Server Error
+--- error_code: 200
+--- response_body
 --- error_log eval
 [
     qr/pausing after "ResponseHeaders"/,
-    qr#\[error\] .*? bad "on_response_headers" return action: "PAUSE"#,
-    qr#\[info\] .*? filter chain failed resuming: previous error \(invalid return action\)#
+    qr/"ResponseHeaders" returned "PAUSE": local response expected but none produced/,
 ]
+--- no_error_log
+[error]
 
 
 
 === TEST 4: proxy_wasm - on_response_body -> Pause
 Triggers response buffering.
---- skip_no_debug: 5
+--- skip_no_debug
 --- wasm_modules: on_phases
 --- config
     location /t {
@@ -158,7 +159,7 @@ pausing after "RequestBody"
 
 
 === TEST 7: proxy_wasm - subrequest on_response_headers -> Pause
-NYI
+Expects local response set in headers phase.
 --- timeout_expected: 1
 --- abort
 --- load_nginx_modules: ngx_http_echo_module
@@ -181,19 +182,22 @@ NYI
         echo_subrequest_async GET /nop;
     }
 --- error_code: 200
---- response_body_like: 500 Internal Server Error
+--- response_body
+ok
+ok
 --- error_log eval
 [
     qr/pausing after "ResponseHeaders"/,
-    qr#\[error\] .*? bad "on_response_headers" return action: "PAUSE"#,
-    qr#\[info\] .*? filter chain failed resuming: previous error \(invalid return action\)#
+    qr/"ResponseHeaders" returned "PAUSE": local response expected but none produced/,
 ]
+--- no_error_log
+[error]
 
 
 
 === TEST 8: proxy_wasm - subrequest on_response_body -> Pause
-NYI
---- skip_no_debug: 5
+Triggers response buffering.
+--- skip_no_debug
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: on_phases
 --- config

--- a/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
@@ -151,7 +151,7 @@ pub(crate) fn test_set_property(ctx: &(dyn TestContext + 'static)) {
 }
 
 pub(crate) fn test_send_status(ctx: &TestHttp, status: u32) {
-    ctx.send_http_response(status, vec![], None)
+    ctx.send_http_response(status, vec![], None);
 }
 
 pub(crate) fn test_send_headers(ctx: &TestHttp) {

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -69,6 +69,7 @@ impl TestHttp {
             /* send_local_response */
             "/t/send_local_response/status/204" => test_send_status(self, 204),
             "/t/send_local_response/status/300" => test_send_status(self, 300),
+            "/t/send_local_response/status/403" => test_send_status(self, 403),
             "/t/send_local_response/status/1000" => test_send_status(self, 1000),
             "/t/send_local_response/headers" => test_send_headers(self),
             "/t/send_local_response/body" => test_send_body(self),


### PR DESCRIPTION
Replaces #470 by implementing the feature at the Proxy-Wasm host layer.