### PR TITLE
chore(util/sdks) check if SDK examples exist before installing them

### DIFF
--- a/util/sdks/assemblyscript.sh
+++ b/util/sdks/assemblyscript.sh
@@ -93,14 +93,16 @@ build_assemblyscript_sdk() {
 }
 
 install_assemblyscript_sdk_examples() {
-    for example in $DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/examples/*; do
-        name=$(basename $example)
-        name=$(echo $name | sed 's/-/_/g')
+    if [[ -d "$DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/examples" ]]; then
+        for example in $DIR_PROXY_WASM_ASSEMBLYSCRIPT_SDK/examples/*; do
+            name=$(basename $example)
+            name=$(echo $name | sed 's/-/_/g')
 
-        pushd $example
-            cp -av build/debug.wasm $DIR_TESTS_LIB_WASM/assemblyscript_$name.wasm
-        popd
-    done
+            pushd $example
+                cp -av build/debug.wasm $DIR_TESTS_LIB_WASM/assemblyscript_$name.wasm
+            popd
+        done
+    fi
 }
 
 ###############################################################################

--- a/util/sdks/go.sh
+++ b/util/sdks/go.sh
@@ -110,16 +110,18 @@ EOF
 }
 
 install_go_sdk_examples() {
-    pushd $DIR_PATCHED_PROXY_WASM_GO_SDK
-        cd examples
+    if [[ -d "$DIR_PATCHED_PROXY_WASM_GO_SDK" ]]; then
+        pushd $DIR_PATCHED_PROXY_WASM_GO_SDK
+            cd examples
 
-        find . -name "*.wasm" | while read f; do
-            # flatten module names, for example:
-            # "./shared_queue/sender/main.wasm" to "go_shared_queue_sender.wasm"
-            name=$(echo "$f" | sed 's,./\(.*\)/main.wasm,go_\1.wasm,;s,/,_,g')
-            cp -av "$f" "$DIR_TESTS_LIB_WASM/$name"
-        done
-    popd
+            find . -name "*.wasm" | while read f; do
+                # flatten module names, for example:
+                # "./shared_queue/sender/main.wasm" to "go_shared_queue_sender.wasm"
+                name=$(echo "$f" | sed 's,./\(.*\)/main.wasm,go_\1.wasm,;s,/,_,g')
+                cp -av "$f" "$DIR_TESTS_LIB_WASM/$name"
+            done
+        popd
+    fi
 }
 
 ###############################################################################


### PR DESCRIPTION
This prevents `./util/test.sh` from failing when `./util/sdks/go.sh` or`./util/sdks/assemblyscript.sh` attempt to install example filters when the respective SDK hasn't been downloaded (`tinygo` or `npm` not available).