### PR TITLE
feat(proxy-wasm) enable multiple parallel dispatch calls

### DIFF
--- a/src/common/ngx_wasm_socket_tcp.c
+++ b/src/common/ngx_wasm_socket_tcp.c
@@ -1363,6 +1363,8 @@ ngx_wasm_socket_tcp_handler(ngx_event_t *ev)
                    (int) ev->write);
 
     if (sock->closed) {
+        ngx_log_debug0(NGX_LOG_DEBUG_WASM, ev->log, 0,
+                       "wasm tcp socket was closed");
         return;
     }
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -339,7 +339,6 @@ ngx_proxy_wasm_ctx_destroy(ngx_proxy_wasm_ctx_t *pwctx)
                                  pwexec->filter->name, pwexec->id,
                                  pwexec->index + 1, pwctx->nfilters);
 
-
         if (pwexec->ictx) {
             if (pwexec->node.key) {
                 ngx_rbtree_delete(&pwexec->ictx->tree_ctxs, &pwexec->node);
@@ -483,6 +482,9 @@ action2rc(ngx_proxy_wasm_ctx_t *pwctx,
     default:
         break;
     }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_WASM, pwctx->log, 0, "proxy_wasm return "
+                   "action: \"%V\"", ngx_proxy_wasm_action_name(action));
 
     /* determine current action rc */
 
@@ -713,13 +715,11 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
 {
     ngx_int_t                 rc;
     ngx_proxy_wasm_err_e      ecode;
-    ngx_proxy_wasm_action_e   action = NGX_PROXY_WASM_ACTION_CONTINUE;
     ngx_proxy_wasm_exec_t    *out;
     ngx_proxy_wasm_ctx_t     *pwctx = pwexec->parent;
     ngx_proxy_wasm_filter_t  *filter = pwexec->filter;
-#if (NGX_DEBUG)
     ngx_proxy_wasm_action_e   old_action = pwctx->action;
-#endif
+    ngx_proxy_wasm_action_e   action = old_action;
 
     ngx_wasm_assert(pwctx->phase);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -180,6 +180,7 @@ struct ngx_proxy_wasm_exec_s {
     ngx_uint_t                         id;
     ngx_uint_t                         index;
     ngx_uint_t                         tick_period;
+    ngx_uint_t                         ncalls;
     ngx_rbtree_node_t                  node;
     ngx_proxy_wasm_err_e               ecode;
     ngx_pool_t                        *pool;

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -180,7 +180,6 @@ struct ngx_proxy_wasm_exec_s {
     ngx_uint_t                         id;
     ngx_uint_t                         index;
     ngx_uint_t                         tick_period;
-    ngx_uint_t                         ncalls;
     ngx_rbtree_node_t                  node;
     ngx_proxy_wasm_err_e               ecode;
     ngx_pool_t                        *pool;
@@ -192,8 +191,9 @@ struct ngx_proxy_wasm_exec_s {
     ngx_proxy_wasm_store_t            *store;
     ngx_event_t                       *ev;
 #ifdef NGX_WASM_HTTP
-    ngx_http_proxy_wasm_dispatch_t    *call;
+    ngx_http_proxy_wasm_dispatch_t    *call;  /* swap pointer for host functions */
 #endif
+    ngx_queue_t                        calls;
 
     /* flags */
 
@@ -400,6 +400,8 @@ ngx_int_t ngx_proxy_wasm_resume(ngx_proxy_wasm_ctx_t *pwctx,
     ngx_wasm_phase_t *phase, ngx_proxy_wasm_step_e step);
 ngx_proxy_wasm_err_e ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     ngx_proxy_wasm_step_e step);
+ngx_uint_t ngx_proxy_wasm_dispatch_calls_total(ngx_proxy_wasm_exec_t *pwexec);
+void ngx_proxy_wasm_dispatch_calls_cancel(ngx_proxy_wasm_exec_t *pwexec);
 
 
 /* host handlers */

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -1087,6 +1087,16 @@ ngx_proxy_wasm_hfuncs_send_local_response(ngx_wavm_instance_t *instance,
                                                NGX_PROXY_WASM_ACTION_DONE);
         }
 
+        /* pwexec->step == NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE) */
+
+        if (ngx_proxy_wasm_dispatch_calls_total(pwexec)) {
+            ngx_proxy_wasm_log_error(NGX_LOG_NOTICE, pwexec->log, 0,
+                                     "local response produced, cancelling "
+                                     "pending dispatch calls");
+
+            ngx_proxy_wasm_dispatch_calls_cancel(pwexec);
+        }
+
         break;
 
     case NGX_ERROR:

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -1180,9 +1180,6 @@ ngx_proxy_wasm_hfuncs_dispatch_http_call(ngx_wavm_instance_t *instance,
 
     *callout_id = call->id;
 
-    ngx_proxy_wasm_ctx_set_next_action(pwexec->parent,
-                                       NGX_PROXY_WASM_ACTION_PAUSE);
-
     return ngx_proxy_wasm_result_ok(rets);
 }
 

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -336,9 +336,6 @@ ngx_http_proxy_wasm_on_dispatch_response(ngx_proxy_wasm_exec_t *pwexec)
                    "(pwexec->id: %d, token_id: %d, n_headers: %d)",
                    pwexec->id, call->id, n_headers);
 
-    ngx_proxy_wasm_ctx_set_next_action(pwexec->parent,
-                                       NGX_PROXY_WASM_ACTION_CONTINUE);
-
     ngx_http_wasm_continue(rctx);
 
     rc = ngx_wavm_instance_call_funcref(pwexec->ictx->instance,

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
@@ -29,6 +29,7 @@ typedef enum {
 
 struct ngx_http_proxy_wasm_dispatch_s {
     ngx_pool_t                             *pool;  /* owned */
+    ngx_queue_t                             q;     /* stored by caller */
     uint32_t                                id;
     ngx_msec_t                              timeout;
     ngx_wasm_socket_tcp_t                   sock;

--- a/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
@@ -9,7 +9,115 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: proxy_wasm - dispatch_http_call() on dispatch response (1 subsequent call)
+=== TEST 1: proxy_wasm - dispatch_http_call() 2 parallel calls
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        echo "Hello world";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              ncalls=2';
+        echo ok;
+    }
+--- response_headers_like
+pwm-call-id: 0, 1
+--- response_body
+ok
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 2: proxy_wasm - dispatch_http_call() 10 parallel calls
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        echo "Hello world";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              ncalls=10';
+        echo ok;
+    }
+--- response_headers_like
+pwm-call-id: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+--- response_body
+ok
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 3: proxy_wasm - dispatch_http_call() on_request_headers: 2 calls, on_request_body: 2 calls
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        echo "Hello world";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              ncalls=2';
+        proxy_wasm hostcalls 'on=request_body \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched \
+                              ncalls=2';
+        echo ok;
+    }
+--- request
+GET /t
+
+Hello world
+--- response_headers_like
+pwm-call-id: 0, 1, 2, 3
+--- response_body
+ok
+--- grep_error_log eval: qr/\[info\] .*? on_(http_call_response|request|response|log).*/
+--- grep_error_log_out eval
+qr/\A.*? on_request_headers.*
+.*? on_http_call_response \(id: 0, status: 200, headers: 5, body_bytes: 12, trailers: 0, op: \).*
+.*? on_http_call_response \(id: 1, status: 200, headers: 5, body_bytes: 12, trailers: 0, op: \).*
+.*? on_request_headers.*
+.*? on_request_body.*
+.*? on_request_body.*
+.*? on_http_call_response \(id: 2, status: 200, headers: 5, body_bytes: 12, trailers: 0, op: \).*
+.*? on_http_call_response \(id: 3, status: 200, headers: 5, body_bytes: 12, trailers: 0, op: \).*
+.*? on_response_headers.*
+.*? on_response_headers.*
+.*? on_response_body.*
+.*? on_response_body.*
+.*? on_response_body.*
+.*? on_response_body.*
+.*? on_log.*
+.*? on_log/
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 4: proxy_wasm - dispatch_http_call() on dispatch response (1 subsequent call)
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -36,7 +144,7 @@ called 2 times
 
 
 
-=== TEST 2: proxy_wasm - dispatch_http_call() on dispatch response (2 subsequent calls)
+=== TEST 5: proxy_wasm - dispatch_http_call() on dispatch response (2 subsequent calls)
 --- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -59,7 +167,7 @@ called 2 times
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched \
                               on_http_call_response=call_again \
-                              ncalls=2';
+                              n_sync_calls=2';
         echo fail;
     }
 --- response_headers_like
@@ -73,7 +181,7 @@ called 3 times
 
 
 
-=== TEST 3: proxy_wasm - dispatch_http_call() on_tick (1 call)
+=== TEST 6: proxy_wasm - dispatch_http_call() on_tick (1 call)
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config
@@ -100,7 +208,7 @@ qr/on_root_http_call_response \(id: 0, status: 200, headers: 5, body_bytes: 12, 
 
 
 
-=== TEST 4: proxy_wasm - dispatch_http_call() on_tick (10 calls)
+=== TEST 7: proxy_wasm - dispatch_http_call() on_tick (10 calls)
 --- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -114,7 +222,7 @@ qr/on_root_http_call_response \(id: 0, status: 200, headers: 5, body_bytes: 12, 
                               on_tick=dispatch \
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched \
-                              ncalls=10';
+                              n_sync_calls=10';
         echo ok;
     }
 --- wait: 2
@@ -139,7 +247,7 @@ on_root_http_call_response \(id: 9, status: 200, headers: 5, body_bytes: 12, tra
 
 
 
-=== TEST 5: proxy_wasm - dispatch_http_call() on_request_headers, filter chain execution sanity
+=== TEST 8: proxy_wasm - dispatch_http_call() on_request_headers, filter chain execution sanity
 should execute all filters request and response steps
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -184,7 +292,7 @@ qr/\A.*? on_request_headers.*
 
 
 
-=== TEST 6: proxy_wasm - dispatch_http_call() on_request_body, filter chain execution sanity
+=== TEST 9: proxy_wasm - dispatch_http_call() on_request_body, filter chain execution sanity
 should execute all filters request and response steps
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -197,7 +305,8 @@ should execute all filters request and response steps
         proxy_wasm hostcalls 'on=request_body \
                               test=/t/dispatch_http_call \
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
-                              path=/dispatched';
+                              path=/dispatched \
+                              ncalls=3';
         proxy_wasm hostcalls;
         echo ok;
     }
@@ -213,6 +322,8 @@ qr/\A.*? on_request_headers.*
 .*? on_request_headers.*
 .*? on_request_body.*
 .*? on_http_call_response \(id: 0, status: 200, headers: 5, body_bytes: 10, trailers: 0, op: \).*
+.*? on_http_call_response \(id: 1, status: 200, headers: 5, body_bytes: 10, trailers: 0, op: \).*
+.*? on_http_call_response \(id: 2, status: 200, headers: 5, body_bytes: 10, trailers: 0, op: \).*
 .*? on_request_body.*
 .*? on_response_headers.*
 .*? on_response_headers.*

--- a/t/05-others/001-socket_buffer_reuse.t
+++ b/t/05-others/001-socket_buffer_reuse.t
@@ -33,7 +33,7 @@ __DATA__
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched \
                               on_http_call_response=call_again \
-                              ncalls=2';
+                              n_sync_calls=2';
         echo fail;
     }
 --- response_body
@@ -74,7 +74,7 @@ ngx_wasm_socket buffers not reused (buffers of size 2)
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched \
                               on_http_call_response=call_again \
-                              ncalls=2';
+                              n_sync_calls=2';
         echo fail;
     }
 --- response_body
@@ -120,7 +120,7 @@ qr/wasm reuse free buf memory \d+ >= \d+/
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched \
                               on_http_call_response=call_again \
-                              ncalls=3';
+                              n_sync_calls=3';
         echo fail;
     }
 --- response_body

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -23,6 +23,8 @@ impl Context for TestHttp {
             token_id, status.unwrap_or("".to_string()), nheaders, body_size, ntrailers, op
         );
 
+        self.add_http_response_header("pwm-call-id", token_id.to_string().as_str());
+
         match op {
             "trap" => panic!("trap!"),
             "log_request_properties" => {
@@ -79,25 +81,25 @@ impl Context for TestHttp {
                 if let Some(response) = bytes {
                     let body = String::from_utf8_lossy(&response);
                     self.add_http_response_header(
-                        format!("pwm-call-{}", self.ncalls + 1).as_str(),
+                        format!("pwm-call-{}", self.n_sync_calls + 1).as_str(),
                         body.trim(),
                     );
                 }
 
                 let again = self
                     .config
-                    .get("ncalls")
-                    .map_or(1, |v| v.parse().expect("bad ncalls value"));
+                    .get("n_sync_calls")
+                    .map_or(1, |v| v.parse().expect("bad n_sync_calls value"));
 
-                if self.ncalls < again {
-                    self.ncalls += 1;
+                if self.n_sync_calls < again {
+                    self.n_sync_calls += 1;
                     self.send_http_dispatch();
                     return;
                 }
 
                 self.send_plain_response(
                     StatusCode::OK,
-                    Some(format!("called {} times", self.ncalls + 1).as_str()),
+                    Some(format!("called {} times", self.n_sync_calls + 1).as_str()),
                 );
             }
             _ => {}

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -14,7 +14,7 @@ proxy_wasm::main! {{
     proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
         Box::new(TestRoot {
             config: HashMap::new(),
-            ncalls: 0,
+            n_sync_calls: 0,
         })
     });
 }}
@@ -88,12 +88,12 @@ impl RootContext for TestRoot {
             "log_property" => test_log_property(self),
             "set_property" => test_set_property(self),
             "dispatch" => {
-                let ncalls = self
+                let n_sync_calls = self
                     .config
-                    .get("ncalls")
-                    .map_or(1, |v| v.parse().expect("bad ncalls value"));
+                    .get("n_sync_calls")
+                    .map_or(1, |v| v.parse().expect("bad n_sync_calls value"));
 
-                if self.ncalls >= ncalls {
+                if self.n_sync_calls >= n_sync_calls {
                     return;
                 }
 
@@ -134,9 +134,9 @@ impl RootContext for TestRoot {
                     headers.push((":scheme", "http"));
                 }
 
-                self.ncalls += 1;
+                self.n_sync_calls += 1;
 
-                info!("call {}", self.ncalls);
+                info!("call {}", self.n_sync_calls);
 
                 self.dispatch_http_call(
                     self.get_config("host").unwrap_or(""),
@@ -172,6 +172,7 @@ impl RootContext for TestRoot {
         Some(Box::new(TestHttp {
             config: self.config.clone(),
             on_phases: phases,
+            n_sync_calls: 0,
             ncalls: 0,
         }))
     }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 pub struct TestHttp {
     pub on_phases: Vec<TestPhase>,
     pub config: HashMap<String, String>,
+    pub n_sync_calls: usize,
     pub ncalls: usize,
 }
 
@@ -96,7 +97,15 @@ impl TestHttp {
 
             /* http dispatch */
             "/t/dispatch_http_call" => {
-                self.send_http_dispatch();
+                let n = self
+                    .config
+                    .get("ncalls")
+                    .map_or(1, |v| v.parse().expect("bad ncalls value"));
+
+                for _ in 0..n {
+                    self.send_http_dispatch();
+                }
+
                 return Action::Pause;
             }
 
@@ -164,8 +173,8 @@ impl TestHttp {
         }
 
         if self.get_config("no_path").is_none() {
-            if self.ncalls > 0 {
-                path.push_str(format!("{}", self.ncalls).as_str());
+            if self.n_sync_calls > 0 {
+                path.push_str(format!("{}", self.n_sync_calls).as_str());
             }
 
             headers.push((":path", path.as_str()));

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_root.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_root.rs
@@ -2,5 +2,5 @@ use crate::*;
 
 pub struct TestRoot {
     pub config: HashMap<String, String>,
-    pub ncalls: usize,
+    pub n_sync_calls: usize,
 }


### PR DESCRIPTION
Update ngx_proxy_wasm host code to better delegate dispatch scheduling
to filters.

- Keep track of number of pending calls in ngx_proxy_wasm_ctx.
- Do not unconditionally CONTINUE after dispatch callback.
- PAUSE after dispatch callback when pending_calls > 0.