### PR TITLE
fix (wasm) memory fault with environ_get

### DIFF
--- a/t/lib/wasi-host-tests/src/lib.rs
+++ b/t/lib/wasi-host-tests/src/lib.rs
@@ -1,5 +1,6 @@
 use ngx::*;
 use std::time::{Instant, SystemTime};
+use std::ffi::CStr;
 
 macro_rules! test_wasi_assert {
     ($e:expr) => {
@@ -43,16 +44,22 @@ pub fn test_wasi_environ_get() {
     if let Ok((size, buf_size)) = unsafe { wasi::environ_sizes_get() } {
         let mut environ: Vec<*mut u8> = vec![&mut u; size];
         let mut environ_buf = vec![0; buf_size];
+        let mut environ_out: Vec<String> = vec![String::new(); size];
 
         if let Ok(()) = unsafe { wasi::environ_get(environ.as_mut_ptr(), environ_buf.as_mut_ptr()) }
         {
-            match std::str::from_utf8(&environ_buf) {
-                Ok(v) => {
-                    resp::ngx_resp_say(Some(v));
-                    return;
-                }
-                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+            for (i, &env) in environ.iter().enumerate() {
+                let c_str = unsafe { CStr::from_ptr(env as *const i8) };
+                match std::str::from_utf8(c_str.to_bytes()) {
+                    Ok(v) => {
+                        environ_out[i] = v.to_string();
+                    }
+                    Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+                };
             };
+            let msg: String = environ_out.join("\n");
+            resp::ngx_resp_say(Some(&msg));
+            return;
         }
     }
 


### PR DESCRIPTION
Using my tingo wasm plugin with kong-enterprise-edition 3.4.3.3 with no-license mode, I found an error in this module. Logs are the below.

After some investigation, I suspect the current implementation of [`ngx_wasi_hfuncs_environ_get` function](https://github.com/Kong/ngx_wasm_module/blob/c37b8ef6006d9474d17ec657742a6e5d1d120622/src/wasm/wasi/ngx_wasi_host.c#L111).

In my plugin case, it is called from [wasi-libc](https://github.com/WebAssembly/wasi-libc/blob/a6489a85633ae36dc1d3ec93f85d27ca242feed0/libc-bottom-half/sources/__wasilibc_initialize_environ.c#L64).

I'm not expert of WASM but it seems to be that it doesn't take care of addres space conversion.

And [test_wsi_environ_get](https://github.com/Kong/ngx_wasm_module/blob/c37b8ef6006d9474d17ec657742a6e5d1d120622/t/lib/wasi-host-tests/src/lib.rs#L47) doesn't check validity of contents of `environ` value.

To fix this problem, First, I rewrite that test to check contens of `environ` value and the test fails.

Then, I've rewrote `ngx_wasi_hfuncs_environ_get` pointer operations as `ngx_wasi_hfuncs_fd_write` function.

Logs:

```
[error] 191#0: *5882 [wasm] error while executing at wasm backtrace:
    0: 0x1c08 - strncmp
                    at /__w/tinygo/tinygo/lib/wasi-libc/libc-top-half/musl/src/string/strncmp.c:7:15
    1: 0x1568 - getenv
                    at /__w/tinygo/tinygo/lib/wasi-libc/libc-top-half/musl/src/env/getenv.c:17:9
    2: 0x24af5 - syscall.Getenv
                    at /usr/local/tinygo/src/syscall/syscall_libc.go:179:20              - time.initLocal
                    at /usr/local/go/src/time/zoneinfo_unix.go:36:26
    3: 0x10049 - (*sync.Once).Do
                    at /usr/local/tinygo/src/sync/once.go:15:3
    4: 0x1cfb9 - (*time.Location).get
    5: 0x2817f - (time.Time).locabs
                    at /usr/local/go/src/time/time.go:484:12
    6: 0x28dae - (time.Time).appendFormat
                    at /usr/local/go/src/time/format.go:650:31              - (time.Time).AppendFormat
                    at /usr/local/go/src/time/format.go:644:24              - (time.Time).Format
                    at /usr/local/go/src/time/format.go:630:20
    7: 0x894af - (*main.myPluginHTTPContext).writeLog
                    at /home/tinygo/go/wasm/my-filter/main.go:349:32
    8: 0x8a990 - (*main.myPluginHTTPContext).OnHttpResponseBody
                    at /home/tinygo/go/wasm/my-filter/main.go:299:20              - (Go interface method)
                    at <Go interface method>              - proxy_on_response_body
                    at /home/tinygo/go/pkg/mod/github.com/tetratelabs/proxy-wasm-go-sdk@v0.22.1-0.20231004080525-84985eec31a8/proxywasm/internal/abi_callback_l7.go:86:31
Caused by:
    0: memory fault at wasm address 0x6c6c7566 in linear memory of size 0xb0000
    1: wasm trap: out of bounds memory access
Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: wasmtime::trap::from_runtime_box
   2: wasmtime::func::Func::call_unchecked_raw
   3: wasmtime::func::Func::call_impl
   4: wasmtime_func_call
   5: ngx_wasmtime_call
             at /home/ubuntu/.cache/bazel/_bazel_ubuntu/53933f63cb18d764e0c8ba27eb580417/execroot/kong/external/ngx_wasm_module/src/wasm/wrt/ngx_wrt_wasmtime.c:657:16
```