### PR TITLE
chore(ci) drop codeql paths/paths-ignore from its config

### DIFF
--- a/.github/actions/codeql-config.yml
+++ b/.github/actions/codeql-config.yml
@@ -1,6 +1,0 @@
-paths:
-  - src/
-  - lib/
-paths-ignore:
-  - work/
-  - t/

--- a/.github/workflows/job-codeql-analyzer.yml
+++ b/.github/workflows/job-codeql-analyzer.yml
@@ -40,7 +40,6 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ inputs.language }}
-          config-file: ./.github/actions/codeql-config.yml
       - name: 'Setup cache - work/ dir'
         uses: actions/cache@v4
         if: ${{ !env.ACT }}


### PR DESCRIPTION
According to the GHA warning:

> The "paths"/"paths-ignore" fields of the config only have effect
for JavaScript, Python, and Ruby.