### PR TITLE
fix(proxy-wasm) always pass 'eof=false' in header steps

### DIFF
--- a/docs/PROXY_WASM.md
+++ b/docs/PROXY_WASM.md
@@ -726,19 +726,28 @@ Proxy-Wasm's design was primarily influenced by Envoy concepts and features, but
 because Envoy and Nginx differ in underlying implementations there remains a few
 limitations on some supported features (non-exhaustive list):
 
-1. Pausing a filter (i.e. `Action::Pause`) can only be done in the following
+1. The `eof` flag will always be `false` in the following steps, even if the
+request/response has a body:
+    - `on_http_request_headers`
+    - `on_http_response_headers`
+
+This is due to internal Nginx constraints while reading request/response
+payloads.
+
+2. Pausing a filter (i.e. `Action::Pause`) can only be done in the following
    steps:
     - `on_http_request_headers`
     - `on_http_request_body`
     - `on_http_response_body` (to enable body buffering)
     - `on_http_call_response`
 
-2. The "queue" shared memory implementation does not implement an automatic
+3. The "queue" shared memory implementation does not implement an automatic
    eviction mechanism when the allocated memory slab is full:
     - `proxy_enqueue_shared_queue`
 
 Future ngx_wasm_module and WasmX work will be aimed at lifting these
-limitations and increasing overall surface support for the Proxy-Wasm SDK.
+limitations when possible and increasing overall surface support for the
+Proxy-Wasm SDK.
 
 [Back to TOC](#table-of-contents)
 

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -6,9 +6,6 @@
 #include <ngx_http_proxy_wasm.h>
 
 
-#define NGX_HTTP_PROXY_WASM_EOF  1
-
-
 static ngx_int_t
 ngx_http_proxy_wasm_on_request_headers(ngx_proxy_wasm_exec_t *pwexec,
     ngx_proxy_wasm_action_e *out)
@@ -40,7 +37,7 @@ ngx_http_proxy_wasm_on_request_headers(ngx_proxy_wasm_exec_t *pwexec,
         rc = ngx_wavm_instance_call_funcref(instance,
                  filter->proxy_on_http_request_headers,
                  &rets, pwexec->id, nheaders,
-                 NGX_HTTP_PROXY_WASM_EOF);
+                 0); /* eof: 0 */
     }
 
     if (rc == NGX_ERROR || rc == NGX_ABORT) {
@@ -71,7 +68,7 @@ ngx_http_proxy_wasm_on_request_body(ngx_proxy_wasm_exec_t *pwexec,
                                         filter->proxy_on_http_request_body,
                                         &rets, pwexec->id,
                                         pwexec->parent->req_body_len,
-                                        NGX_HTTP_PROXY_WASM_EOF);
+                                        1); /* eof: 1 */
     if (rc == NGX_ERROR || rc == NGX_ABORT) {
         return rc;
     }
@@ -188,7 +185,7 @@ ngx_http_proxy_wasm_on_response_headers(ngx_proxy_wasm_exec_t *pwexec,
         rc = ngx_wavm_instance_call_funcref(instance,
                  pwexec->filter->proxy_on_http_response_headers,
                  &rets, pwexec->id, nheaders,
-                 NGX_HTTP_PROXY_WASM_EOF);
+                 0); /* eof: 0 */
     }
 
     if (rc == NGX_ERROR || rc == NGX_ABORT) {
@@ -284,7 +281,7 @@ ngx_http_proxy_wasm_on_response_trailers(ngx_proxy_wasm_exec_t *pwexec,
         rc = ngx_wavm_instance_call_funcref(instance,
                  pwexec->filter->proxy_on_http_response_trailers,
                  &rets, pwexec->id, ntrailers,
-                 NGX_HTTP_PROXY_WASM_EOF);
+                 0); /* eof: 0 */
     }
 
     if (rc == NGX_ERROR || rc == NGX_ABORT) {
@@ -337,7 +334,7 @@ ngx_http_proxy_wasm_on_dispatch_response(ngx_proxy_wasm_exec_t *pwexec)
                                         filter->proxy_on_http_call_response,
                                         NULL, filter->id, call->id,
                                         n_headers,
-                                        call->http_reader.body_len, 0);
+                                        call->http_reader.body_len, 0); /* eof: 0 */
 
     return rc;
 }

--- a/t/03-proxy_wasm/hfuncs/115-proxy_get_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/115-proxy_get_http_response_body.t
@@ -78,28 +78,7 @@ qr/on_response_body, 0 bytes, eof: true.*/
 
 
 
-=== TEST 4: proxy_wasm - get_http_response_body() retrieves None (too early)
---- load_nginx_modules: ngx_http_echo_module
---- wasm_modules: hostcalls
---- config
-    location /t {
-        proxy_wasm hostcalls 'test=/t/log/response_body on=request_body';
-        echo 'Hello world';
-    }
---- response_body
-Hello world
---- grep_error_log eval: qr/(on_response_body,|response body chunk).*/
---- grep_error_log_out eval
-qr/on_response_body, 12 bytes, eof: false.*
-on_response_body, 0 bytes, eof: true.*
-\z/
---- no_error_log
-[error]
-[crit]
-
-
-
-=== TEST 5: proxy_wasm - get_http_response_body() truncates body if longer than max_size
+=== TEST 4: proxy_wasm - get_http_response_body() truncates body if longer than max_size
 --- valgrind
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -125,7 +104,7 @@ on_response_body, 0 bytes, eof: true.*/
 
 
 
-=== TEST 6: proxy_wasm - get_http_response_body() errors out on overflowing arguments
+=== TEST 5: proxy_wasm - get_http_response_body() errors out on overflowing arguments
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
 --- config

--- a/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
@@ -151,10 +151,10 @@ impl Context for OnPhases {
 }
 
 impl HttpContext for OnPhases {
-    fn on_http_request_headers(&mut self, nheaders: usize, _eof: bool) -> Action {
+    fn on_http_request_headers(&mut self, nheaders: usize, eof: bool) -> Action {
         info!(
-            "#{} on_request_headers, {} headers",
-            self.context_id, nheaders
+            "#{} on_request_headers, {} headers, eof: {}",
+            self.context_id, nheaders, eof
         );
 
         self.next_action(Phase::RequestHeaders)
@@ -169,10 +169,10 @@ impl HttpContext for OnPhases {
         self.next_action(Phase::RequestBody)
     }
 
-    fn on_http_response_headers(&mut self, nheaders: usize, _eof: bool) -> Action {
+    fn on_http_response_headers(&mut self, nheaders: usize, eof: bool) -> Action {
         info!(
-            "#{} on_response_headers, {} headers",
-            self.context_id, nheaders
+            "#{} on_response_headers, {} headers, eof: {}",
+            self.context_id, nheaders, eof
         );
 
         self.next_action(Phase::ResponseHeaders)


### PR DESCRIPTION
Reflect the fact that we do not know whether or not a request/response has a body in the RequestHeaders and ResponseHeaders steps due to internal Nginx behavior.

Thus, always pass `eof=false` to these handlers so filters can assume the same behavior: assuming that the request/response *may or may not* have a body. As such, both request/response body steps *may or may not* be invoked (same as Envoy), and the `eof` flag is not an appropriate heuristic for determining body steps invocations.

This also factorizes the on_http_phases suite into a much more concise set of tests.

See #504