### PR TITLE
feat(*) generalization of WasmX namespace for IPC modules

### DIFF
--- a/config
+++ b/config
@@ -122,26 +122,17 @@ fi
 
 ###############################################################################
 
-# core
+# wasmx
 
-NGX_WASM_INCS="\
-    $ngx_wasm_runtime_path \
-    $ngx_addon_dir/src/wasm \
-    $ngx_addon_dir/src/wasm/wrt \
-    $ngx_addon_dir/src/wasm/vm \
-    $ngx_addon_dir/src/wasm/wasi \
+NGX_WASMX_INCS="\
+    $ngx_addon_dir/src \
     $ngx_addon_dir/src/common \
     $ngx_addon_dir/src/common/proxy_wasm \
     $ngx_addon_dir/src/common/shm \
     $ngx_addon_dir/src/common/lua"
 
-NGX_WASM_DEPS="\
-    $ngx_addon_dir/src/wasm/wrt/ngx_wrt.h \
-    $ngx_addon_dir/src/wasm/ngx_wasm.h \
-    $ngx_addon_dir/src/wasm/ngx_wasm_ops.h \
-    $ngx_addon_dir/src/wasm/vm/ngx_wavm.h \
-    $ngx_addon_dir/src/wasm/vm/ngx_wavm_host.h \
-    $ngx_addon_dir/src/wasm/wasi/ngx_wasi.h \
+NGX_WASMX_DEPS="\
+    $ngx_addon_dir/src/ngx_wasmx.h \
     $ngx_addon_dir/src/common/ngx_wasm_subsystem.h \
     $ngx_addon_dir/src/common/ngx_wasm_socket_tcp.h \
     $ngx_addon_dir/src/common/ngx_wasm_socket_tcp_readers.h \
@@ -152,15 +143,8 @@ NGX_WASM_DEPS="\
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm_kv.h \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.h"
 
-NGX_WASM_SRCS="\
-    $ngx_addon_dir/src/wasm/ngx_wasm.c \
-    $ngx_addon_dir/src/wasm/ngx_wasm_ops.c \
-    $ngx_addon_dir/src/wasm/ngx_wasm_util.c \
-    $ngx_addon_dir/src/wasm/ngx_wasm_directives.c \
-    $ngx_addon_dir/src/wasm/wrt/ngx_wrt_utils.c \
-    $ngx_addon_dir/src/wasm/vm/ngx_wavm.c \
-    $ngx_addon_dir/src/wasm/vm/ngx_wavm_host.c \
-    $ngx_addon_dir/src/wasm/wasi/ngx_wasi_host.c \
+NGX_WASMX_SRCS="\
+    $ngx_addon_dir/src/ngx_wasmx.c \
     $ngx_addon_dir/src/common/ngx_wasm_subsystem.c \
     $ngx_addon_dir/src/common/ngx_wasm_socket_tcp.c \
     $ngx_addon_dir/src/common/ngx_wasm_socket_tcp_readers.c \
@@ -171,12 +155,55 @@ NGX_WASM_SRCS="\
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_util.c \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm.c \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm_kv.c \
-    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.c \
-    $ngx_wasm_runtime_srcs"
+    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.c"
+
+# wasm
+
+NGX_WASM_INCS="\
+    $NGX_WASMX_INCS \
+    $ngx_wasm_runtime_path \
+    $ngx_addon_dir/src/wasm \
+    $ngx_addon_dir/src/wasm/wrt \
+    $ngx_addon_dir/src/wasm/vm \
+    $ngx_addon_dir/src/wasm/wasi"
+
+NGX_WASM_DEPS="\
+    $NGX_WASMX_DEPS \
+    $ngx_addon_dir/src/wasm/ngx_wasm.h \
+    $ngx_addon_dir/src/wasm/wrt/ngx_wrt.h \
+    $ngx_addon_dir/src/wasm/ngx_wasm_ops.h \
+    $ngx_addon_dir/src/wasm/vm/ngx_wavm.h \
+    $ngx_addon_dir/src/wasm/vm/ngx_wavm_host.h \
+    $ngx_addon_dir/src/wasm/wasi/ngx_wasi.h"
+
+NGX_WASM_SRCS="\
+    $NGX_WASMX_SRCS \
+    $ngx_wasm_runtime_srcs \
+    $ngx_addon_dir/src/wasm/ngx_wasm_ops.c \
+    $ngx_addon_dir/src/wasm/ngx_wasm_util.c \
+    $ngx_addon_dir/src/wasm/ngx_wasm_directives.c \
+    $ngx_addon_dir/src/wasm/wrt/ngx_wrt_utils.c \
+    $ngx_addon_dir/src/wasm/vm/ngx_wavm.c \
+    $ngx_addon_dir/src/wasm/vm/ngx_wavm_host.c \
+    $ngx_addon_dir/src/wasm/wasi/ngx_wasi_host.c"
 
 NGX_WASM_CORE_SRCS="\
     $ngx_addon_dir/src/wasm/ngx_wasm_core_module.c \
     $ngx_addon_dir/src/wasm/ngx_wasm_core_host.c"
+
+# ipc
+
+NGX_IPC_INCS="\
+    $ngx_addon_dir/src/ipc"
+
+NGX_IPC_DEPS="\
+    $ngx_addon_dir/src/ipc/ngx_ipc.h"
+
+NGX_IPC_SRCS="\
+    $ngx_addon_dir/src/ipc/ngx_ipc.c"
+
+NGX_IPC_CORE_SRCS="\
+    $ngx_addon_dir/src/ipc/ngx_ipc_core_module.c"
 
 # http
 
@@ -275,13 +302,15 @@ fi
 
 if [ "$ngx_module_link" = DYNAMIC ]; then
     ngx_module_order="$ngx_addon_name \
+                      ngx_ipc_core_module \
                       ngx_wasm_core_module"
 
     ngx_module_type=CORE
     ngx_module_name=$ngx_addon_name
-    ngx_module_incs="$NGX_WASM_INCS"
-    ngx_module_deps="$NGX_WASM_DEPS"
+    ngx_module_incs="$NGX_WASM_INCS $NGX_IPC_INCS"
+    ngx_module_deps="$NGX_WASM_DEPS $NGX_IPC_DEPS"
     ngx_module_srcs="$NGX_WASM_SRCS \
+                     $NGX_IPC_SRCS \
                      $NGX_WASM_CORE_SRCS"
     ngx_module_libs=$ngx_wasm_runtime_libs
 
@@ -296,10 +325,10 @@ else
     # addon
     ngx_module_type=CORE
     ngx_module_name=$ngx_addon_name
-    ngx_module_incs="$NGX_WASM_INCS"
-    ngx_module_deps="$NGX_WASM_DEPS"
-    ngx_module_srcs="$NGX_WASM_SRCS"
-    ngx_module_libs=$ngx_wasm_runtime_libs
+    ngx_module_incs="$NGX_WASM_INCS $NGX_IPC_INCS"
+    ngx_module_deps="$NGX_WASM_DEPS $NGX_IPC_DEPS"
+    ngx_module_srcs="$NGX_WASM_SRCS $NGX_IPC_SRCS"
+    ngx_module_libs=
 
     . auto/module
 
@@ -308,6 +337,15 @@ else
     ngx_module_incs="$NGX_WASM_INCS"
     ngx_module_deps="$NGX_WASM_DEPS"
     ngx_module_srcs="$NGX_WASM_CORE_SRCS"
+    ngx_module_libs=$ngx_wasm_runtime_libs
+
+    . auto/module
+
+    ngx_module_type=IPC
+    ngx_module_name=ngx_ipc_core_module
+    ngx_module_incs="$NGX_IPC_INCS"
+    ngx_module_deps="$NGX_IPC_DEPS"
+    ngx_module_srcs="$NGX_IPC_CORE_SRCS"
     ngx_module_libs=
 
     . auto/module
@@ -417,8 +455,10 @@ if [ "$ngx_module_link" = DYNAMIC ]; then
 
 else
     # addon
-    # bypass auto/make which does not recognize $WASM_ variables
+    # bypass auto/make which does not recognize custom $*_MODULES variables
     CORE_MODULES="$CORE_MODULES $WASM_MODULES"
+    # initialize after the event module (connections initializer)
+    EVENT_MODULES="$EVENT_MODULES $IPC_MODULES"
 fi
 
 # vim:ft=sh ts=4 sts=4 sw=4:

--- a/src/common/debug/ngx_wasm_debug_module.c
+++ b/src/common/debug/ngx_wasm_debug_module.c
@@ -37,7 +37,7 @@ ngx_wasm_debug_init(ngx_cycle_t *cycle)
      * ngx_wasm_phase_lookup NULL return branch is unreacheable in
      * normal ngx_wasm_module usage.
      */
-    ngx_wasm_assert(
+    ngx_wa_assert(
         ngx_wasm_phase_lookup(&ngx_wasm_debug_subsystem, 3) == NULL
     );
 

--- a/src/common/lua/ngx_wasm_lua.c
+++ b/src/common/lua/ngx_wasm_lua.c
@@ -35,7 +35,7 @@ ngx_wasm_lua_thread_is_dead(ngx_wasm_lua_ctx_t *lctx)
         ngx_wasm_log_error(NGX_LOG_WASM_NYI, lctx->log, 0,
                            "NYI - subsystem kind: %d",
                            env->subsys->kind);
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         break;
     }
 
@@ -64,7 +64,7 @@ ngx_wasm_lua_thread_cache_key(ngx_pool_t *pool, const char *tag, u_char *src,
 #elif (NGX_WASM_STREAM)
     p = ngx_stream_lua_digest_hex(p, src, src_len);
 #else
-    ngx_wasm_assert(0);
+    ngx_wa_assert(0);
     ngx_pfree(pool, out);
     return NULL;
 #endif
@@ -82,7 +82,7 @@ ngx_wasm_lua_thread_destroy(ngx_wasm_lua_ctx_t *lctx)
 
     dd("enter");
 
-    ngx_wasm_assert(env);
+    ngx_wa_assert(env);
 
     switch (env->subsys->kind) {
 #if (NGX_WASM_HTTP)
@@ -103,7 +103,7 @@ ngx_wasm_lua_thread_destroy(ngx_wasm_lua_ctx_t *lctx)
     }
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         break;
     }
 
@@ -173,7 +173,7 @@ ngx_wasm_lua_thread_new(const char *tag, const char *src,
         ngx_wasm_log_error(NGX_LOG_WASM_NYI, lctx->log, 0,
                            "NYI - subsystem kind: %d",
                            env->subsys->kind);
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         goto error;
     }
 
@@ -218,7 +218,7 @@ ngx_wasm_lua_thread_new(const char *tag, const char *src,
         break;
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         goto error;
     }
 
@@ -264,7 +264,7 @@ ngx_wasm_lua_thread_init(ngx_wasm_lua_ctx_t *lctx)
         }
 
         /* preserve ngx_wasm_lua_content_wev_handler */
-        ngx_wasm_assert(!ctx->entered_content_phase);
+        ngx_wa_assert(!ctx->entered_content_phase);
 
         lctx->ctx.rlctx = ctx;
         break;
@@ -293,7 +293,7 @@ ngx_wasm_lua_thread_init(ngx_wasm_lua_ctx_t *lctx)
     }
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
     }
 
@@ -326,7 +326,7 @@ ngx_wasm_lua_thread_handle_rc(ngx_wasm_lua_ctx_t *lctx, ngx_int_t rc)
 
         break;
     case NGX_OK:
-        ngx_wasm_assert(ngx_wasm_lua_thread_is_dead(lctx));
+        ngx_wa_assert(ngx_wasm_lua_thread_is_dead(lctx));
 
         if (lctx->success_handler) {
 #if (DDEBUG)
@@ -350,12 +350,12 @@ ngx_wasm_lua_thread_handle_rc(ngx_wasm_lua_ctx_t *lctx, ngx_int_t rc)
     default:
         ngx_wasm_log_error(NGX_LOG_WASM_NYI, lctx->log, 0,
                            "NYI - lua resume handler rc: %d", rc);
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         rc = NGX_ERROR;
         break;
     }
 
-    ngx_wasm_assert(rc == NGX_DONE
+    ngx_wa_assert(rc == NGX_DONE
                     || rc == NGX_AGAIN
                     || rc == NGX_ERROR);
 
@@ -445,7 +445,7 @@ ngx_wasm_lua_thread_run(ngx_wasm_lua_ctx_t *lctx)
     }
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         goto error;
     }
 
@@ -491,7 +491,7 @@ ngx_wasm_lua_thread_resume(ngx_wasm_lua_ctx_t *lctx)
         ngx_http_request_t  *r = env->ctx.rctx->r;
         ngx_http_lua_ctx_t  *ctx = lctx->ctx.rlctx;
 
-        ngx_wasm_assert(ctx == ngx_http_get_module_ctx(r, ngx_http_lua_module));
+        ngx_wa_assert(ctx == ngx_http_get_module_ctx(r, ngx_http_lua_module));
 
         ngx_wasm_set_resume_handler(env);
         rc = ctx->resume_handler(r);
@@ -499,7 +499,7 @@ ngx_wasm_lua_thread_resume(ngx_wasm_lua_ctx_t *lctx)
     }
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
     }
 

--- a/src/common/lua/ngx_wasm_lua_ffi.c
+++ b/src/common/lua/ngx_wasm_lua_ffi.c
@@ -114,7 +114,7 @@ ngx_http_wasm_ffi_plan_attach(ngx_http_request_t *r, ngx_wasm_ops_plan_t *plan,
     loc->plan = plan;
 
     rc = ngx_http_wasm_rctx(r, &rctx);
-    ngx_wasm_assert(rc != NGX_DECLINED);
+    ngx_wa_assert(rc != NGX_DECLINED);
     if (rc != NGX_OK) {
         return NGX_ERROR;
     }
@@ -145,14 +145,14 @@ ngx_http_wasm_ffi_start(ngx_http_request_t *r)
     }
 
 #if 1
-    ngx_wasm_assert(rctx->ffi_attached);
+    ngx_wa_assert(rctx->ffi_attached);
 #else
     /*
      * presently, the above rctx rc is already NGX_DECLINED
      * since loc->plan is empty
      */
     if (!rctx->ffi_attached) {
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_DECLINED;
     }
 #endif
@@ -173,7 +173,7 @@ ngx_http_wasm_ffi_start(ngx_http_request_t *r)
 
     /* ignore errors: resume could trap, but FFI call succeeded */
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_DONE
                     || rc == NGX_AGAIN
                     || rc >= NGX_HTTP_SPECIAL_RESPONSE);

--- a/src/common/lua/ngx_wasm_lua_resolver.c
+++ b/src/common/lua/ngx_wasm_lua_resolver.c
@@ -96,8 +96,8 @@ ngx_wasm_lua_resolver_error_handler(ngx_wasm_lua_ctx_t *lctx)
 
     dd("enter");
 
-    ngx_wasm_assert(lctx->co_ctx->co_status == NGX_HTTP_LUA_CO_DEAD);
-    ngx_wasm_assert(!rslv_ctx->naddrs);
+    ngx_wa_assert(lctx->co_ctx->co_status == NGX_HTTP_LUA_CO_DEAD);
+    ngx_wa_assert(!rslv_ctx->naddrs);
 
     if (lctx->yielded) {
         /* re-enter normal resolver path (handler) if we yielded */
@@ -122,7 +122,7 @@ ngx_wasm_lua_resolver_success_handler(ngx_wasm_lua_ctx_t *lctx)
     dd("enter");
 
     /* resolution should have succeeded */
-    ngx_wasm_assert(rslv_ctx->naddrs);
+    ngx_wa_assert(rslv_ctx->naddrs);
 
     rslv_ctx->handler(rslv_ctx);
 
@@ -188,7 +188,7 @@ ngx_wasm_lua_resolver_resolve(ngx_resolver_ctx_t *rslv_ctx)
         break;
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_AGAIN);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_AGAIN);
 
     return rc;
 

--- a/src/common/ngx_wasm_socket_tcp.c
+++ b/src/common/ngx_wasm_socket_tcp.c
@@ -67,7 +67,7 @@ ngx_wasm_socket_tcp_err(ngx_wasm_socket_tcp_t *sock,
             return;
         }
 
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
     }
 }
 
@@ -99,7 +99,7 @@ ngx_wasm_socket_tcp_resume(ngx_wasm_socket_tcp_t *sock)
             ngx_wasm_error(&rctx->env);
             break;
         default:
-            ngx_wasm_assert(rc == NGX_OK);
+            ngx_wa_assert(rc == NGX_OK);
             ngx_wasm_continue(&rctx->env);
             break;
         }
@@ -111,7 +111,7 @@ ngx_wasm_socket_tcp_resume(ngx_wasm_socket_tcp_t *sock)
         ngx_wasm_log_error(NGX_LOG_WASM_NYI, sock->log, 0,
                            "NYI - subsystem kind: %d",
                            sock->env.subsys->kind);
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         break;
     }
 }
@@ -145,7 +145,7 @@ ngx_wasm_socket_tcp_init(ngx_wasm_socket_tcp_t *sock,
         ngx_wasm_log_error(NGX_LOG_WASM_NYI, sock->log, 0,
                            "NYI - subsystem kind: %d",
                            sock->env.subsys->kind);
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
     }
 
@@ -277,7 +277,7 @@ ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock)
             recv_timeout = wcf->recv_timeout;
 
         } else {
-            ngx_wasm_assert(r->loc_conf);
+            ngx_wa_assert(r->loc_conf);
             loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
 
             sock->buffer_size = loc->socket_buffer_size;
@@ -327,7 +327,7 @@ ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock)
         rc = ngx_wasm_socket_tcp_connect_peer(sock);
 #if (NGX_SSL)
         if (rc == NGX_OK) {
-            ngx_wasm_assert(sock->connected);
+            ngx_wa_assert(sock->connected);
 
             if (sock->ssl_conf) {
                 return ngx_wasm_socket_tcp_ssl_handshake(sock);
@@ -384,7 +384,7 @@ ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock)
         break;
 #endif
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
     }
 
@@ -393,7 +393,7 @@ ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock)
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(rslv_ctx != NGX_NO_RESOLVER);
+    ngx_wa_assert(rslv_ctx != NGX_NO_RESOLVER);
 
     rslv_ctx->name = rslv_tmp.name;
     rslv_ctx->timeout = rslv_tmp.timeout;
@@ -535,8 +535,8 @@ ngx_wasm_socket_tcp_connect_peer(ngx_wasm_socket_tcp_t *sock)
     ngx_log_debug0(NGX_LOG_DEBUG_WASM, sock->log, 0,
                    "wasm tcp socket connecting...");
 
-    ngx_wasm_assert(!sock->connected);
-    ngx_wasm_assert(sock->resolved.sockaddr);
+    ngx_wa_assert(!sock->connected);
+    ngx_wa_assert(sock->resolved.sockaddr);
 
     pc = &sock->peer;
     pc->log = sock->log;
@@ -559,7 +559,7 @@ ngx_wasm_socket_tcp_connect_peer(ngx_wasm_socket_tcp_t *sock)
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_AGAIN);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_AGAIN);
 
     sock->write_event_handler = ngx_wasm_socket_tcp_connect_handler;
     sock->read_event_handler = ngx_wasm_socket_tcp_connect_handler;
@@ -638,7 +638,7 @@ ngx_wasm_socket_tcp_ssl_handshake(ngx_wasm_socket_tcp_t *sock)
 
     if (rc == NGX_OK) {
         rc = ngx_wasm_socket_tcp_ssl_handshake_done(c);
-        ngx_wasm_assert(rc != NGX_AGAIN);
+        ngx_wa_assert(rc != NGX_AGAIN);
 
     } else if (rc == NGX_AGAIN) {
         ngx_add_timer(c->write, sock->connect_timeout);
@@ -895,7 +895,7 @@ ngx_wasm_socket_tcp_send(ngx_wasm_socket_tcp_t *sock, ngx_chain_t *cl)
             continue;
         }
 
-        ngx_wasm_assert(n == NGX_ERROR || n == NGX_AGAIN);
+        ngx_wa_assert(n == NGX_ERROR || n == NGX_AGAIN);
         break;
     }
 
@@ -906,7 +906,7 @@ ngx_wasm_socket_tcp_send(ngx_wasm_socket_tcp_t *sock, ngx_chain_t *cl)
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(n == NGX_AGAIN);
+    ngx_wa_assert(n == NGX_AGAIN);
 
     sock->write_event_handler = ngx_wasm_socket_tcp_send_handler;
 
@@ -1080,7 +1080,7 @@ ngx_wasm_socket_tcp_read(ngx_wasm_socket_tcp_t *sock,
                 return NGX_OK;
             }
 
-            ngx_wasm_assert(rc == NGX_AGAIN);
+            ngx_wa_assert(rc == NGX_AGAIN);
 
             if (b->pos < b->last) {
                 dd("more to read, continue");
@@ -1150,7 +1150,7 @@ ngx_wasm_socket_tcp_read(ngx_wasm_socket_tcp_t *sock,
         b->last += n;
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_AGAIN);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_AGAIN);
 
     if (ngx_handle_read_event(rev, 0) != NGX_OK) {
         return NGX_ERROR;

--- a/src/common/ngx_wasm_socket_tcp_readers.c
+++ b/src/common/ngx_wasm_socket_tcp_readers.c
@@ -205,7 +205,7 @@ ngx_wasm_http_alloc_large_buffer(ngx_wasm_http_reader_ctx_t *in_ctx)
                    r->header_in->pos - old, b->end - b->pos);
 
 #if 1
-    ngx_wasm_assert(r->header_in->pos - old <= b->end - b->start);
+    ngx_wa_assert(r->header_in->pos - old <= b->end - b->start);
 
 #else
     if (r->header_in->pos - old > b->end - b->start) {
@@ -314,7 +314,7 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
     ngx_http_upstream_main_conf_t   *umcf;
     ngx_http_wasm_req_ctx_t         *rctx;
 
-    ngx_wasm_assert(bytes);
+    ngx_wa_assert(bytes);
 
     r = &in_ctx->fake_r;
     rctx = in_ctx->rctx;
@@ -358,7 +358,7 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
                 return NGX_AGAIN;
             }
 
-            ngx_wasm_assert(rc == NGX_OK);
+            ngx_wa_assert(rc == NGX_OK);
 
             buf_in->buf->last = src->pos;
 
@@ -437,7 +437,7 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
                 break;
             }
 
-            ngx_wasm_assert(rc == NGX_OK);
+            ngx_wa_assert(rc == NGX_OK);
 
             /* header */
 
@@ -508,7 +508,7 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
                     break;
                 }
 
-                ngx_wasm_assert(rc == NGX_OK);
+                ngx_wa_assert(rc == NGX_OK);
 
                 in_ctx->body_len += in_ctx->chunked.size;
                 in_ctx->rest = in_ctx->chunked.size;
@@ -581,8 +581,8 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
                 return rc;
             }
 
-            ngx_wasm_assert(rc == NGX_OK);
-            ngx_wasm_assert(in_ctx->rest == 0);
+            ngx_wa_assert(rc == NGX_OK);
+            ngx_wa_assert(in_ctx->rest == 0);
 
             in_ctx->chunked.size = 0;
 
@@ -624,7 +624,7 @@ ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in, ssize_t bytes,
         }
 
 #if 0
-        ngx_wasm_assert((size_t) ngx_buf_size(buf) == in_ctx->body_len);
+        ngx_wa_assert((size_t) ngx_buf_size(buf) == in_ctx->body_len);
 
         dd("body_len: %ld", in_ctx->body_len);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -239,7 +239,7 @@ ngx_proxy_wasm_ctx(ngx_uint_t *filter_ids, size_t nfilters,
             filter = ngx_proxy_wasm_lookup_filter(id);
             if (filter == NULL) {
                 /* TODO: log error */
-                ngx_wasm_assert(0);
+                ngx_wa_assert(0);
                 return NULL;
             }
 
@@ -265,7 +265,7 @@ destroy_pwexec(ngx_proxy_wasm_exec_t *pwexec)
 
 #if 1
     /* never called on root rexec for now */
-    ngx_wasm_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
+    ngx_wa_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
 
 #else
     if (pwexec->ev) {
@@ -331,7 +331,7 @@ ngx_proxy_wasm_ctx_destroy(ngx_proxy_wasm_ctx_t *pwctx)
     for (i = 0; i < pwctx->pwexecs.nelts; i++) {
         pwexec = &pwexecs[i];
 
-        ngx_wasm_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
+        ngx_wa_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
 
         ngx_proxy_wasm_log_error(NGX_LOG_DEBUG, pwctx->log, 0,
                                  "\"%V\" filter freeing context #%d "
@@ -431,7 +431,7 @@ action2rc(ngx_proxy_wasm_ctx_t *pwctx,
 
     dd("enter (pwexec: %p, action: %d)", pwexec, action);
 
-    ngx_wasm_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
+    ngx_wa_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
 
     if (pwexec->ecode) {
         if (!pwexec->ecode_logged
@@ -558,7 +558,7 @@ action2rc(ngx_proxy_wasm_ctx_t *pwctx,
 
 error:
 
-    ngx_wasm_assert(rc == NGX_ERROR
+    ngx_wa_assert(rc == NGX_ERROR
 #ifdef NGX_WASM_HTTP
                     || rc >= NGX_HTTP_SPECIAL_RESPONSE
 #endif
@@ -615,7 +615,7 @@ ngx_proxy_wasm_resume(ngx_proxy_wasm_ctx_t *pwctx,
     default:
         if (step <= pwctx->last_completed_step) {
             dd("step %d already completed, exit", step);
-            ngx_wasm_assert(rc == NGX_OK);
+            ngx_wa_assert(rc == NGX_OK);
             goto ret;
         }
     }
@@ -624,7 +624,7 @@ ngx_proxy_wasm_resume(ngx_proxy_wasm_ctx_t *pwctx,
 
     pwexecs = (ngx_proxy_wasm_exec_t *) pwctx->pwexecs.elts;
 
-    ngx_wasm_assert(pwctx->pwexecs.nelts == pwctx->nfilters);
+    ngx_wa_assert(pwctx->pwexecs.nelts == pwctx->nfilters);
 
     for (i = pwctx->exec_index; i < pwctx->nfilters; i++) {
         pwexec = &pwexecs[i];
@@ -638,7 +638,7 @@ ngx_proxy_wasm_resume(ngx_proxy_wasm_ctx_t *pwctx,
            pwexec->filter->name->data,
            pwctx);
 
-        ngx_wasm_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
+        ngx_wa_assert(pwexec->root_id != NGX_PROXY_WASM_ROOT_CTX_ID);
 
         /* check for yielded state */
 
@@ -723,7 +723,7 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     ngx_proxy_wasm_action_e   old_action = pwctx->action;
     ngx_proxy_wasm_action_e   action = old_action;
 
-    ngx_wasm_assert(pwctx->phase);
+    ngx_wa_assert(pwctx->phase);
 
     dd("--> enter (pwexec: %p, ictx: %p, trapped: %d)",
        pwexec, pwexec->ictx,
@@ -744,8 +744,8 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     }
 #endif
 
-    ngx_wasm_assert(!pwexec->ictx->instance->trapped);
-    ngx_wasm_assert(pwexec->ictx->module == filter->module);
+    ngx_wa_assert(!pwexec->ictx->instance->trapped);
+    ngx_wa_assert(pwexec->ictx->module == filter->module);
 
     pwctx->step = step;
 
@@ -809,7 +809,7 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
         switch (pwctx->action) {
         case NGX_PROXY_WASM_ACTION_DONE:
             /* e.g. proxy_send_local_response() */
-            ngx_wasm_assert(pwctx->action != old_action);
+            ngx_wa_assert(pwctx->action != old_action);
             goto done;
         default:
             ngx_proxy_wasm_ctx_set_next_action(pwctx, action);
@@ -817,7 +817,7 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
         }
     }
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_ABORT
                     || rc == NGX_ERROR);
 
@@ -916,7 +916,7 @@ get_instance(ngx_proxy_wasm_filter_t *filter,
     dd("get instance in store: %p", store);
 
     /* store initialized */
-    ngx_wasm_assert(store->pool);
+    ngx_wa_assert(store->pool);
 
     for (q = ngx_queue_head(&store->busy);
          q != ngx_queue_sentinel(&store->busy);
@@ -947,7 +947,7 @@ get_instance(ngx_proxy_wasm_filter_t *filter,
     {
         ictx = ngx_queue_data(q, ngx_proxy_wasm_instance_t, q);
 
-        ngx_wasm_assert(!ictx->instance->trapped);
+        ngx_wa_assert(!ictx->instance->trapped);
 
         if (ictx->module == module) {
             dd("reuse free instance, going to busy");
@@ -1128,7 +1128,7 @@ ngx_proxy_wasm_create_context(ngx_proxy_wasm_filter_t *filter,
         } else {
             if (in->ictx != ictx) {
                 dd("replace pwexec instance");
-                ngx_wasm_assert(in->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
+                ngx_wa_assert(in->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
 
                 in->ictx = ictx;
                 in->started = 0;
@@ -1245,7 +1245,7 @@ ngx_proxy_wasm_create_context(ngx_proxy_wasm_filter_t *filter,
         }
 #if (NGX_DEBUG)
         else {
-            ngx_wasm_assert(pwexec->id == id);
+            ngx_wa_assert(pwexec->id == id);
             dd("pwexec #%ld found in instance %p", pwexec->id, ictx);
         }
 #endif
@@ -1360,7 +1360,7 @@ ngx_proxy_wasm_on_tick(ngx_proxy_wasm_exec_t *pwexec)
     wasm_val_vec_t            args;
     ngx_proxy_wasm_filter_t  *filter = pwexec->filter;
 
-    ngx_wasm_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
+    ngx_wa_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
 
     wasm_val_vec_new_uninitialized(&args, 1);
     ngx_wasm_vec_set_i32(&args, 0, pwexec->id);
@@ -1723,7 +1723,7 @@ ngx_proxy_wasm_filter_start(ngx_proxy_wasm_filter_t *filter)
 {
     ngx_proxy_wasm_err_e   ecode;
 
-    ngx_wasm_assert(filter->loaded);
+    ngx_wa_assert(filter->loaded);
 
     if (filter->ecode) {
         return NGX_ERROR;
@@ -1846,7 +1846,7 @@ ngx_proxy_wasm_instance_destroy(ngx_proxy_wasm_instance_t *ictx)
         n = ngx_rbtree_min(*root, *sentinel);
         pwexec = ngx_rbtree_data(n, ngx_proxy_wasm_exec_t, node);
 
-        ngx_wasm_assert(pwexec->ev == NULL);
+        ngx_wa_assert(pwexec->ev == NULL);
 
         dd("destroy ctx #%ld (pwexec: %p)", pwexec->id, pwexec);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -139,7 +139,7 @@ ngx_proxy_wasm_get_buffer_helper(ngx_wavm_instance_t *instance,
                 return NULL;
             }
 
-            ngx_wasm_assert(reader->body);
+            ngx_wa_assert(reader->body);
 
             return reader->body;
         }
@@ -371,7 +371,7 @@ ngx_proxy_wasm_hfuncs_get_buffer(ngx_wavm_instance_t *instance,
     *rlen = (uint32_t) len;
 
     if (start == NULL) {
-        ngx_wasm_assert(cl);
+        ngx_wa_assert(cl);
 
         if (cl->next == NULL) {
             /* single buffer */
@@ -385,9 +385,9 @@ ngx_proxy_wasm_hfuncs_get_buffer(ngx_wavm_instance_t *instance,
         }
 
     } else {
-        ngx_wasm_assert(cl);
-        ngx_wasm_assert(cl->buf);
-        ngx_wasm_assert(cl->next);
+        ngx_wa_assert(cl);
+        ngx_wa_assert(cl->buf);
+        ngx_wa_assert(cl->next);
         len = 0;
 
         for (/* void */; cl; cl = cl->next) {
@@ -474,7 +474,7 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
 
         rctx = ngx_http_proxy_wasm_get_rctx(instance);
 
-        ngx_wasm_assert(rctx);
+        ngx_wa_assert(rctx);
 
         if (offset == 0 && max == 0 && buf_len > 0) {
             rc = ngx_http_wasm_prepend_req_body(rctx, &s);
@@ -483,7 +483,7 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
             rc = ngx_http_wasm_set_req_body(rctx, &s, offset, max);
         }
 
-        ngx_wasm_assert(rc != NGX_ABORT);
+        ngx_wa_assert(rc != NGX_ABORT);
         break;
 
     case NGX_PROXY_WASM_BUFFER_HTTP_RESPONSE_BODY:
@@ -504,7 +504,7 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
 
         rctx = ngx_http_proxy_wasm_get_rctx(instance);
 
-        ngx_wasm_assert(rctx);
+        ngx_wa_assert(rctx);
 
         if (offset == 0 && max == 0 && buf_len > 0) {
             rc = ngx_http_wasm_prepend_resp_body(rctx, &s);
@@ -513,7 +513,7 @@ ngx_proxy_wasm_hfuncs_set_buffer(ngx_wavm_instance_t *instance,
             rc = ngx_http_wasm_set_resp_body(rctx, &s, offset, max);
         }
 
-        ngx_wasm_assert(rc != NGX_ABORT);
+        ngx_wa_assert(rc != NGX_ABORT);
         break;
 #endif
 
@@ -694,7 +694,7 @@ ngx_proxy_wasm_hfuncs_set_header_map_pairs(ngx_wavm_instance_t *instance,
      * NGX_ABORT: read-only
      */
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_ABORT);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_ABORT);
 
     return ngx_proxy_wasm_result_ok(rets);
 }
@@ -748,7 +748,7 @@ ngx_proxy_wasm_hfuncs_add_header_map_value(ngx_wavm_instance_t *instance,
         return ngx_proxy_wasm_result_err(rets);
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_ABORT);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_ABORT);
 
     return ngx_proxy_wasm_result_ok(rets);
 }
@@ -802,7 +802,7 @@ ngx_proxy_wasm_hfuncs_replace_header_map_value(ngx_wavm_instance_t *instance,
         return ngx_proxy_wasm_result_err(rets);
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_ABORT);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_ABORT);
 
     return ngx_proxy_wasm_result_ok(rets);
 }
@@ -834,7 +834,7 @@ ngx_proxy_wasm_hfuncs_remove_header_map_value(ngx_wavm_instance_t *instance,
         return ngx_proxy_wasm_result_err(rets);
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_ABORT);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_ABORT);
 
     return ngx_proxy_wasm_result_ok(rets);
 }
@@ -886,7 +886,7 @@ ngx_proxy_wasm_hfuncs_get_property(ngx_wavm_instance_t *instance,
 
         return ngx_proxy_wasm_result_err(rets);
     default:
-        ngx_wasm_assert(rc == NGX_OK);
+        ngx_wa_assert(rc == NGX_OK);
     }
 
     p = ngx_proxy_wasm_alloc(pwexec, value.len);
@@ -947,7 +947,7 @@ ngx_proxy_wasm_hfuncs_set_property(ngx_wavm_instance_t *instance,
 
         return ngx_proxy_wasm_result_err(rets);
     default:
-        ngx_wasm_assert(rc == NGX_OK);
+        ngx_wa_assert(rc == NGX_OK);
     }
 
     return ngx_proxy_wasm_result_ok(rets);
@@ -1036,7 +1036,7 @@ ngx_proxy_wasm_hfuncs_send_local_response(ngx_wavm_instance_t *instance,
 #if (NGX_DEBUG)
     grpc_status = args[7].of.i32;
 
-    ngx_wasm_assert(grpc_status == -1);
+    ngx_wa_assert(grpc_status == -1);
 #endif
 
     if (ngx_proxy_wasm_pairs_unmarshal(pwexec, &headers, &map) != NGX_OK) {
@@ -1117,7 +1117,7 @@ ngx_proxy_wasm_hfuncs_send_local_response(ngx_wavm_instance_t *instance,
 
     default:
         /* unreachable */
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_WAVM_NYI;
 
     }
@@ -1255,7 +1255,7 @@ ngx_proxy_wasm_hfuncs_get_shared_data(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_BAD_USAGE);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     /* get */
 
@@ -1269,7 +1269,7 @@ ngx_proxy_wasm_hfuncs_get_shared_data(ngx_wavm_instance_t *instance,
         return ngx_proxy_wasm_result_notfound(rets);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     /* return value */
 
@@ -1329,7 +1329,7 @@ ngx_proxy_wasm_hfuncs_set_shared_data(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_BAD_USAGE);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     /* set */
 
@@ -1355,7 +1355,7 @@ ngx_proxy_wasm_hfuncs_set_shared_data(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_ERROR);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     if (!written) {
         return ngx_proxy_wasm_result_cas_mismatch(rets);
@@ -1441,7 +1441,7 @@ ngx_proxy_wasm_hfuncs_enqueue_shared_queue(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_BAD_USAGE);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     shm = zone->data;
 
@@ -1458,7 +1458,7 @@ ngx_proxy_wasm_hfuncs_enqueue_shared_queue(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_ERROR);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     return ngx_proxy_wasm_result_ok(rets);
 }
@@ -1515,7 +1515,7 @@ ngx_proxy_wasm_hfuncs_dequeue_shared_queue(ngx_wavm_instance_t *instance,
                                           NGX_WAVM_BAD_USAGE);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     shm = zone->data;
 
@@ -1534,7 +1534,7 @@ ngx_proxy_wasm_hfuncs_dequeue_shared_queue(ngx_wavm_instance_t *instance,
         return ngx_proxy_wasm_result_empty(rets);
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     /* return value */
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
@@ -151,7 +151,7 @@ ngx_proxy_wasm_maps_get_all(ngx_wavm_instance_t *instance,
         for (i = 0; ngx_proxy_wasm_maps_special_keys[i].key.len; i++) {
             mkey = &ngx_proxy_wasm_maps_special_keys[i];
 
-            ngx_wasm_assert(mkey->get_);
+            ngx_wa_assert(mkey->get_);
 
             if (map_type != mkey->map_type) {
                 continue;
@@ -272,7 +272,7 @@ ngx_proxy_wasm_maps_get(ngx_wavm_instance_t *instance,
 
 found:
 
-    ngx_wasm_assert(value);
+    ngx_wa_assert(value);
 
     return value;
 }
@@ -352,11 +352,11 @@ ngx_proxy_wasm_maps_set(ngx_wavm_instance_t *instance,
         break;
 
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(rc == NGX_DECLINED);
+    ngx_wa_assert(rc == NGX_DECLINED);
 
     switch (map_type) {
 
@@ -381,7 +381,7 @@ ngx_proxy_wasm_maps_set(ngx_wavm_instance_t *instance,
 #endif
 
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ERROR;
 
     }
@@ -404,7 +404,7 @@ ngx_proxy_wasm_maps_get_special_key(ngx_wavm_instance_t *instance,
 
         dd("key: %.*s", (int) mkey->key.len, mkey->key.data);
 
-        ngx_wasm_assert(mkey->get_);
+        ngx_wa_assert(mkey->get_);
 
         if (map_type != mkey->map_type
             || !ngx_str_eq(mkey->key.data, mkey->key.len, key->data, key->len))
@@ -650,7 +650,7 @@ ngx_proxy_wasm_maps_get_response_status(ngx_wavm_instance_t *instance,
     ngx_http_wasm_req_ctx_t  *rctx;
     ngx_http_request_t       *r;
 
-    ngx_wasm_assert(map_type == NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS);
+    ngx_wa_assert(map_type == NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS);
 
     pwexec = ngx_proxy_wasm_instance2pwexec(instance);
     rctx = ngx_http_proxy_wasm_get_rctx(instance);
@@ -696,7 +696,7 @@ ngx_proxy_wasm_maps_get_response_status(ngx_wavm_instance_t *instance,
                                      - pwctx->response_status.data;
     }
 
-    ngx_wasm_assert(pwctx->response_status.len);
+    ngx_wa_assert(pwctx->response_status.len);
 
     return &pwctx->response_status;
 }
@@ -712,7 +712,7 @@ ngx_proxy_wasm_maps_get_dispatch_status(ngx_wavm_instance_t *instance,
     ngx_http_proxy_wasm_dispatch_t  *call;
     ngx_wasm_http_reader_ctx_t      *reader;
 
-    ngx_wasm_assert(map_type == NGX_PROXY_WASM_MAP_HTTP_CALL_RESPONSE_HEADERS);
+    ngx_wa_assert(map_type == NGX_PROXY_WASM_MAP_HTTP_CALL_RESPONSE_HEADERS);
 
     pwexec = ngx_proxy_wasm_instance2pwexec(instance);
     pwctx = pwexec->parent;
@@ -721,7 +721,7 @@ ngx_proxy_wasm_maps_get_dispatch_status(ngx_wavm_instance_t *instance,
 
     /* status */
 
-    ngx_wasm_assert(reader->fake_r.upstream);
+    ngx_wa_assert(reader->fake_r.upstream);
 
     if (reader->fake_r.upstream == NULL) {
         return NULL;
@@ -756,7 +756,7 @@ ngx_proxy_wasm_maps_get_dispatch_status(ngx_wavm_instance_t *instance,
                                  - pwctx->call_status.data;
     }
 
-    ngx_wasm_assert(pwctx->call_status.len);
+    ngx_wa_assert(pwctx->call_status.len);
 
     return &pwctx->call_status;
 }

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -843,7 +843,7 @@ ngx_proxy_wasm_properties_set_ngx(ngx_proxy_wasm_ctx_t *pwctx,
 #if 0
         /* fake requests are presently caught above */
         if (r->variables == NULL) {
-            ngx_wasm_assert(r->connection->fd == NGX_WASM_BAD_FD);
+            ngx_wa_assert(r->connection->fd == NGX_WA_BAD_FD);
             return NGX_ERROR;
         }
 #endif
@@ -936,7 +936,7 @@ set_hpn_value(host_props_node_t *hpn, ngx_str_t *value, unsigned is_const)
     u_char  *new_data;
 
     if (value->data == NULL) {
-        ngx_wasm_assert(is_const);
+        ngx_wa_assert(is_const);
         new_data = NULL;
         hpn->is_const_null = 1;
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -62,12 +62,12 @@ ngx_proxy_wasm_step_name(ngx_proxy_wasm_step_e step)
 {
     ngx_str_t  *name;
 
-    ngx_wasm_assert(step);
-    ngx_wasm_assert(step <= NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE);
+    ngx_wa_assert(step);
+    ngx_wa_assert(step <= NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE);
 
     name = &ngx_proxy_wasm_steplist[step];
 
-    ngx_wasm_assert(name);
+    ngx_wa_assert(name);
 
     return name;
 }
@@ -78,12 +78,12 @@ ngx_proxy_wasm_action_name(ngx_proxy_wasm_action_e action)
 {
     ngx_str_t  *name;
 
-    ngx_wasm_assert(action >= NGX_PROXY_WASM_ACTION_CONTINUE);
-    ngx_wasm_assert(action <= NGX_PROXY_WASM_ACTION_CLOSE);
+    ngx_wa_assert(action >= NGX_PROXY_WASM_ACTION_CONTINUE);
+    ngx_wa_assert(action <= NGX_PROXY_WASM_ACTION_CLOSE);
 
     name = &ngx_proxy_wasm_actionlist[action];
 
-    ngx_wasm_assert(name);
+    ngx_wa_assert(name);
 
     return name;
 }
@@ -160,7 +160,7 @@ ngx_proxy_wasm_log_error(ngx_uint_t level, ngx_log_t *log,
                          ? pwexec->root_id
                          : pwexec->id);
 
-        ngx_wasm_assert(pre->len == (size_t) (p - pre->data));
+        ngx_wa_assert(pre->len == (size_t) (p - pre->data));
     }
 
 skip_prefix:
@@ -202,7 +202,7 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
 
     dd("enter");
 
-    ngx_wasm_assert(rexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
+    ngx_wa_assert(rexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
 
     ngx_free(ev);
 
@@ -409,7 +409,7 @@ ngx_proxy_wasm_pairs_marshal(ngx_list_t *list, ngx_array_t *extras, u_char *buf,
         n++;
     }
 
-    ngx_wasm_assert(n == count);
+    ngx_wa_assert(n == count);
 
     n = 0;
 
@@ -451,7 +451,7 @@ ngx_proxy_wasm_pairs_marshal(ngx_list_t *list, ngx_array_t *extras, u_char *buf,
         n++;
     }
 
-    ngx_wasm_assert(n == count);
+    ngx_wa_assert(n == count);
 }
 
 

--- a/src/common/shm/ngx_wasm_shm.c
+++ b/src/common/shm/ngx_wasm_shm.c
@@ -56,7 +56,7 @@ ngx_wasm_shm_init(ngx_cycle_t *cycle)
             break;
 
         default:
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             return NGX_ERROR;
         }
     }

--- a/src/common/shm/ngx_wasm_shm_kv.c
+++ b/src/common/shm/ngx_wasm_shm_kv.c
@@ -36,7 +36,7 @@ typedef struct {
 static ngx_inline ngx_wasm_shm_kv_t *
 ngx_wasm_shm_get_kv(ngx_wasm_shm_t *shm)
 {
-    ngx_wasm_assert(shm->type == NGX_WASM_SHM_TYPE_KV);
+    ngx_wa_assert(shm->type == NGX_WASM_SHM_TYPE_KV);
     return shm->data;
 }
 
@@ -128,7 +128,7 @@ queue_for_node(ngx_wasm_shm_t *shm, ngx_wasm_shm_kv_node_t *n)
     }
 
     /* unreachable */
-    ngx_wasm_assert(0);
+    ngx_wa_assert(0);
     return NULL;
 }
 

--- a/src/common/shm/ngx_wasm_shm_queue.c
+++ b/src/common/shm/ngx_wasm_shm_queue.c
@@ -19,7 +19,7 @@ typedef struct {
 static ngx_inline ngx_wasm_shm_queue_t *
 ngx_wasm_shm_get_queue(ngx_wasm_shm_t *shm)
 {
-    ngx_wasm_assert(shm->type == NGX_WASM_SHM_TYPE_QUEUE);
+    ngx_wa_assert(shm->type == NGX_WASM_SHM_TYPE_QUEUE);
     return shm->data;
 }
 
@@ -54,7 +54,7 @@ inc_ptr(ngx_wasm_shm_queue_t *queue, ngx_uint_t *ptr, ngx_uint_t n)
 
     if (new_ptr >= cap) {
         new_ptr = new_ptr - cap;
-        ngx_wasm_assert(new_ptr < cap);
+        ngx_wa_assert(new_ptr < cap);
     }
 
     *ptr = new_ptr;
@@ -68,8 +68,8 @@ circular_write(ngx_log_t *log, ngx_wasm_shm_queue_t *queue,
     ngx_uint_t  cap = queue_capacity(queue);
     ngx_uint_t  forward_capacity = cap - ptr;
 
-    ngx_wasm_assert(data_size <= cap - queue_occupancy(queue));
-    ngx_wasm_assert(ptr < cap);
+    ngx_wa_assert(data_size <= cap - queue_occupancy(queue));
+    ngx_wa_assert(ptr < cap);
 
     dd("forward_capacity: %lu, data_size: %lu",
        forward_capacity, data_size);
@@ -95,9 +95,9 @@ circular_read(ngx_log_t *log, ngx_wasm_shm_queue_t *queue,
     ngx_uint_t  cap = queue_capacity(queue);
     ngx_uint_t  forward_capacity = cap - ptr;
 
-    ngx_wasm_assert(data_size <= queue_occupancy(queue));
-    ngx_wasm_assert(ptr < cap);
-    ngx_wasm_assert(data_out);
+    ngx_wa_assert(data_size <= queue_occupancy(queue));
+    ngx_wa_assert(ptr < cap);
+    ngx_wa_assert(data_out);
 
     if (data_size >= forward_capacity) {
         ngx_log_debug0(NGX_LOG_DEBUG_WASM, log, 0,
@@ -119,8 +119,8 @@ check_queue_invariance(ngx_wasm_shm_queue_t *queue)
 #if (NGX_DEBUG)
     ngx_uint_t  cap = queue_capacity(queue);
 
-    ngx_wasm_assert(queue->push_ptr < cap);
-    ngx_wasm_assert(queue->pop_ptr < cap);
+    ngx_wa_assert(queue->push_ptr < cap);
+    ngx_wa_assert(queue->pop_ptr < cap);
 #endif
 }
 
@@ -139,7 +139,7 @@ ngx_wasm_shm_queue_init(ngx_wasm_shm_t *shm)
     }
 
     buffer_size = shm->shpool->end - shm->shpool->start;
-    ngx_wasm_assert(buffer_size > reserved_size);
+    ngx_wa_assert(buffer_size > reserved_size);
     buffer_size -= reserved_size;
 
     queue->buffer = ngx_slab_calloc(shm->shpool, buffer_size);

--- a/src/http/ngx_http_wasm_filter_module.c
+++ b/src/http/ngx_http_wasm_filter_module.c
@@ -83,7 +83,7 @@ ngx_http_wasm_header_filter_handler(ngx_http_request_t *r)
         goto done;
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     rctx->entered_header_filter = 1;
 
@@ -167,7 +167,7 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
 
         if (r != r->main && rctx == NULL) {
             /* subrequest with no rctx; merge main rctx for buffering */
-            ngx_wasm_assert(mrctx);
+            ngx_wa_assert(mrctx);
             rctx = mrctx;
         }
     }
@@ -190,7 +190,7 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
             goto done;
         case NGX_OK:
             /* chunk in buffers */
-            ngx_wasm_assert(rctx->resp_bufs);
+            ngx_wa_assert(rctx->resp_bufs);
 
             if (!rctx->resp_chunk_eof) {
                 /* more to come; go again */
@@ -208,7 +208,7 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
             ngx_http_wasm_body_filter_resume(rctx, rctx->resp_bufs);
             break;
         default:
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
         }
     }
@@ -233,7 +233,7 @@ ngx_http_wasm_body_filter_handler(ngx_http_request_t *r, ngx_chain_t *in)
 
 done:
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_AGAIN || rc == NGX_ERROR);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_AGAIN || rc == NGX_ERROR);
 
     ngx_log_debug1(NGX_LOG_DEBUG_WASM, r->connection->log, 0,
                    "wasm \"body_filter\" phase rc: %d", rc);
@@ -289,7 +289,7 @@ ngx_http_wasm_body_filter_buffer(ngx_http_wasm_req_ctx_t *rctx, ngx_chain_t *in)
 
     dd("enter");
 
-    ngx_wasm_assert(rctx->resp_buffering);
+    ngx_wa_assert(rctx->resp_buffering);
 
     cl = rctx->resp_buf_last;
     loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
@@ -379,7 +379,7 @@ ngx_http_wasm_body_filter_buffer(ngx_http_wasm_req_ctx_t *rctx, ngx_chain_t *in)
 
             if (copy < n) {
                 /* more to copy, next buffer */
-                ngx_wasm_assert(cl->buf->last == cl->buf->end);
+                ngx_wa_assert(cl->buf->last == cl->buf->end);
                 rctx->resp_buf_last = cl;
                 cl = NULL;
             }

--- a/src/http/ngx_http_wasm_headers.c
+++ b/src/http/ngx_http_wasm_headers.c
@@ -38,7 +38,7 @@ ngx_http_wasm_htype_list(ngx_http_request_t *r,
         return &r->headers_out.headers;
 
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NULL;
 
     }
@@ -112,10 +112,10 @@ ngx_http_wasm_set_header(ngx_http_request_t *r,
         break;
     }
 
-    ngx_wasm_assert(hv.key);
-    ngx_wasm_assert(hv.value);
-    ngx_wasm_assert(hv.list);
-    ngx_wasm_assert(hv.handler);
+    ngx_wa_assert(hv.key);
+    ngx_wa_assert(hv.value);
+    ngx_wa_assert(hv.list);
+    ngx_wa_assert(hv.handler);
 
     return hv.handler->handler_(&hv);
 }
@@ -177,7 +177,7 @@ again:
                 goto again;
 
             } else {
-                ngx_wasm_assert(hv->mode == NGX_HTTP_WASM_HEADERS_SET);
+                ngx_wa_assert(hv->mode == NGX_HTTP_WASM_HEADERS_SET);
 
                 dd("updating '%.*s: %.*s' to '%.*s: %.*s'",
                    (int) h[i].key.len, h[i].key.data,
@@ -324,7 +324,7 @@ ngx_http_wasm_set_builtin_header_handler(ngx_http_wasm_header_set_ctx_t *hv)
         return NGX_DECLINED;
     }
 
-    ngx_wasm_assert(hv->mode == NGX_HTTP_WASM_HEADERS_SET);
+    ngx_wa_assert(hv->mode == NGX_HTTP_WASM_HEADERS_SET);
 
     dd("updating existing '%.*s: %.*s' builtin header to '%.*s: %.*s'",
        (int) h->key.len, h->key.data, (int) h->value.len, h->value.data,

--- a/src/http/ngx_http_wasm_headers_request.c
+++ b/src/http/ngx_http_wasm_headers_request.c
@@ -295,7 +295,7 @@ ngx_http_wasm_set_ua_header_handler(ngx_http_wasm_header_set_ctx_t *hv)
 
     if (user_agent == NULL) {
         /* cleared */
-        ngx_wasm_assert(hv->mode == NGX_HTTP_WASM_HEADERS_REMOVE);
+        ngx_wa_assert(hv->mode == NGX_HTTP_WASM_HEADERS_REMOVE);
         return NGX_OK;
     }
 
@@ -372,7 +372,7 @@ ngx_http_wasm_set_cl_header_handler(ngx_http_wasm_header_set_ctx_t *hv)
             goto error;
         }
 
-        ngx_wasm_assert(hv->mode == NGX_HTTP_WASM_HEADERS_REMOVE);
+        ngx_wa_assert(hv->mode == NGX_HTTP_WASM_HEADERS_REMOVE);
 
         len = -1;
     }

--- a/src/http/ngx_http_wasm_host.c
+++ b/src/http/ngx_http_wasm_host.c
@@ -15,7 +15,7 @@ ngx_http_wasm_hfuncs_resp_get_status(ngx_wavm_instance_t *instance,
     ngx_http_request_t       *r = rctx->r;
     uint32_t                  status;
 
-    if (r->connection->fd == NGX_WASM_BAD_FD) {
+    if (r->connection->fd == NGX_WA_BAD_FD) {
         return NGX_WAVM_BAD_USAGE;
     }
 
@@ -47,7 +47,7 @@ ngx_http_wasm_hfuncs_resp_set_status(ngx_wavm_instance_t *instance,
     ngx_http_request_t       *r = rctx->r;
     uint32_t                  status;
 
-    if (r->connection->fd == NGX_WASM_BAD_FD) {
+    if (r->connection->fd == NGX_WA_BAD_FD) {
         return NGX_WAVM_BAD_USAGE;
     }
 
@@ -86,7 +86,7 @@ ngx_http_wasm_hfuncs_resp_say(ngx_wavm_instance_t *instance,
     body_len = args[1].of.i32;
     body = NGX_WAVM_HOST_LIFT_SLICE(instance, args[0].of.i32, body_len);
 
-    if (r->connection->fd == NGX_WASM_BAD_FD) {
+    if (r->connection->fd == NGX_WA_BAD_FD) {
         return NGX_WAVM_BAD_USAGE;
     }
 
@@ -135,7 +135,7 @@ ngx_http_wasm_hfuncs_resp_say(ngx_wavm_instance_t *instance,
 
     } else if (rc == NGX_AGAIN) {
         /* TODO: NYI - NGX_WAVM_AGAIN */
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_WAVM_NYI;
     }
 

--- a/src/http/ngx_http_wasm_local_response.c
+++ b/src/http/ngx_http_wasm_local_response.c
@@ -189,7 +189,7 @@ ngx_http_wasm_flush_local_response(ngx_http_wasm_req_ctx_t *rctx)
     }
 
     if (rctx->local_resp_flushed) {
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ABORT;
     }
 

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -396,7 +396,7 @@ ngx_http_wasm_postconfig(ngx_conf_t *cf)
 
     cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
 
-    ngx_wasm_assert(cmcf); /* in http{} block */
+    ngx_wa_assert(cmcf); /* in http{} block */
 
     for (i = 0; i <= NGX_HTTP_LOG_PHASE; i++) {
         if (phase_handlers[i]) {
@@ -511,7 +511,7 @@ ngx_http_wasm_rctx(ngx_http_request_t *r, ngx_http_wasm_req_ctx_t **out)
     rctx = ngx_http_get_module_ctx(r, ngx_http_wasm_module);
     if (rctx == NULL) {
         loc = NULL;
-        fake = r->connection->fd == NGX_WASM_BAD_FD;
+        fake = r->connection->fd == NGX_WA_BAD_FD;
 
         if (!fake) {
             loc = ngx_http_get_module_loc_conf(r, ngx_http_wasm_module);
@@ -552,7 +552,7 @@ ngx_http_wasm_rctx(ngx_http_request_t *r, ngx_http_wasm_req_ctx_t **out)
         if (!fake) {
             mcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
                                                       ngx_http_wasm_module);
-            ngx_wasm_assert(mcf); /* in http{} block */
+            ngx_wa_assert(mcf); /* in http{} block */
 
             /* attach plan */
 
@@ -689,7 +689,7 @@ ngx_http_wasm_rewrite_handler(ngx_http_request_t *r)
         goto done;
     }
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_DONE
                     || rc == NGX_AGAIN
                     || rc == NGX_DECLINED);
@@ -757,7 +757,7 @@ ngx_http_wasm_access_handler(ngx_http_request_t *r)
     rc = ngx_wasm_ops_resume(&rctx->opctx, NGX_HTTP_ACCESS_PHASE);
     rc = ngx_http_wasm_check_finalize(rctx, rc);
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_DONE
                     || rc == NGX_AGAIN
                     || rc == NGX_DECLINED);
@@ -807,7 +807,7 @@ ngx_http_wasm_content(ngx_http_wasm_req_ctx_t *rctx)
         goto done;
     default:
         dd("enter/continue");
-        ngx_wasm_assert(rctx->env.state == NGX_WASM_STATE_CONTINUE);
+        ngx_wa_assert(rctx->env.state == NGX_WASM_STATE_CONTINUE);
         break;
     }
 
@@ -834,7 +834,7 @@ ngx_http_wasm_content(ngx_http_wasm_req_ctx_t *rctx)
 
         break;
     default:
-        ngx_wasm_assert(rc > NGX_OK);
+        ngx_wa_assert(rc > NGX_OK);
         goto finalize;
     }
 
@@ -889,7 +889,7 @@ orig:
 
         break;
     default:
-        ngx_wasm_assert(rc > NGX_OK);
+        ngx_wa_assert(rc > NGX_OK);
         break;
     }
 
@@ -1056,13 +1056,13 @@ last_finalize:
 
     if (rctx->fake_request) {
         dd("last finalize (fake request)");
-        ngx_wasm_assert(r->connection->fd == NGX_WASM_BAD_FD);
+        ngx_wa_assert(r->connection->fd == NGX_WA_BAD_FD);
         ngx_http_wasm_finalize_fake_request(r, NGX_DONE);
 
     } else {
         dd("last finalize (rc: %ld, main: %d, count: %d)",
            rc, r == r->main, r->main->count);
-        ngx_wasm_assert(r->connection->fd != NGX_WASM_BAD_FD);
+        ngx_wa_assert(r->connection->fd != NGX_WA_BAD_FD);
         ngx_http_finalize_request(r, rc);
     }
 
@@ -1102,7 +1102,7 @@ ngx_http_wasm_resume(ngx_http_wasm_req_ctx_t *rctx, unsigned main, unsigned wev)
 
     dd("enter");
 
-    ngx_wasm_assert(wev);
+    ngx_wa_assert(wev);
 
     if (ngx_wasm_yielding(&rctx->env)) {
         dd("yielding");

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -83,8 +83,8 @@ ngx_http_wasm_send_chain_link(ngx_http_request_t *r, ngx_chain_t *in)
         goto done;
     }
 
-    ngx_wasm_assert(r->header_sent);
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(r->header_sent);
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_AGAIN
                     || rc == NGX_DONE
                     || rc == NGX_DECLINED);
@@ -132,7 +132,7 @@ done:
             dd("r->main->count++: %d", r->main->count);
         }
 
-        ngx_wasm_assert(rc >= NGX_OK);
+        ngx_wa_assert(rc >= NGX_OK);
         break;
     }
 
@@ -426,7 +426,7 @@ ngx_http_wasm_prepend_resp_body(ngx_http_wasm_req_ctx_t *rctx, ngx_str_t *body)
 #else
     /* Presently, prepend_resp_body is only
      * called when body->len > 0 */
-    ngx_wasm_assert(rctx->resp_chunk_len);
+    ngx_wa_assert(rctx->resp_chunk_len);
 #endif
 
     return NGX_OK;
@@ -548,13 +548,13 @@ ngx_http_wasm_init_fake_connection(ngx_connection_t *c)
 
     port = c->listening->servers;
 
-    ngx_wasm_assert(port->naddrs == 1);
+    ngx_wa_assert(port->naddrs == 1);
 
 #if 0
     /* disabled: does not seem needed, unable to test it */
 
     if (port->naddrs > 1) {
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         /* there are several addresses on this port and one of them
          * is an "*:port" wildcard so getsockname() in ngx_http_server_addr()
          * is required to determine a server address */
@@ -650,7 +650,7 @@ ngx_http_wasm_create_fake_connection(ngx_pool_t *pool)
         goto failed;
     }
 
-    c->fd = NGX_WASM_BAD_FD;
+    c->fd = NGX_WA_BAD_FD;
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
 #if 0
@@ -827,7 +827,7 @@ ngx_http_wasm_finalize_fake_request(ngx_http_request_t *r, ngx_int_t rc)
     ngx_http_lua_ssl_ctx_t  *cctx;
 #endif
 
-    ngx_wasm_assert(rc == NGX_DONE);
+    ngx_wa_assert(rc == NGX_DONE);
 
 #if (NGX_DEBUG)
     c = r->connection;
@@ -915,7 +915,7 @@ ngx_http_wasm_close_fake_connection(ngx_connection_t *c)
 
     ngx_free_connection(c);
 
-    c->fd = NGX_WASM_BAD_FD;
+    c->fd = NGX_WA_BAD_FD;
 
     if (ngx_cycle->files) {
         ngx_cycle->files[0] = saved_c;

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -434,7 +434,7 @@ ngx_http_proxy_wasm_resume(ngx_proxy_wasm_exec_t *pwexec,
         break;
     }
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_AGAIN
                     || rc == NGX_ABORT
                     || rc == NGX_ERROR);

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -156,8 +156,8 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
     /* rctx or fake request */
 
     if (rctx == NULL) {
-        ngx_wasm_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
-        ngx_wasm_assert(pwexec->parent->id == NGX_PROXY_WASM_ROOT_CTX_ID);
+        ngx_wa_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
+        ngx_wa_assert(pwexec->parent->id == NGX_PROXY_WASM_ROOT_CTX_ID);
 
         c = ngx_http_wasm_create_fake_connection(pwexec->pool);
         if (c == NULL) {
@@ -173,7 +173,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
             return NULL;
         }
 
-        ngx_wasm_assert(r->pool == rctxp->pool);
+        ngx_wa_assert(r->pool == rctxp->pool);
 
         rctxp->data = pwexec->parent;
 
@@ -354,7 +354,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 
     sock = &call->sock;
 
-    ngx_wasm_assert(rctx);
+    ngx_wa_assert(rctx);
 
     if (ngx_wasm_socket_tcp_init(sock, &call->host, enable_ssl,
                                  &call->authority, &rctx->env)
@@ -712,7 +712,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
 
     dd("enter");
 
-    ngx_wasm_assert(&call->sock == sock);
+    ngx_wa_assert(&call->sock == sock);
 
     if (sock->err) {
         goto error;
@@ -743,7 +743,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
             break;
         }
 
-        ngx_wasm_assert(rc == NGX_OK);
+        ngx_wa_assert(rc == NGX_OK);
 
         call->state = NGX_HTTP_PROXY_WASM_DISPATCH_SENDING;
 
@@ -773,7 +773,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
                                 &rctx->free_bufs, &rctx->busy_bufs,
                                 &nl, buf_tag);
 
-        ngx_wasm_assert(rc == NGX_OK);
+        ngx_wa_assert(rc == NGX_OK);
 
         call->state = NGX_HTTP_PROXY_WASM_DISPATCH_RECEIVING;
 
@@ -791,7 +791,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
             break;
         }
 
-        ngx_wasm_assert(rc == NGX_OK);
+        ngx_wa_assert(rc == NGX_OK);
 
         call->state = NGX_HTTP_PROXY_WASM_DISPATCH_RECEIVED;
 
@@ -893,7 +893,7 @@ ngx_http_proxy_wasm_dispatch_resume_handler(ngx_wasm_socket_tcp_t *sock)
 
     }
 
-    ngx_wasm_assert(rc == NGX_AGAIN || rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_AGAIN || rc == NGX_OK);
 
     goto done;
 
@@ -912,7 +912,7 @@ error2:
     ngx_wasm_error(&rctx->env);
     ngx_http_proxy_wasm_dispatch_err(call);
 
-    ngx_wasm_assert(rc == NGX_ERROR);
+    ngx_wa_assert(rc == NGX_ERROR);
 
 done:
 

--- a/src/ipc/ngx_ipc.c
+++ b/src/ipc/ngx_ipc.c
@@ -1,0 +1,6 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_ipc.h>

--- a/src/ipc/ngx_ipc.h
+++ b/src/ipc/ngx_ipc.h
@@ -1,0 +1,17 @@
+#ifndef _NGX_IPC_H_INCLUDED_
+#define _NGX_IPC_H_INCLUDED_
+
+
+#include <ngx_core.h>
+
+
+#define NGX_IPC_MODULE              0x00495043   /* "IPC" */
+#define NGX_IPC_CONF                0x00300000
+
+
+typedef struct {
+    ngx_int_t                    (*init)(ngx_cycle_t *cycle);
+} ngx_ipc_module_t;
+
+
+#endif /* _NGX_IPC_H_INCLUDED_ */

--- a/src/ipc/ngx_ipc_core_module.c
+++ b/src/ipc/ngx_ipc_core_module.c
@@ -1,0 +1,50 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_ipc.h>
+
+
+static ngx_int_t ngx_ipc_core_init(ngx_cycle_t *cycle);
+static ngx_int_t ngx_ipc_core_init_process(ngx_cycle_t *cycle);
+
+
+static ngx_command_t  ngx_ipc_core_commands[] = {
+    ngx_null_command
+};
+
+
+static ngx_ipc_module_t  ngx_ipc_core_module_ctx = {
+    ngx_ipc_core_init                      /* init module */
+};
+
+
+ngx_module_t  ngx_ipc_core_module = {
+    NGX_MODULE_V1,
+    &ngx_ipc_core_module_ctx,              /* module context */
+    ngx_ipc_core_commands,                 /* module directives */
+    NGX_IPC_MODULE,                        /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    ngx_ipc_core_init_process,             /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+ngx_ipc_core_init(ngx_cycle_t *cycle)
+{
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_ipc_core_init_process(ngx_cycle_t *cycle)
+{
+    return NGX_OK;
+}

--- a/src/ngx_wasmx.h
+++ b/src/ngx_wasmx.h
@@ -1,0 +1,16 @@
+#ifndef _NGX_WA_H_INCLUDED_
+#define _NGX_WA_H_INCLUDED_
+
+
+#include <ngx_core.h>
+
+
+#if (NGX_DEBUG)
+#include <assert.h>
+#   define ngx_wasm_assert(a)        assert(a)
+#else
+#   define ngx_wasm_assert(a)
+#endif
+
+
+#endif /* _NGX_WA_H_INCLUDED_ */

--- a/src/ngx_wasmx.h
+++ b/src/ngx_wasmx.h
@@ -7,10 +7,12 @@
 
 #if (NGX_DEBUG)
 #include <assert.h>
-#   define ngx_wasm_assert(a)        assert(a)
+#   define ngx_wa_assert(a)        assert(a)
 #else
-#   define ngx_wasm_assert(a)
+#   define ngx_wa_assert(a)
 #endif
+
+#define NGX_WA_BAD_FD              (ngx_socket_t) -1
 
 
 #endif /* _NGX_WA_H_INCLUDED_ */

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -2,19 +2,13 @@
 #define _NGX_WASM_H_INCLUDED_
 
 
-#include <ngx_core.h>
+#include <ngx_wasmx.h>
 #include <ngx_wrt.h>
 #include <ngx_wasm_shm.h>
 #if (NGX_SSL)
 #include <ngx_wasm_ssl.h>
 #endif
 
-#if (NGX_DEBUG)
-#include <assert.h>
-#   define ngx_wasm_assert(a)        assert(a)
-#else
-#   define ngx_wasm_assert(a)
-#endif
 
 #define NGX_LOG_DEBUG_WASM           NGX_LOG_DEBUG_ALL
 #define NGX_LOG_WASM_NYI             NGX_LOG_ALERT

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -22,8 +22,6 @@
 #define NGX_WASM_DONE_PHASE          15
 #define NGX_WASM_BACKGROUND_PHASE    16
 
-#define NGX_WASM_BAD_FD              (ngx_socket_t) -1
-
 #define NGX_WASM_CONF_ERR_DUPLICATE  "is duplicate"
 #define NGX_WASM_CONF_ERR_NO_WASM                                            \
     "is specified but config has no \"wasm\" section"

--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -233,7 +233,7 @@ ngx_wasm_core_shms(ngx_cycle_t *cycle)
     ngx_wasm_core_conf_t  *wcf;
 
     wcf = ngx_wasm_core_cycle_get_conf(cycle);
-    ngx_wasm_assert(wcf);
+    ngx_wa_assert(wcf);
 
     return &wcf->shms;
 }
@@ -550,7 +550,7 @@ ngx_wasm_core_init_ssl(ngx_cycle_t *cycle)
                    "wasm initializing tls");
 
     wcf = ngx_wasm_core_cycle_get_conf(cycle);
-    ngx_wasm_assert(wcf);
+    ngx_wa_assert(wcf);
 
     wcf->ssl_conf.ssl.log = cycle->log;
 

--- a/src/wasm/ngx_wasm_directives.c
+++ b/src/wasm/ngx_wasm_directives.c
@@ -101,7 +101,7 @@ ngx_wasm_core_flag_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                            NGX_WASM_RUNTIME, fname);
         return NGX_CONF_ERROR;
     default:
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         break;
     }
 

--- a/src/wasm/ngx_wasm_ops.c
+++ b/src/wasm/ngx_wasm_ops.c
@@ -230,7 +230,7 @@ ngx_wasm_ops_plan_destroy(ngx_wasm_ops_plan_t *plan)
 ngx_int_t
 ngx_wasm_ops_plan_attach(ngx_wasm_ops_plan_t *plan, ngx_wasm_op_ctx_t *ctx)
 {
-    ngx_wasm_assert(plan->loaded);
+    ngx_wa_assert(plan->loaded);
 
     ctx->plan = plan;
 
@@ -302,7 +302,7 @@ ngx_wasm_ops_resume(ngx_wasm_op_ctx_t *ctx, ngx_uint_t phaseidx)
         break;
     }
 
-    ngx_wasm_assert(rc == NGX_OK
+    ngx_wa_assert(rc == NGX_OK
                     || rc == NGX_DECLINED
                     || rc == NGX_AGAIN
                     || rc == NGX_DONE);
@@ -329,7 +329,7 @@ ngx_wasm_op_call_handler(ngx_wasm_op_ctx_t *opctx, ngx_wasm_phase_t *phase,
     ngx_wavm_instance_t  *instance;
     ngx_wavm_funcref_t   *funcref;
 
-    ngx_wasm_assert(op->code == NGX_WASM_OP_CALL);
+    ngx_wa_assert(op->code == NGX_WASM_OP_CALL);
 
     funcref = op->conf.call.funcref;
     if (funcref == NULL) {
@@ -358,7 +358,7 @@ ngx_wasm_op_call_handler(ngx_wasm_op_ctx_t *opctx, ngx_wasm_phase_t *phase,
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(rc == NGX_OK);
+    ngx_wa_assert(rc == NGX_OK);
 
     /* next call op */
 
@@ -384,7 +384,7 @@ ngx_wasm_op_proxy_wasm_handler(ngx_wasm_op_ctx_t *opctx,
     subsystem = &ngx_http_proxy_wasm;
 #endif
 
-    ngx_wasm_assert(op->code == NGX_WASM_OP_PROXY_WASM);
+    ngx_wa_assert(op->code == NGX_WASM_OP_PROXY_WASM);
 
     ids = &opctx->plan->conf.proxy_wasm.filter_ids;
     isolation = opctx->ctx.proxy_wasm.isolation;
@@ -394,7 +394,7 @@ ngx_wasm_op_proxy_wasm_handler(ngx_wasm_op_ctx_t *opctx,
         isolation = loc->isolation;
 
 #else
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         isolation = NGX_PROXY_WASM_ISOLATION_NONE;
 #endif
     }
@@ -494,7 +494,7 @@ ngx_wasm_op_proxy_wasm_handler(ngx_wasm_op_ctx_t *opctx,
 
 done:
 
-    ngx_wasm_assert(rc == NGX_OK           /* step completed */
+    ngx_wa_assert(rc == NGX_OK           /* step completed */
 #ifdef NGX_WASM_HTTP
                     || rc >= NGX_HTTP_SPECIAL_RESPONSE
 #endif

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -87,7 +87,7 @@ ngx_wasm_chain_clear(ngx_chain_t *in, size_t offset, unsigned *eof,
             pos += n;
             buf->last = buf->pos + n;  /* partially consume buffer */
 
-            ngx_wasm_assert(pos == offset);
+            ngx_wa_assert(pos == offset);
 
         } else if (pos == offset) {
             /* past start offset, consume buffer */
@@ -108,7 +108,7 @@ ngx_wasm_chain_clear(ngx_chain_t *in, size_t offset, unsigned *eof,
         pos += fill;
     }
 
-    ngx_wasm_assert(pos == offset);
+    ngx_wa_assert(pos == offset);
 
     return fill;
 }
@@ -259,7 +259,7 @@ ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
 
         if (buf->tag != tag) {
             if (ll) {
-                /* ngx_wasm_assert(ll->next == cl); */
+                /* ngx_wa_assert(ll->next == cl); */
                 ll->next = cl->next;
             }
 
@@ -288,7 +288,7 @@ ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
     buf = nl->buf;
 
 #if 1
-    ngx_wasm_assert(!extend);
+    ngx_wa_assert(!extend);
 #else
     /* presently all calls have extend = 0 therefore fill == 0 */
     if (fill) {
@@ -301,7 +301,7 @@ ngx_wasm_chain_append(ngx_pool_t *pool, ngx_chain_t **in, size_t at,
 
     /* write */
 
-    ngx_wasm_assert(rest == str->len);
+    ngx_wa_assert(rest == str->len);
 
     buf->last = ngx_cpymem(buf->last, str->data, rest);
 

--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -129,7 +129,7 @@ ngx_wavm_engine_init(ngx_wavm_t *vm)
                    "wasm initializing \"%V\" vm engine (engine: %p)",
                    vm->name, &vm->wrt_engine);
 
-    ngx_wasm_assert(vm->config);
+    ngx_wa_assert(vm->config);
 
     config = ngx_wrt.conf_init(vm->config, vm->log);
     if (config == NULL) {
@@ -722,7 +722,7 @@ ngx_wavm_module_link(ngx_wavm_module_t *module, ngx_wavm_host_def_t *host)
             continue;
         }
 
-        ngx_wasm_assert(wasm_externtype_kind(wasm_importtype_type(importtype))
+        ngx_wa_assert(wasm_externtype_kind(wasm_importtype_type(importtype))
                         == WASM_EXTERN_FUNC);
 
         s.len = importname->size;
@@ -1051,14 +1051,14 @@ ngx_wavm_instance_create(ngx_wavm_module_t *module, ngx_pool_t *pool,
             break;
 
         case NGX_WRT_EXTERN_MEMORY:
-            ngx_wasm_assert(instance->memory == NULL);
+            ngx_wa_assert(instance->memory == NULL);
             instance->memory = wextern;
             break;
 
         }
     }
 
-    ngx_wasm_assert(instance->funcs.nelts == module->exports.size);
+    ngx_wa_assert(instance->funcs.nelts == module->exports.size);
 
     /* _start */
 
@@ -1096,8 +1096,8 @@ ngx_wavm_func_call(ngx_wavm_func_t *f, wasm_val_vec_t *args,
     ngx_int_t             rc;
     ngx_wavm_instance_t  *instance;
 
-    ngx_wasm_assert(args);
-    ngx_wasm_assert(rets);
+    ngx_wa_assert(args);
+    ngx_wa_assert(rets);
 
     instance = f->instance;
 
@@ -1197,7 +1197,7 @@ ngx_wavm_instance_call_func_va(ngx_wavm_instance_t *instance,
         *rets = &func->rets;
     }
 
-    ngx_wasm_assert(rc == NGX_OK || rc == NGX_ERROR || rc == NGX_ABORT);
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_ERROR || rc == NGX_ABORT);
 
     return rc;
 }
@@ -1278,11 +1278,11 @@ ngx_wavm_instance_call_funcref(ngx_wavm_instance_t *instance,
                    instance, instance->wrt_store.store);
 #endif
 
-    ngx_wasm_assert(funcref->module == instance->module);
+    ngx_wa_assert(funcref->module == instance->module);
 
     func = &((ngx_wavm_func_t *) instance->funcs.elts)[funcref->exports_idx];
 
-    ngx_wasm_assert(func);
+    ngx_wa_assert(func);
 
     dd("func: %p (args: %p, args->nelts: %ld)",
        func, &func->args, func->args.size);
@@ -1301,11 +1301,11 @@ ngx_wavm_instance_call_funcref_vec(ngx_wavm_instance_t *instance,
 {
     ngx_wavm_func_t  *func;
 
-    ngx_wasm_assert(funcref->module == instance->module);
+    ngx_wa_assert(funcref->module == instance->module);
 
     func = &((ngx_wavm_func_t *) instance->funcs.elts)[funcref->exports_idx];
 
-    ngx_wasm_assert(func);
+    ngx_wa_assert(func);
 
     return ngx_wavm_instance_call_func_vec(instance, func, rets, args);
 }

--- a/src/wasm/vm/ngx_wavm.h
+++ b/src/wasm/vm/ngx_wavm.h
@@ -156,7 +156,7 @@ ngx_wavm_instance_set_data(ngx_wavm_instance_t *instance, void *data,
 static ngx_inline size_t
 ngx_wavm_memory_data_size(ngx_wrt_extern_t *mem)
 {
-    ngx_wasm_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
+    ngx_wa_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
 
 #ifdef NGX_WASM_HAVE_WASMTIME
     return wasmtime_memory_data_size(mem->context, &mem->ext.of.memory);
@@ -170,7 +170,7 @@ ngx_wavm_memory_data_size(ngx_wrt_extern_t *mem)
 static ngx_inline byte_t *
 ngx_wavm_memory_base(ngx_wrt_extern_t *mem)
 {
-    ngx_wasm_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
+    ngx_wa_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
 
 #ifdef NGX_WASM_HAVE_WASMTIME
     return (byte_t *) wasmtime_memory_data(mem->context, &mem->ext.of.memory);
@@ -185,7 +185,7 @@ static ngx_inline void *
 ngx_wavm_memory_lift(ngx_wrt_extern_t *mem, ngx_wavm_ptr_t p,
     uint32_t size, uint32_t align, unsigned *err_count)
 {
-    ngx_wasm_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
+    ngx_wa_assert(mem->kind == NGX_WRT_EXTERN_MEMORY);
 
     if (p == 0) {
         /* NULL pointers are only valid for empty slices */

--- a/src/wasm/vm/ngx_wavm_host.c
+++ b/src/wasm/vm/ngx_wavm_host.c
@@ -129,7 +129,7 @@ ngx_wavm_host_kindvec2typevec(const wasm_valkind_t **valkinds,
 
     for (i = 0; i < out->size; i++) {
         valkind = ((wasm_valkind_t **) valkinds)[i];
-        ngx_wasm_assert(valkind);
+        ngx_wa_assert(valkind);
         out->data[i] = wasm_valtype_new(*valkind);
     }
 }
@@ -301,7 +301,7 @@ ngx_wavm_hfunc_trampoline(void *env,
     case NGX_WAVM_NYI:
         err = "host trap (function not yet implemented)";
 
-        ngx_wasm_assert(!instance->trapmsg.len);
+        ngx_wa_assert(!instance->trapmsg.len);
 
         ngx_wavm_instance_trap_printf(instance, "%V", &hfunc->def->name);
         break;
@@ -330,7 +330,7 @@ ngx_wavm_hfunc_trampoline(void *env,
 
         p = ngx_snprintf(p, len - (p - buf), "%V", &instance->trapmsg);
 
-        ngx_wasm_assert( ((size_t) (p - buf)) == len );
+        ngx_wa_assert( ((size_t) (p - buf)) == len );
 
     } else {
         wasm_name_new(&trapmsg, ngx_strlen(err)

--- a/src/wasm/wrt/ngx_wrt_utils.c
+++ b/src/wasm/wrt/ngx_wrt_utils.c
@@ -64,8 +64,8 @@ ngx_wrt_apply_flags(wasm_config_t *config, ngx_wavm_conf_t *conf,
 
         handler = get_flag_handler(name);
 
-        ngx_wasm_assert(handler);
-        ngx_wasm_assert(handler->handler);
+        ngx_wa_assert(handler);
+        ngx_wa_assert(handler->handler);
 
         rc = handler->handler(config, name, value, log,
                               handler->wrt_config_set);

--- a/src/wasm/wrt/ngx_wrt_v8.c
+++ b/src/wasm/wrt/ngx_wrt_v8.c
@@ -367,7 +367,7 @@ ngx_v8_link_module(ngx_wrt_module_t *module, ngx_array_t *hfuncs,
                 if (ngx_str_eq(importname->data, importname->size,
                                hfunc->def->name.data, hfunc->def->name.len))
                 {
-                    ngx_wasm_assert(i == hfunc->idx);
+                    ngx_wa_assert(i == hfunc->idx);
 
                     dd("   -> hfuncs resolved: \"%.*s\"",
                        (int) hfunc->def->name.len, hfunc->def->name.data);
@@ -401,7 +401,7 @@ ngx_v8_link_module(ngx_wrt_module_t *module, ngx_array_t *hfuncs,
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(module->nimports == module->import_types->size);
+    ngx_wa_assert(module->nimports == module->import_types->size);
 
     return NGX_OK;
 }
@@ -492,7 +492,7 @@ ngx_v8_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
 #endif
     }
 
-    ngx_wasm_assert(nimports == module->nimports);
+    ngx_wa_assert(nimports == module->nimports);
 
     instance->instance = wasm_instance_new(store->store, module->module,
                                            (const wasm_extern_t **)
@@ -556,7 +556,7 @@ ngx_v8_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
     const wasm_name_t        *exportname;
     const wasm_externtype_t  *externtype;
 
-    ngx_wasm_assert(idx < module->export_types->size);
+    ngx_wa_assert(idx < module->export_types->size);
 
     exporttype = module->export_types->data[idx];
     exportname = wasm_exporttype_name(exporttype);
@@ -569,12 +569,12 @@ ngx_v8_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
     switch (wasm_externtype_kind(externtype)) {
 
     case WASM_EXTERN_FUNC:
-        ngx_wasm_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_FUNC);
+        ngx_wa_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_FUNC);
         ext->kind = NGX_WRT_EXTERN_FUNC;
         break;
 
     case WASM_EXTERN_MEMORY:
-        ngx_wasm_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_MEMORY);
+        ngx_wa_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_MEMORY);
         ext->kind = NGX_WRT_EXTERN_MEMORY;
         instance->memory = wasm_extern_as_memory(ext->ext);
         break;
@@ -585,7 +585,7 @@ ngx_v8_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
 
     default:
         /* NYI */
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ABORT;
 
     }
@@ -612,7 +612,7 @@ ngx_v8_call(ngx_wrt_instance_t *instance, ngx_str_t *func_name,
 
     ext = instance->externs.data[func_idx];
 
-    ngx_wasm_assert(wasm_extern_kind(ext) == WASM_EXTERN_FUNC);
+    ngx_wa_assert(wasm_extern_kind(ext) == WASM_EXTERN_FUNC);
 
     func = wasm_extern_as_func(ext);
 

--- a/src/wasm/wrt/ngx_wrt_wasmer.c
+++ b/src/wasm/wrt/ngx_wrt_wasmer.c
@@ -74,7 +74,7 @@ ngx_wasmer_init_conf(ngx_wavm_conf_t *conf, ngx_log_t *log)
     char           *auto_compiler = NULL;
     wasm_config_t  *config;
 
-    ngx_wasm_assert(conf->backtraces != NGX_CONF_UNSET);
+    ngx_wa_assert(conf->backtraces != NGX_CONF_UNSET);
 
     if (conf->backtraces) {
         setenv("RUST_BACKTRACE", "full", 1);
@@ -274,7 +274,7 @@ ngx_wasmer_link_module(ngx_wrt_module_t *module, ngx_array_t *hfuncs,
      * clang-analyzer: ensure the 'wasi_get_unordered_imports' branch is taken
      * below; or else 'wasi_imports' may be considered uninitialized.
      */
-    ngx_wasm_assert(!module->wasi);
+    ngx_wa_assert(!module->wasi);
 
     /* WASI */
 
@@ -415,7 +415,7 @@ linking:
                                hfunc->def->name.data,
                                hfunc->def->name.len))
                 {
-                    ngx_wasm_assert(i == hfunc->idx);
+                    ngx_wa_assert(i == hfunc->idx);
 
                     dd("   -> hfuncs resolved: \"%.*s\"",
                        (int) hfunc->def->name.len, hfunc->def->name.data);
@@ -456,7 +456,7 @@ linking:
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(module->nimports == module->import_types->size);
+    ngx_wa_assert(module->nimports == module->import_types->size);
 
     return NGX_OK;
 }
@@ -587,14 +587,14 @@ ngx_wasmer_init_instance(ngx_wrt_instance_t *instance, ngx_wrt_store_t *store,
 
         default:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             return NGX_ABORT;
 
         }
     }
 
-    ngx_wasm_assert(nimports == module->nimports);
-    ngx_wasm_assert(instance->env.size == module->nimports);
+    ngx_wa_assert(nimports == module->nimports);
+    ngx_wa_assert(instance->env.size == module->nimports);
 
     instance->pool = pool;
     instance->store = store;
@@ -675,7 +675,7 @@ ngx_wasmer_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
     const wasm_name_t         *exportname;
     const wasm_externtype_t   *externtype;
 
-    ngx_wasm_assert(idx < module->export_types->size);
+    ngx_wa_assert(idx < module->export_types->size);
 
     exporttype = module->export_types->data[idx];
     exportname = wasm_exporttype_name(exporttype);
@@ -688,12 +688,12 @@ ngx_wasmer_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
     switch (wasm_externtype_kind(externtype)) {
 
     case WASM_EXTERN_FUNC:
-        ngx_wasm_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_FUNC);
+        ngx_wa_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_FUNC);
         ext->kind = NGX_WRT_EXTERN_FUNC;
         break;
 
     case WASM_EXTERN_MEMORY:
-        ngx_wasm_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_MEMORY);
+        ngx_wa_assert(wasm_extern_kind(ext->ext) == WASM_EXTERN_MEMORY);
         ext->kind = NGX_WRT_EXTERN_MEMORY;
         instance->memory = wasm_extern_as_memory(ext->ext);
 
@@ -709,7 +709,7 @@ ngx_wasmer_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
 
     default:
         /* NYI */
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ABORT;
 
     }
@@ -736,7 +736,7 @@ ngx_wasmer_call(ngx_wrt_instance_t *instance, ngx_str_t *func_name,
 
     ext = instance->externs.data[func_idx];
 
-    ngx_wasm_assert(wasm_extern_kind(ext) == WASM_EXTERN_FUNC);
+    ngx_wa_assert(wasm_extern_kind(ext) == WASM_EXTERN_FUNC);
 
     func = wasm_extern_as_func(ext);
 

--- a/src/wasm/wrt/ngx_wrt_wasmtime.c
+++ b/src/wasm/wrt/ngx_wrt_wasmtime.c
@@ -135,7 +135,7 @@ ngx_wasmtime_init_conf(ngx_wavm_conf_t *conf, ngx_log_t *log)
     wasmtime_error_t  *err = NULL;
 #endif
 
-    ngx_wasm_assert(conf->backtraces != NGX_CONF_UNSET);
+    ngx_wa_assert(conf->backtraces != NGX_CONF_UNSET);
 
     if (conf->backtraces) {
         setenv("WASMTIME_BACKTRACE_DETAILS", "1", 1);
@@ -469,7 +469,7 @@ ngx_wasmtime_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
         return NGX_ERROR;
     }
 
-    ngx_wasm_assert(idx < m->export_types->size);
+    ngx_wa_assert(idx < m->export_types->size);
 
     ext->instance = instance;
     ext->context = s->context;
@@ -487,12 +487,12 @@ ngx_wasmtime_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
     switch (wasm_externtype_kind(externtype)) {
 
     case WASM_EXTERN_FUNC:
-        ngx_wasm_assert(ext->ext.kind == WASMTIME_EXTERN_FUNC);
+        ngx_wa_assert(ext->ext.kind == WASMTIME_EXTERN_FUNC);
         ext->kind = NGX_WRT_EXTERN_FUNC;
         break;
 
     case WASM_EXTERN_MEMORY:
-        ngx_wasm_assert(ext->ext.kind == WASMTIME_EXTERN_MEMORY);
+        ngx_wa_assert(ext->ext.kind == WASMTIME_EXTERN_MEMORY);
         ext->kind = NGX_WRT_EXTERN_MEMORY;
         instance->memory = &ext->ext.of.memory;
         break;
@@ -503,7 +503,7 @@ ngx_wasmtime_init_extern(ngx_wrt_extern_t *ext, ngx_wrt_instance_t *instance,
 
     default:
         /* NYI */
-        ngx_wasm_assert(0);
+        ngx_wa_assert(0);
         return NGX_ABORT;
 
     }
@@ -540,7 +540,7 @@ ngx_wasm_valvec2wasmtime(wasmtime_val_t *out, wasm_val_vec_t *vec)
 
         default:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
 
         }
@@ -554,7 +554,7 @@ ngx_wasmtime_valvec2wasm(wasm_val_vec_t *out, wasmtime_val_t *vec, size_t nvals)
     size_t           i;
     wasmtime_val_t  *val;
 
-    ngx_wasm_assert(out->size == nvals);
+    ngx_wa_assert(out->size == nvals);
 
     for (i = 0; i < nvals; i++) {
         val = vec + i;
@@ -583,22 +583,22 @@ ngx_wasmtime_valvec2wasm(wasm_val_vec_t *out, wasmtime_val_t *vec, size_t nvals)
 
         case WASMTIME_V128:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
 
         case WASMTIME_FUNCREF:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
 
         case WASMTIME_EXTERNREF:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
 
         default:
             /* NYI */
-            ngx_wasm_assert(0);
+            ngx_wa_assert(0);
             break;
 
         }
@@ -626,7 +626,7 @@ ngx_wasmtime_call(ngx_wrt_instance_t *instance, ngx_str_t *func_name,
         goto done;
     }
 
-    ngx_wasm_assert(item.kind == WASMTIME_EXTERN_FUNC);
+    ngx_wa_assert(item.kind == WASMTIME_EXTERN_FUNC);
 
     func = &item.of.func;
 


### PR DESCRIPTION
Introduce IPC modules (which can be initialized at different points than Wasm modules and offer specialized extension handlers). Generalize the codebase with the new `ngx_wa` namespace which stands as the general WasmX prefix (containing mutually-exclusive Wasm + IPC features).

As we move forward, other facilities that can be generalized between multiple core features will also be moved to the wider `ngx_wa` namespace as needed. 

- [ ] compilation guards
- [ ] source lexicon update
- [ ] build tests