### PR TITLE
fix(shm/kv) re-allocate memory if current value is replaced by a larger one

### DIFF
--- a/src/common/shm/ngx_wasm_shm_kv.c
+++ b/src/common/shm/ngx_wasm_shm_kv.c
@@ -282,7 +282,7 @@ ngx_wasm_shm_kv_set_locked(ngx_wasm_shm_t *shm, ngx_str_t *key,
 
     /* set */
 
-    if (n && key->len > n->value.len) {
+    if (n && value->len > n->value.len) {
         old = n;
         n = NULL;
     }


### PR DESCRIPTION
The first time `ngx_wasm_shm_kv_set_locked` is called with a key `k` and a value `v`, it allocates `sizeof(ngx_wasm_shm_kv_node_t) + key->len + value->len` bytes to store node, key and value contents.

If `ngx_wasm_shm_kv_set_locked` is later called with the key `k` and a value larger than `v`, it will write beyond the initially allocated memory when copying the value's bytes to the shared memory: `ngx_memcpy(n->value.data, value->data, value->len)`.