### PR TITLE
tests(lua-resolver) 2 parallel dispatch calls with DNS resolution

### DIFF
--- a/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
+++ b/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
@@ -509,3 +509,29 @@ qr/\[error\] .*? lua entry thread aborted: .*? wasm lua failed resolving "httpbi
 wasm tcp socket resolver failed before query
 --- no_error_log
 [crit]
+
+
+
+=== TEST 14: proxy_wasm - dispatch_http_call() 2 parallel calls with DNS resolution
+--- valgrind
+--- skip_no_debug
+--- timeout eval: $::ExtTimeout
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=httpbin.org \
+                              path=/headers \
+                              ncalls=2';
+        echo ok;
+    }
+--- response_headers_like
+pwm-call-id: 0, 1
+--- response_body
+ok
+--- no_error_log
+[error]
+[crit]

--- a/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
+++ b/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
@@ -535,3 +535,29 @@ ok
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 15: proxy_wasm - dispatch_http_call() 2 parallel calls with DNS resolution, different hosts
+--- valgrind
+--- skip_no_debug
+--- timeout eval: $::ExtTimeout
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              hosts=httpbin.org,example.com \
+                              path=/headers \
+                              ncalls=2';
+        echo ok;
+    }
+--- response_headers_like
+pwm-call-id: 0, 1
+--- response_body
+ok
+--- no_error_log
+[error]
+[crit]

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -93,7 +93,7 @@ impl Context for TestHttp {
 
                 if self.n_sync_calls < again {
                     self.n_sync_calls += 1;
-                    self.send_http_dispatch();
+                    self.send_http_dispatch(self.n_sync_calls - 1);
                     return;
                 }
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -101,8 +101,8 @@ impl TestHttp {
                     .get("ncalls")
                     .map_or(1, |v| v.parse().expect("bad ncalls value"));
 
-                for _ in 0..n {
-                    self.send_http_dispatch();
+                for i in 0..n {
+                    self.send_http_dispatch(i);
                 }
 
                 return Action::Pause;
@@ -141,7 +141,7 @@ impl TestHttp {
         Action::Continue
     }
 
-    pub fn send_http_dispatch(&mut self) {
+    pub fn send_http_dispatch(&mut self, i: usize) {
         let mut timeout = Duration::from_secs(0);
         let mut headers = Vec::new();
         let mut path = self
@@ -207,8 +207,13 @@ impl TestHttp {
         headers.push(("Host", "ignoreme"));
         headers.push(("connection", "ignoreme"));
 
+        let host = match self.get_config("hosts") {
+            Some(list) => list.split(',').collect::<Vec<&str>>()[i],
+            None => self.get_config("host").unwrap_or(""),
+        };
+
         self.dispatch_http_call(
-            self.get_config("host").unwrap_or(""),
+            host,
             headers,
             self.get_config("body").map(|v| v.as_bytes()),
             vec![],


### PR DESCRIPTION
Test cases for running 2 parallel dispatch calls triggering DNS resolution using the Lua resolver.

First commit is a minimal test: this is the basic TEST 1 from `t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t`, which triggers two parallel dispatch calls with `ncalls=2`, but with the httpbin.org configuration from TEST 1 from `t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t`. No changes are made to the existing test filters.

Second commit is a modified version of the test, which applies a change to the test filter allowing for a different hostname on each call, so we can observe which one resolved and which one didn't.
