### PR TITLE
fix(ffi) allow 'load()' to fail and be invoked again

### DIFF
--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -102,10 +102,10 @@ typedef struct {
 
 
 typedef struct {
-    ngx_proxy_wasm_store_t             store;
-    ngx_queue_t                        plans;
-    ngx_wasm_ops_t                    *ops;
     ngx_wavm_t                        *vm;
+    ngx_wasm_ops_t                    *ops;
+    ngx_queue_t                        plans;
+    ngx_proxy_wasm_filters_root_t      pwroot;                 /* worker proxy-wasm root */
 } ngx_http_wasm_main_conf_t;
 
 

--- a/src/http/ngx_http_wasm_directives.c
+++ b/src/http/ngx_http_wasm_directives.c
@@ -125,8 +125,10 @@ ngx_http_wasm_proxy_wasm_directive(ngx_conf_t *cf, ngx_command_t *cmd,
         return NGX_CONF_ERROR;
     }
 
-    rc = ngx_http_wasm_ops_add_filter(loc->plan, name, config,
-                                      &mcf->store, mcf->vm);
+    loc->plan->conf.proxy_wasm.pwroot = &mcf->pwroot;
+    loc->plan->conf.proxy_wasm.worker_pwroot = &mcf->pwroot;
+
+    rc = ngx_http_wasm_ops_add_filter(loc->plan, name, config, mcf->vm);
     if (rc != NGX_OK) {
         if (rc == NGX_ABORT) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -435,12 +435,19 @@ ngx_http_wasm_prepend_resp_body(ngx_http_wasm_req_ctx_t *rctx, ngx_str_t *body)
 
 ngx_int_t
 ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
-    ngx_str_t *name, ngx_str_t *config, ngx_proxy_wasm_store_t *store,
-    ngx_wavm_t *vm)
+    ngx_str_t *name, ngx_str_t *config, ngx_wavm_t *vm)
 {
-    ngx_int_t                 rc = NGX_ERROR;
-    ngx_wasm_op_t            *op;
-    ngx_proxy_wasm_filter_t  *filter;
+    ngx_int_t                       rc = NGX_ERROR;
+    ngx_wasm_op_t                  *op;
+    ngx_proxy_wasm_store_t         *store;
+    ngx_proxy_wasm_filter_t        *filter;
+    ngx_proxy_wasm_filters_root_t  *pwroot, *worker_pwroot;
+
+    pwroot = plan->conf.proxy_wasm.pwroot;
+    worker_pwroot = plan->conf.proxy_wasm.worker_pwroot;
+    store = &worker_pwroot->store;
+
+    ngx_proxy_wasm_root_init(pwroot, plan->pool);
 
     filter = ngx_pcalloc(plan->pool, sizeof(ngx_proxy_wasm_filter_t));
     if (filter == NULL) {

--- a/src/http/ngx_http_wasm_util.h
+++ b/src/http/ngx_http_wasm_util.h
@@ -24,8 +24,7 @@ ngx_int_t ngx_http_wasm_send_chain_link(ngx_http_request_t *r, ngx_chain_t *in);
 
 /* proxy-wasm with wasm ops */
 ngx_int_t ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
-    ngx_str_t *name, ngx_str_t *config, ngx_proxy_wasm_store_t *store,
-    ngx_wavm_t *vm);
+    ngx_str_t *name, ngx_str_t *config, ngx_wavm_t *vm);
 
 /* fake requests */
 ngx_connection_t *ngx_http_wasm_create_fake_connection(ngx_pool_t *pool);

--- a/src/wasm/ngx_wasm_ops.h
+++ b/src/wasm/ngx_wasm_ops.h
@@ -73,7 +73,8 @@ typedef struct {
 
 typedef struct {
     ngx_array_t                              filter_ids;
-    ngx_uint_t                               nfilters;
+    ngx_proxy_wasm_filters_root_t           *pwroot;
+    ngx_proxy_wasm_filters_root_t           *worker_pwroot;  /* &mcf->pwroot */
 } ngx_wasm_ops_plan_proxy_wasm_t;
 
 


### PR DESCRIPTION
Before instantiating filter chains and request contexts, filters themselves (i.e. their root context) are represented in the module. Eventually, `ngx_proxy_wasm_start` iterates over all filters to start their root contexts.

Previously, all filters declared in `proxy_wasm` directives were stored globally. With the introduction of the FFI filters can be dynamically added to the internal representation during `proxy_wasm.load`, which makes it possible for `ngx_proxy_wasm_start` to be invoked several times.

However, since the filters structure was global then all previously declared filters were started again, including filters that previously failed initializing their root contexts. This was not happening with `proxy_wasm` directives since a filter failing initialization in that case would not allow Nginx to start in the first place.

Now all filters are stored in a "filters root" structure which can divide filter root contexts as needed. Each worker has a global "worker filters root", and each `ngx_wasm_ops_plan` created by the FFI has its own isolated "filters root".