### PR TITLE
feat(proxy-wasm) metrics

### DIFF
--- a/config
+++ b/config
@@ -129,6 +129,7 @@ NGX_WASMX_INCS="\
     $ngx_addon_dir/src/common \
     $ngx_addon_dir/src/common/proxy_wasm \
     $ngx_addon_dir/src/common/shm \
+    $ngx_addon_dir/src/common/metrics \
     $ngx_addon_dir/src/common/lua"
 
 NGX_WASMX_DEPS="\
@@ -141,7 +142,9 @@ NGX_WASMX_DEPS="\
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_properties.h \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm.h \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm_kv.h \
-    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.h"
+    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.h \
+    $ngx_addon_dir/src/common/metrics/ngx_wa_histogram.h \
+    $ngx_addon_dir/src/common/metrics/ngx_wa_metrics.h"
 
 NGX_WASMX_SRCS="\
     $ngx_addon_dir/src/ngx_wasmx.c \
@@ -155,7 +158,9 @@ NGX_WASMX_SRCS="\
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_util.c \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm.c \
     $ngx_addon_dir/src/common/shm/ngx_wasm_shm_kv.c \
-    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.c"
+    $ngx_addon_dir/src/common/shm/ngx_wasm_shm_queue.c \
+    $ngx_addon_dir/src/common/metrics/ngx_wa_histogram.c \
+    $ngx_addon_dir/src/common/metrics/ngx_wa_metrics.c"
 
 # wasm
 

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -6,6 +6,7 @@ By alphabetical order:
 - [cache_config](#cache-config)
 - [compiler](#compiler)
 - [flag](#flag)
+- [max_metric_name_length](#max_metric_name_length)
 - [module](#module)
 - [proxy_wasm](#proxy_wasm)
 - [proxy_wasm_isolation](#proxy_wasm_isolation)
@@ -16,6 +17,7 @@ By alphabetical order:
 - [resolver_timeout](#resolver_timeout)
 - [shm_kv](#shm_kv)
 - [shm_queue](#shm_queue)
+- [slab_size](#slab_size)
 - [socket_buffer_size](#socket_buffer_size)
 - [socket_buffer_reuse](#socket_buffer_reuse)
 - [socket_connect_timeout](#socket_connect_timeout)
@@ -57,6 +59,9 @@ By context:
     - [tls_trusted_certificate](#tls_trusted_certificate)
     - [tls_verify_cert](#tls_verify_cert)
     - [tls_verify_host](#tls_verify_host)
+    - `metrics{}`
+        - [max_metric_name_length](#max_metric_name_length)
+        - [slab_size](#slab_size)
     - `wasmtime{}`
         - [cache_config](#cache-config)
         - [flag](#flag)
@@ -202,6 +207,24 @@ wasm {
     }
 }
 ```
+
+[Back to TOC](#directives)
+
+max_metric_name_length
+---------
+
+**usage**    | `max_metric_name_length <length>;`
+------------:|:----------------------------------------------------------------
+**contexts** | `metrics{}`
+**default**  | `256`
+**example**  | `max_metric_name_length 512;`
+
+Set the maximum allowed length of a metric name.
+
+> Notes
+
+See [Metrics] for a complete description of how metrics are represented in
+memory.
 
 [Back to TOC](#directives)
 
@@ -522,6 +545,33 @@ Shared queue memory zones can be used via the [proxy-wasm SDK](#proxy-wasm)'s
 
 **Note:** shared memory queues do not presently implement an automatic eviction
 policy, and writes will fail when the allocated memory slab is full.
+
+[Back to TOC](#directives)
+
+slab_size
+---------
+
+**usage**    | `slab_size <size>;`
+------------:|:----------------------------------------------------------------
+**contexts** | `metrics{}`
+**default**  | `5m`
+**example**  | `slab_size 12m;`
+
+Set the `size` of the shared memory slab dedicated to metrics storage. The value
+must be at least 3 * pagesize, e.g. `15k` on Linux.
+
+> Notes
+
+The space in memory occupied by a metric depends on its name length, type and
+the number of worker processes running. As an example, if all metric names are
+64 chars long and 4 workers are running, `5m` can accommodate 20k counters, 20k
+gauges, or up to 16k histograms.
+
+See the [max_metric_name_length](#max_metric_name_length) directive to configure
+the max name length in chars for metrics.
+
+See [Metrics] for a complete description of how metrics are represented in
+memory.
 
 [Back to TOC](#directives)
 
@@ -939,7 +989,8 @@ the `http{}` contexts.
 
 [Contexts]: USER.md#contexts
 [Execution Chain]: USER.md#execution-chain
-[SLRU eviction algorithm]: SLRU.md
+[Metrics]: METRICS.md
 [OpenResty]: https://openresty.org/en/
 [resolver]: https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver
 [resolver_timeout]: https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver_timeout
+[SLRU eviction algorithm]: SLRU.md

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,97 @@
+# Metrics
+
+## Introduction
+
+In the context of ngx_wasm_module, in accordance with Proxy-Wasm, a metric is
+either a counter, a gauge or a histogram.
+
+A counter is an unsigned 64-bit int that can only be incremented.
+A gauge is an unsigned 64-bit int that can take arbitrary values.
+
+## Histograms
+
+A histogram represents ranges frequencies of a variable and can be defined as a
+set of pairs of range and counter. For example, the distribution of response
+time of HTTP requests, can be represented as a histogram with ranges `[0, 1]`,
+`(1, 2]`, `(2, 4]` and `(4, Inf]`. The 1st range's counter, would be the number
+of requests with response time less or equal to 1ms; the 2nd range's counter,
+requests with response time between 1ms and 2ms; the 3rd range's counter,
+requests with response time between 2ms and 4ms; and the last range's counter,
+requests with response time bigger than 4ms.
+
+### Binning
+
+The above example demonstrates a histogram with ranges, or bins, whose upper
+bound grows in powers of 2, i.e. 2^0, 2^1 and 2^2. This is usually called
+logarithmic binning and is indeed how histograms bins are represented in the
+ngx_wasm_module. This binning strategy implicates that when a value `v` is
+recorded, it is matched with the smallest power of two that's bigger than `v`;
+this value is the upper bound of the bin associated with `v`; if the histogram
+contain, or can contain, such bin, its counter is incremented; if not, the bin
+with the next smallest upper bound bigger than `v` has its counter incremented.
+
+### Update and expansion
+
+Histograms are created with 5 bins, 1 initialized and 4 uninitialized. If a
+value `v` is recorded and its bin isn't part of the initialized bins, one of the
+uninitialized bins is initialized with the upper bound associated with `v` and
+its counter is incremented. If the histogram is out of uninitialized bins, it
+can be expanded, up to 18 bins, to accommodate the additional bin for `v`. The
+bin initialized upon histogram creation has upper bound 2^32 and its counter is
+incremented if it's the only bin whose upper bound is bigger than the recorded
+value.
+
+## Memory consumption
+
+The space in memory occupied by a metric contains its name, value and the
+underlying structure representing them in the key-value store. While the
+key-value structure has a fixed size of 96 bytes, the sizes of name and value
+vary.
+
+The size in memory of the value of a counter or gauge is 8 bytes plus 16 bytes
+per worker process. The value size grows according to the number of workers
+because metric value is segmented across them. Each worker has its own segment
+of the value to write updates to. When a metric is retrieved, the segments are
+consolidated and returned as a single metric. This storage strategy allows
+metric updates to be performed without the aid of locks at the cost of 16 bytes
+per worker.
+
+Histograms' values also have a baseline size of 8 bytes plus 16 bytes per
+worker. However, histograms need extra space per worker for bins storage. Bins
+storage costs 4 bytes plus 8 bytes per bin. So a 5-bin histogram takes 8 bytes
+plus (16 + 4 + 5*8), 60 bytes per worker.
+
+As such, in a 4-workers setup, a counter or gauge whose name is 64 chars long
+takes 168 bytes, a 5-bin histogram with the same name takes 408 bytes and a
+18-bin histogram with the same name takes 824 bytes.
+
+### Shared memory allocation
+
+Nginx employs an allocation model for shared memory that enforces allocation
+size to be a power of 2 and greater than 8; nonconforming values are rounded up,
+see [Nginx shared memory].
+
+This means that an allocation of 168 bytes, for instance, ends up taking 256
+bytes from the shared memory. This should be taken into account when estimating
+the space required for a group of metrics.
+
+### Prefixing
+
+The name of a metric is always prefixed with `pw.{filter_name}.` to avoid naming
+conflicts between Proxy-Wasm filters. This means that a metric named `a_counter`
+by the filter `a_filter` ends up named as `pw.a_filter.a_counter`.
+The maximum length of a metric name, configured via `max_metric_name_length`,
+is enforced on the prefixed name and might need to be increased in some cases.
+
+## Nginx Reconfiguration
+
+If Nginx is reconfigured with a different number of workers or a different size
+for the metrics shared memory zone, existing metrics need to be reallocated into
+a brand new shared memory zone. This is due to the metric values being segmented
+across workers.
+
+As such, it's important to ensure a new size of the metrics' shared memory zone 
+is enough to accommodate existing metrics and that the value of
+`max_metric_name_len` isn't less than any existing metric name.
+
+[Nginx shared memory]: https://nginx.org/en/docs/dev/development_guide.html#shared_memory

--- a/docs/PROXY_WASM.md
+++ b/docs/PROXY_WASM.md
@@ -536,10 +536,10 @@ SDK ABI `0.2.1`) and their present status in ngx_wasm_module:
 `proxy_enqueue_shared_queue`          | :heavy_check_mark:  | No automatic eviction mechanism if the queue is full.
 `proxy_resolve_shared_queue`          | :x:                 |
 *Stats/metrics*                       |                     |
-`proxy_define_metric`                 | :x:                 |
-`proxy_get_metric`                    | :x:                 |
-`proxy_record_metric`                 | :x:                 |
-`proxy_increment_metric`              | :x:                 |
+`proxy_define_metric`                 | :heavy_check_mark:  |
+`proxy_get_metric`                    | :heavy_check_mark:  |
+`proxy_record_metric`                 | :heavy_check_mark:  |
+`proxy_increment_metric`              | :heavy_check_mark:  |
 *Custom extension points*             |                     |
 `proxy_call_foreign_function`         | :x:                 |
 

--- a/docs/adr/005-metrics.md
+++ b/docs/adr/005-metrics.md
@@ -1,0 +1,219 @@
+# Metrics
+
+* Status: proposed
+* Deciders: WasmX
+* Date: 2024-05-03
+
+## Table of Contents
+
+- [Problem Statement](#problem-statement)
+- [Technical Context](#technical-context)
+- [Decision Drivers](#decision-drivers)
+- [Proposal](#proposal)
+    - [Histograms](#histograms)
+        - [Binning](#binning)
+        - [Allocation and update handling](#allocation-and-update-handling)
+        - [Growth](#growth)
+
+## Problem Statement
+
+Support definition, update and retrieval of metrics from Proxy-Wasm filters,
+ngx_wasm_module itself and Lua land. How exactly are metrics stored and how 
+access to them is coordinated to ensure two Nginx workers never write to the
+same memory space?
+
+[Back to TOC](#table-of-contents)
+
+## Technical Context
+
+A metric can be either a counter, a gauge or a histogram.
+A counter is an integer that can only be incremented.
+A gauge is an integer that can take arbitrary positive values. 
+
+A histogram, used to represent ranges frequency of a variable, can be defined
+as a set of pairs of range and counter. For example, the distribution of the
+response time of a group of HTTP requests, can be represented as a histogram
+with ranges `[0, 10]`, `(10, 100]` and `(100, Inf]`. The 1st range's counter,
+would be the number of requests whose response time <= 10ms; the 2nd range's
+counter, requests whose 10ms < response time <= l00ms; and the last range's
+counter, requests whose response time > 100ms.
+
+A metric's value should reflect updates from all worker processes. If a counter
+is `0`, after being incremented by workers 0 and 1, it should be `2` -- despite
+the worker it's retrieved from. A gauge, however, is whatever value last set by
+any of the workers. Histograms, like counters, account for values recorded by
+all workers.
+
+[Back to TOC](#table-of-contents)
+
+## Decision Drivers
+
+* Full Proxy-Wasm ABI compatibility
+* Build atop ngx_wasm_shm
+* Minimize memory usage
+* Minimize metrics access cost
+
+[Back to TOC](#table-of-contents)
+
+## Proposal
+
+The proposed scheme for metrics storage builds atop ngx_wasm_shm's key-value
+store. Metric name is stored as a key in a red-black tree node along with metric
+value. Metric value is represented by `ngx_wa_metric_t`, see below. The member
+`type` is the metric type while the flexible array member `slots`, stores actual
+metric data.
+
+The length of `slots` equals the number of worker processes running when the
+metric is defined. This ensures each worker has its own dedicated slot to write
+metric updates.
+
+For counters, each entry in the `slots` array is simply an unsigned integer that
+its assigned worker increments. When a counter is retrieved, the values in the
+`slots` array are then summed and returned.
+
+For gauges, each of the `slots` is a pair of unsigned integer and timestamp.
+When a worker sets a gauge, the value is stored along with the time
+it's being updated in its slot. When a gauge is retrieved, the values in the
+`slots` are iterated and the most recent value is returned.
+
+For histograms, each of the `slots` points to a `ngx_wa_metrics_histogram_t`
+instance. Each worker updates the histogram pointed to by its slot. When a
+histogram is retrieved, the `slots` array is iterated and each worker's
+histogram is merged into a temporary histogram, which can then be serialized.
+
+```c
+typedef enum {
+    NGX_WA_METRIC_COUNTER,
+    NGX_WA_METRIC_GAUGE,
+    NGX_WA_METRIC_HISTOGRAM,
+} ngx_wa_metric_type_e;
+
+typedef struct {
+    ngx_uint_t  value;
+    ngx_msec_t  last_update;
+} ngx_wa_metrics_gauge_t;
+
+
+typedef struct {
+    uint32_t  upper_bound;
+    uint32_t  count;
+} ngx_wa_metrics_bin_t;
+
+typedef struct {
+    uint8_t               n_bins;
+    ngx_wa_metrics_bin_t  bins[];
+} ngx_wa_metrics_histogram_t;
+
+
+typedef union {
+    ngx_uint_t                   counter;
+    ngx_wa_metrics_gauge_t       gauge;
+    ngx_wa_metrics_histogram_t  *histogram;
+} ngx_wa_metric_val_t;
+
+typedef struct {
+    ngx_wa_metric_type_e  type;
+    ngx_wa_metric_val_t   slots[];
+} ngx_wa_metric_t;
+```
+
+This storage strategy ensures that two workers **never** write to the same
+memory address when updating a metric as long as no memory allocation is
+performed. This is indeed the case for counters and gauges and it's also the
+case for most histogram updates.
+
+This is an important feature of this design as it allows the more frequent
+update operations to be performed without the aid of locks. The cost of a
+lock-less metric update then becomes merely the cost of searching the red-black
+tree of the underlying key-value store, O(logn).
+
+The capacity of updating a metric without having to acquire a lock is
+particularly attractive when a set of worker processes is under heavy load. In
+such conditions, lock contention is likely to impact proxy throughput as workers
+are more likely to wait for a lock to be released before proceeding with its
+metric update and resume its workload.
+
+Metric definition and removal still require locks to be safely performed as two
+workers might end up attempting to write to the same memory location. This is
+also true for histogram updates which cause them to grow in number of `bins`.
+
+The ABI proposed to accomplish the described system closely resembles the one
+from Proxy-Wasm specification itself:
+
+```c
+ngx_int_t ngx_wa_metrics_add(ngx_wa_metrics_t *metrics, ngx_str_t *name,
+    ngx_wa_metric_type_e type, uint32_t *out);
+ngx_int_t ngx_wa_metrics_get(ngx_wa_metrics_t *metrics, uint32_t metric_id,
+    ngx_uint_t *out);
+ngx_int_t ngx_wa_metrics_increment(ngx_wa_metrics_t *metrics,
+    uint32_t metric_id, ngx_int_t val);
+ngx_int_t ngx_wa_metrics_record(ngx_wa_metrics_t *metrics, uint32_t metric_id,
+    ngx_int_t val);
+```
+
+[Back to TOC](#table-of-contents)
+
+### Histograms
+
+This proposal includes a scheme composed of `ngx_wa_metrics_bin_t`, a pair of
+upper bound and counter, and `ngx_wa_metrics_histogram_t`, a list of
+`ngx_wa_metrics_bin_t` ordered by upper bound, to represent histogram data in
+memory. A bin's counter is the number of recorded values less than or equal to
+its upper bound and bigger than the previous bin's upper bound.
+
+This storage layout can represent both histograms with user-defined bins and
+those following an automatic binning strategy, like logarithmic binning. This
+document will focus, however, on logarithmic binning; user-defined bins are left
+for a future iteration.
+
+[Back to TOC](#table-of-contents)
+
+#### Binning
+
+The proposed binning strategy assumes the domain of the variables being measured
+is the set of nonnegative integers and divides this domain into bins whose upper
+bound grows in powers of 2, i.e., 1, 2, 4, 8, 16, etc. The mapping of a value
+`v` to its bin is given by the function `pow(2, ceil(log2(v)))` which calculates
+the bin's upper bound. The value 10, for example, is mapped to the bin whose
+upper bound is `pow(2, ceil(log2(10)))`, or 16. The bin with upper bound `16`
+represents recorded values between `8` and `16`.
+
+This logarithmic scaling provides good enough resolution for small values in
+return for low resolution for large values while keeping the memory footprint
+reasonably low: values up to 65,536 can be represented with only 16 bins. These
+characteristics fit the typical use case of measuring HTTP response time in
+milliseconds.
+
+[Back to TOC](#table-of-contents)
+
+#### Allocation and update handling
+
+Histograms are created with enough space for 5 bins, one of which is initialized
+with NGX_MAX_UINT32_VALUE as upper bound, leaving 4 uninitialized.
+
+If a value v is recorded into a histogram and its respective bin is part of the
+histogram's bins, its counter is simply incremented. If not, and there's at
+least one uninitialized bin, then one bin is initialized with v's upper bound,
+the bins are rearranged to ensure ascending order with respect to upper bound,
+and the new bin's counter is finally incremented.
+
+[Back to TOC](#table-of-contents)
+
+#### Expansion
+
+If a value v is recorded but its bin isn't part of the histogram's bins and
+there aren't any uninitialized bins left, the histogram needs to grow to
+accommodate the new value's bin.
+
+Expanding a histogram means allocating memory for a new histogram instance with
+enough space for the additional bin, copying memory from the old instance to
+the new one and finally releasing the old histogram's memory. The new
+uninitialized bin is then initialized with v's upper bound and its counter is
+incremented.
+
+Histograms, however, can only grow up to a maximum number of bins. When a value
+`v` is recorded into a histogram, but its bin isn't part of the bins and the
+histogram's reached the bin limit, the bin with the smallest upper bound bigger
+than `v` is incremented.
+
+[Back to TOC](#table-of-contents)

--- a/src/common/debug/ngx_wasm_debug_module.c
+++ b/src/common/debug/ngx_wasm_debug_module.c
@@ -9,6 +9,8 @@
 #include <ngx_http_wasm.h>
 #endif
 
+#include <ngx_wa_metrics.h>
+
 #if (!NGX_DEBUG)
 #   error ngx_wasm_debug_module included in a non-debug build
 #endif
@@ -20,6 +22,11 @@
 static ngx_int_t
 ngx_wasm_debug_init(ngx_cycle_t *cycle)
 {
+    size_t                   long_metric_name_len = NGX_MAX_ERROR_STR;
+    uint32_t                 mid;
+    ngx_str_t                metric_name;
+    u_char                   buf[long_metric_name_len];
+
     static ngx_wasm_phase_t  ngx_wasm_debug_phases[] = {
         { ngx_string("a_phase"), 0, 0, 0 },
         { ngx_null_string, 0, 0, 0 }
@@ -39,6 +46,25 @@ ngx_wasm_debug_init(ngx_cycle_t *cycle)
      */
     ngx_wa_assert(
         ngx_wasm_phase_lookup(&ngx_wasm_debug_subsystem, 3) == NULL
+    );
+
+    metric_name.len = long_metric_name_len;
+    metric_name.data = buf;
+
+    /* invalid metric name length */
+    ngx_wa_assert(
+        ngx_wa_metrics_define(ngx_wasmx_metrics(cycle),
+                              &metric_name,
+                              NGX_WA_METRIC_COUNTER,
+                              &mid) == NGX_ABORT
+    );
+
+    /* invalid metric type */
+    ngx_wa_assert(
+        ngx_wa_metrics_define(ngx_wasmx_metrics(cycle),
+                              &metric_name,
+                              100,
+                              &mid) == NGX_ABORT
     );
 
     return NGX_OK;

--- a/src/common/metrics/ngx_wa_histogram.c
+++ b/src/common/metrics/ngx_wa_histogram.c
@@ -1,0 +1,234 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_wasm.h>
+#include <ngx_wa_histogram.h>
+
+#define NGX_WA_INITIAL_BINS    5
+#define NGX_WA_MAX_BINS        18
+#define NGX_WA_BINS_INCREMENT  4
+
+
+static uint32_t
+bin_log2_upper_bound(ngx_uint_t n)
+{
+    uint32_t upper_bound = 2;
+
+    if (n <= 1) {
+        return 1;
+    }
+
+    if (n > NGX_MAX_UINT32_VALUE / 2) {
+        return NGX_MAX_UINT32_VALUE;
+    }
+
+    for (n = n - 1; n >>= 1; upper_bound <<= 1) { /* void */ }
+
+    return upper_bound;
+}
+
+
+static ngx_int_t
+histogram_grow(ngx_wa_metrics_t *metrics, ngx_wa_metrics_histogram_t *h,
+    ngx_wa_metrics_histogram_t **out)
+{
+    size_t                       old_size, size;
+    ngx_int_t                    rc = NGX_OK;
+    ngx_uint_t                   n;
+    ngx_wa_metrics_histogram_t  *new_h = NULL;
+
+    if (h->n_bins == NGX_WA_MAX_BINS) {
+        return NGX_ERROR;
+    }
+
+    ngx_log_debug(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                  "growing histogram");
+
+    n = ngx_min(NGX_WA_BINS_INCREMENT, NGX_WA_MAX_BINS - h->n_bins);
+    old_size = sizeof(ngx_wa_metrics_histogram_t)
+               + sizeof(ngx_wa_metrics_bin_t) * h->n_bins;
+    size = old_size + sizeof(ngx_wa_metrics_bin_t) * n;
+
+    if (metrics->shm->eviction == NGX_WASM_SHM_EVICTION_NONE) {
+        ngx_wasm_shm_lock(metrics->shm);
+    }
+
+    new_h = ngx_slab_calloc_locked(metrics->shm->shpool, size);
+    if (new_h == NULL) {
+        ngx_log_debug(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                      "cannot expand histogram");
+        rc = NGX_ERROR;
+        goto error;
+    }
+
+    ngx_memcpy(new_h, h, old_size);
+    ngx_slab_free_locked(metrics->shm->shpool, h);
+
+    new_h->n_bins += n;
+    *out = new_h;
+
+error:
+
+    if (metrics->shm->eviction == NGX_WASM_SHM_EVICTION_NONE) {
+        ngx_wasm_shm_unlock(metrics->shm);
+    }
+
+    return rc;
+}
+
+
+static ngx_wa_metrics_bin_t *
+histogram_bin(ngx_wa_metrics_t *metrics, ngx_wa_metrics_histogram_t *h,
+    ngx_uint_t n, ngx_wa_metrics_histogram_t **out)
+{
+    size_t                 i, j = 0;
+    uint32_t               ub = bin_log2_upper_bound(n);
+    ngx_wa_metrics_bin_t  *b;
+
+    for (i = 0; i < h->n_bins; i++) {
+        b = &h->bins[i];
+        j = (j == 0 && ub < b->upper_bound) ? i : j;
+
+        if (b->upper_bound == ub) {
+            return b;
+
+        }  else if (b->upper_bound == 0) {
+            break;
+        }
+    }
+
+    if (i == h->n_bins) {
+        if (out && histogram_grow(metrics, h, out) == NGX_OK) {
+            h = *out;
+
+        } else {
+            ngx_wasm_log_error(NGX_LOG_INFO, metrics->shm->log, 0,
+                               "cannot add a new histogram bin for value "
+                               "\"%uD\", returning next closest bin", n);
+            return &h->bins[j];
+        }
+    }
+
+    /* shift bins to create space for the new one */
+    ngx_memcpy(&h->bins[j + 1], &h->bins[j],
+               sizeof(ngx_wa_metrics_bin_t) * (i - j));
+
+    h->bins[j].upper_bound = ub;
+    h->bins[j].count = 0;
+
+    return &h->bins[j];
+}
+
+
+void
+ngx_wa_metrics_histogram_get(ngx_wa_metrics_t *metrics, ngx_wa_metric_t *m,
+    ngx_uint_t slots, ngx_wa_metrics_histogram_t *out)
+{
+    size_t                       i, j = 0;
+    ngx_wa_metrics_bin_t        *b, *out_b;
+    ngx_wa_metrics_histogram_t  *h;
+
+    for (i = 0; i < slots; i++) {
+        h = m->slots[i].histogram;
+
+        for (j = 0; j < h->n_bins; j++) {
+            b = &h->bins[j];
+            if (b->upper_bound == 0) {
+                break;
+            }
+
+            out_b = histogram_bin(metrics, out, b->upper_bound, NULL);
+            out_b->count += b->count;
+        }
+    }
+}
+
+#if (NGX_DEBUG)
+static void
+histogram_log(ngx_wa_metrics_t *metrics, ngx_wa_metric_t *m, uint32_t mid)
+{
+    size_t                       i, size = sizeof(ngx_wa_metrics_histogram_t)
+                                           + sizeof(ngx_wa_metrics_bin_t)
+                                           * NGX_WA_MAX_BINS;
+    ngx_wa_metrics_bin_t        *b;
+    ngx_wa_metrics_histogram_t  *h;
+    u_char                      *p, buf[size], s_buf[NGX_MAX_ERROR_STR];
+
+    ngx_memzero(buf, size);
+
+    p = s_buf;
+    h = (ngx_wa_metrics_histogram_t *) buf;
+    h->n_bins = NGX_WA_MAX_BINS;
+    h->bins[0].upper_bound = NGX_MAX_UINT32_VALUE;
+
+    ngx_wa_metrics_histogram_get(metrics, m, metrics->workers, h);
+
+    for (i = 0; i < h->n_bins; i++) {
+        b = &h->bins[i];
+        if (b->upper_bound == 0) {
+            break;
+        }
+
+        p = ngx_sprintf(p, " %uD: %uD;", b->upper_bound, b->count);
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                   "histogram \"%uD\": %*s", mid, p - s_buf - 1, s_buf + 1);
+}
+#endif
+
+ngx_int_t
+ngx_wa_metrics_histogram_add_locked(ngx_wa_metrics_t *metrics,
+    ngx_wa_metric_t *m)
+{
+    size_t                        i;
+    static uint16_t               n_bins = NGX_WA_INITIAL_BINS;
+    ngx_wa_metrics_histogram_t  **h;
+
+    for (i = 0; i < metrics->workers; i++) {
+        h = &m->slots[i].histogram;
+        *h = ngx_slab_calloc_locked(metrics->shm->shpool,
+                                    sizeof(ngx_wa_metrics_histogram_t)
+                                    + sizeof(ngx_wa_metrics_bin_t) * n_bins);
+        if (*h == NULL) {
+            goto error;
+        }
+
+        (*h)->n_bins = n_bins;
+        (*h)->bins[0].upper_bound = NGX_MAX_UINT32_VALUE;
+    }
+
+    return NGX_OK;
+
+error:
+
+    ngx_wasm_log_error(NGX_LOG_ERR, metrics->shm->log, 0,
+                       "cannot allocate histogram");
+
+    for (/* void */ ; i > 0; i--) {
+        ngx_slab_free_locked(metrics->shm->shpool, m->slots[i - 1].histogram);
+    }
+
+    return NGX_ERROR;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_histogram_record(ngx_wa_metrics_t *metrics, ngx_wa_metric_t *m,
+    ngx_uint_t slot, uint32_t mid, ngx_uint_t n)
+{
+    ngx_wa_metrics_bin_t        *b;
+    ngx_wa_metrics_histogram_t  *h;
+
+    h = m->slots[slot].histogram;
+    b = histogram_bin(metrics, h, n, &m->slots[slot].histogram);
+    b->count += 1;
+
+#if (NGX_DEBUG)
+    histogram_log(metrics, m, mid);
+#endif
+
+    return NGX_OK;
+}

--- a/src/common/metrics/ngx_wa_histogram.h
+++ b/src/common/metrics/ngx_wa_histogram.h
@@ -1,0 +1,16 @@
+#ifndef _NGX_WA_HISTOGRAM_H_INCLUDED_
+#define _NGX_WA_HISTOGRAM_H_INCLUDED_
+
+
+#include <ngx_wa_metrics.h>
+
+
+ngx_int_t ngx_wa_metrics_histogram_add_locked(ngx_wa_metrics_t *metrics,
+    ngx_wa_metric_t *m);
+ngx_int_t ngx_wa_metrics_histogram_record(ngx_wa_metrics_t *metrics,
+    ngx_wa_metric_t *m, ngx_uint_t slot, uint32_t mid, ngx_uint_t n);
+void ngx_wa_metrics_histogram_get(ngx_wa_metrics_t *metrics, ngx_wa_metric_t *m,
+    ngx_uint_t slots, ngx_wa_metrics_histogram_t *out);
+
+
+#endif /* _NGX_WA_HISTOGRAM_H_INCLUDED_ */

--- a/src/common/metrics/ngx_wa_metrics.c
+++ b/src/common/metrics/ngx_wa_metrics.c
@@ -1,0 +1,466 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#include <ngx_wasm.h>
+#include <ngx_wa_metrics.h>
+#include <ngx_wa_histogram.h>
+
+#define NGX_WA_DEFAULT_METRIC_NAME_LEN    256
+#define NGX_WA_DEFAULT_METRICS_SLAB_SIZE  1024 * 1024 * 5
+
+
+static ngx_str_t *
+metric_type_name(ngx_wa_metric_type_e type)
+{
+    static ngx_str_t  counter = ngx_string("counter");
+    static ngx_str_t  gauge = ngx_string("gauge");
+    static ngx_str_t  histogram = ngx_string("histogram");
+    static ngx_str_t  unknown = ngx_string("unknown");
+
+    switch (type) {
+    case NGX_WA_METRIC_COUNTER:
+        return &counter;
+
+    case NGX_WA_METRIC_GAUGE:
+        return &gauge;
+
+    case NGX_WA_METRIC_HISTOGRAM:
+        return &histogram;
+
+    default:
+        return &unknown;
+    }
+}
+
+
+static ngx_uint_t
+counter_get(ngx_wa_metric_t *m, ngx_uint_t slots)
+{
+    ngx_uint_t  i, val = 0;
+
+    for (i = 0; i < slots; i++) {
+        val += m->slots[i].counter;
+    }
+
+    return val;
+}
+
+
+static ngx_uint_t
+gauge_get(ngx_wa_metric_t *m, ngx_uint_t slots)
+{
+    ngx_msec_t  l;
+    ngx_uint_t  i, val = 0;
+
+    val = m->slots[0].gauge.value;
+    l = m->slots[0].gauge.last_update;
+
+    for (i = 1; i < slots; i++) {
+        if (m->slots[i].gauge.last_update > l) {
+            val = m->slots[i].gauge.value;
+            l = m->slots[i].gauge.last_update;
+        }
+    }
+
+    return val;
+}
+
+
+static ngx_int_t
+histogram_reallocate(ngx_wa_metrics_t *metrics, ngx_wa_metric_t *old_m,
+    uint32_t mid)
+{
+    uint32_t          cas, slots = metrics->old_metrics->workers;
+    ngx_int_t         rc;
+    ngx_str_t        *val;
+    ngx_wa_metric_t  *m;
+
+    rc = ngx_wasm_shm_kv_get_locked(metrics->shm, NULL, &mid, &val, &cas);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    m = (ngx_wa_metric_t *) val->data;
+
+    ngx_wa_metrics_histogram_get(metrics, old_m, slots, m->slots[0].histogram);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+metrics_reallocate(ngx_wa_metrics_t *metrics, ngx_rbtree_node_t *node,
+    ngx_rbtree_node_t *sentinel)
+{
+    uint32_t                 mid;
+    ngx_int_t                rc;
+    ngx_uint_t               val;
+    ngx_wasm_shm_kv_node_t  *n = (ngx_wasm_shm_kv_node_t *) node;
+    ngx_wa_metric_t         *m = (ngx_wa_metric_t *) n->value.data;
+
+    if (node == sentinel) {
+        return NGX_OK;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                   "reallocating metric \"%V\"", &n->key.str);
+
+    if (ngx_wa_metrics_define(metrics, &n->key.str, m->type, &mid) != NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_ERR, metrics->shm->log, 0,
+                           "failed redefining metric \"%V\"", &n->key.str);
+
+        return NGX_ERROR;
+    }
+
+    switch (m->type) {
+    case NGX_WA_METRIC_COUNTER:
+        val = counter_get(m, metrics->old_metrics->workers);
+        rc = ngx_wa_metrics_increment(metrics, mid, val);
+        break;
+
+    case NGX_WA_METRIC_GAUGE:
+        val = gauge_get(m, metrics->old_metrics->workers);
+        rc = ngx_wa_metrics_record(metrics, mid, val);
+        break;
+
+    case NGX_WA_METRIC_HISTOGRAM:
+        rc = histogram_reallocate(metrics, m, mid);
+        break;
+
+    default:
+        ngx_wa_assert(0);
+        return NGX_ERROR;
+    }
+
+    if (rc != NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_ERR, metrics->shm->log, 0,
+                           "failed updating metric \"%V\"", &n->key.str);
+        return NGX_ERROR;
+    }
+
+    if (node->left
+        && metrics_reallocate(metrics, node->left, sentinel) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    if (node->right
+        && metrics_reallocate(metrics, node->right, sentinel) != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_wa_metrics_t *
+ngx_wa_metrics_alloc(ngx_cycle_t *cycle)
+{
+    static ngx_str_t   shm_name = ngx_string("metrics");
+    ngx_wa_metrics_t  *metrics;
+
+    metrics = ngx_pcalloc(cycle->pool, sizeof(ngx_wa_metrics_t));
+    if (metrics == NULL) {
+        return NULL;
+    }
+
+    metrics->old_metrics = ngx_wasmx_metrics(cycle->old_cycle);
+    metrics->config.slab_size = NGX_CONF_UNSET_SIZE;
+    metrics->config.max_metric_name_length = NGX_CONF_UNSET_SIZE;
+
+    metrics->shm = ngx_pcalloc(cycle->pool, sizeof(ngx_wasm_shm_t));
+    if (metrics->shm == NULL) {
+        ngx_pfree(cycle->pool, metrics);
+
+        return NULL;
+    }
+
+    metrics->shm->log = &cycle->new_log;
+    metrics->shm->name = shm_name;
+    metrics->shm->type = NGX_WASM_SHM_TYPE_METRICS;
+    metrics->shm->eviction = NGX_WASM_SHM_EVICTION_NONE;
+
+    return metrics;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_init_conf(ngx_wa_metrics_t *metrics, ngx_conf_t *cf)
+{
+    ngx_cycle_t       *cycle = cf->cycle;
+    ngx_core_conf_t   *ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                                              ngx_core_module);
+    ngx_wa_metrics_t  *old_metrics = metrics->old_metrics;
+
+    if (metrics->config.slab_size == NGX_CONF_UNSET_SIZE) {
+        metrics->config.slab_size = NGX_WA_DEFAULT_METRICS_SLAB_SIZE;
+    }
+
+    if (metrics->config.max_metric_name_length == NGX_CONF_UNSET_SIZE) {
+        metrics->config.max_metric_name_length = NGX_WA_DEFAULT_METRIC_NAME_LEN;
+    }
+
+    /* TODO: if eviction is enabled, metrics->workers must be set to 1 */
+    metrics->workers = ccf->worker_processes;
+    metrics->shm_zone = ngx_shared_memory_add(cf, &metrics->shm->name,
+                                              metrics->config.slab_size,
+                                              &ngx_wasmx_module);
+    if (metrics->shm_zone == NULL) {
+        return NGX_ERROR;
+    }
+
+    metrics->shm_zone->data = metrics->shm;
+    metrics->shm_zone->init = ngx_wasm_shm_init_zone;
+    metrics->shm_zone->noreuse = 0;
+
+    if (old_metrics
+        && (metrics->workers != old_metrics->workers
+            || metrics->config.slab_size != old_metrics->config.slab_size))
+    {
+        metrics->shm_zone->noreuse = 1;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_init(ngx_wa_metrics_t *metrics, ngx_cycle_t *cycle)
+{
+    ngx_int_t           rc;
+    ngx_wasm_shm_kv_t  *old_shm_kv;
+
+    if (metrics->old_metrics && !metrics->shm_zone->noreuse) {
+        /* reuse old kv store */
+        metrics->shm->data = metrics->old_metrics->shm->data;
+
+        return NGX_OK;
+    }
+
+    rc = ngx_wasm_shm_kv_init(metrics->shm);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    if (metrics->old_metrics && metrics->shm_zone->noreuse) {
+        old_shm_kv = ngx_wasm_shm_get_kv(metrics->old_metrics->shm);
+
+        return metrics_reallocate(metrics, old_shm_kv->rbtree.root,
+                                  old_shm_kv->rbtree.sentinel);
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_define(ngx_wa_metrics_t *metrics, ngx_str_t *name,
+    ngx_wa_metric_type_e type, uint32_t *out)
+{
+    ssize_t           size = sizeof(ngx_wa_metric_t)
+                             + sizeof(ngx_wa_metric_val_t) * metrics->workers;
+    uint32_t          cas, mid;
+    ngx_int_t         rc, written;
+    ngx_str_t        *p, val;
+    ngx_wa_metric_t  *m;
+    u_char            buf[size];
+
+    if (type != NGX_WA_METRIC_COUNTER
+        && type != NGX_WA_METRIC_GAUGE
+        && type != NGX_WA_METRIC_HISTOGRAM)
+    {
+        return NGX_ABORT;
+    }
+
+    if (name->len > metrics->config.max_metric_name_length) {
+        return NGX_ABORT;
+    }
+
+    mid = ngx_crc32_long(name->data, name->len);
+
+    ngx_wasm_shm_lock(metrics->shm);
+
+    rc = ngx_wasm_shm_kv_get_locked(metrics->shm, NULL, &mid, &p, &cas);
+    if (rc == NGX_OK) {
+        ngx_log_debug1(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                       "wasm returning existing metric \"%z\"", mid);
+        goto done;
+    }
+
+    ngx_memzero(buf, size);
+    m = (ngx_wa_metric_t *) buf;
+    m->type = type;
+
+    if (type == NGX_WA_METRIC_HISTOGRAM) {
+        rc = ngx_wa_metrics_histogram_add_locked(metrics, m);
+        if (rc != NGX_OK) {
+            goto error;
+        }
+    }
+
+    val.len = size;
+    val.data = buf;
+
+    rc = ngx_wasm_shm_kv_set_locked(metrics->shm, name, &val, 0, &written);
+
+    if (rc != NGX_OK) {
+        goto error;
+    }
+
+done:
+
+    *out = mid;
+
+error:
+
+    ngx_wasm_shm_unlock(metrics->shm);
+
+    if (rc == NGX_OK) {
+        ngx_wasm_log_error(NGX_LOG_INFO, metrics->shm->log, 0,
+                           "defined %V \"%V\" with id %uD",
+                           metric_type_name(type), name, mid);
+    }
+
+    return rc;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_get(ngx_wa_metrics_t *metrics, uint32_t mid, ngx_uint_t *out)
+{
+    uint32_t          cas;
+    ngx_int_t         rc;
+    ngx_str_t        *n;
+    ngx_wa_metric_t  *m;
+
+    rc = ngx_wasm_shm_kv_get_locked(metrics->shm, NULL, &mid, &n, &cas);
+    if (rc != NGX_OK) {
+        return NGX_DECLINED;
+    }
+
+    m = (ngx_wa_metric_t *) n->data;
+
+    switch (m->type) {
+    case NGX_WA_METRIC_COUNTER:
+        *out = counter_get(m, metrics->workers);
+        break;
+
+    case NGX_WA_METRIC_GAUGE:
+        *out = gauge_get(m, metrics->workers);
+        break;
+
+    default:
+        return NGX_ABORT;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_increment(ngx_wa_metrics_t *metrics, uint32_t mid, ngx_int_t n)
+{
+    uint32_t          cas;
+    ngx_int_t         rc;
+    ngx_str_t        *val;
+    ngx_uint_t        slot;
+    ngx_wa_metric_t  *m;
+
+    slot = (ngx_process == NGX_PROCESS_WORKER) ? ngx_worker : 0;
+
+#if 0
+    if (metrics->shm->eviction != NGX_WASM_EVICTION_NONE) {
+        slot = 0;
+        ngx_wasm_shm_lock(metrics->shm);
+    }
+#endif
+
+    rc = ngx_wasm_shm_kv_get_locked(metrics->shm, NULL, &mid, &val, &cas);
+    if (rc != NGX_OK) {
+        goto error;
+    }
+
+    m = (ngx_wa_metric_t *) val->data;
+
+    if (m->type != NGX_WA_METRIC_COUNTER) {
+        rc = NGX_ABORT;
+        goto error;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                   "wasm updating metric \"%uD\" with %d", mid, n);
+
+    m->slots[slot].counter += n;
+
+error:
+
+#if 0
+    if (metrics->shm->eviction != NGX_WASM_EVICTION_NONE) {
+        ngx_wasm_shm_unlock(metrics->shm);
+    }
+#endif
+
+    return rc;
+}
+
+
+ngx_int_t
+ngx_wa_metrics_record(ngx_wa_metrics_t *metrics, uint32_t mid, ngx_int_t n)
+{
+    uint32_t          cas;
+    ngx_int_t         rc = NGX_OK;
+    ngx_str_t        *val;
+    ngx_uint_t        slot;
+    ngx_wa_metric_t  *m;
+
+    slot = (ngx_process == NGX_PROCESS_WORKER) ? ngx_worker : 0;
+
+#if 0
+    if (metrics->shm->eviction != NGX_WASM_EVICTION_NONE) {
+        slot = 0;
+        ngx_wasm_shm_lock(metrics->shm);
+    }
+#endif
+
+    rc = ngx_wasm_shm_kv_get_locked(metrics->shm, NULL, &mid, &val, &cas);
+    if (rc != NGX_OK) {
+        goto error;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_WASM, metrics->shm->log, 0,
+                   "wasm updating metric \"%uD\" with %d", mid, n);
+
+    m = (ngx_wa_metric_t *) val->data;
+
+    switch (m->type) {
+    case NGX_WA_METRIC_GAUGE:
+        m->slots[slot].gauge.value = n;
+        m->slots[slot].gauge.last_update = ngx_current_msec;
+
+        break;
+
+    case NGX_WA_METRIC_HISTOGRAM:
+        ngx_wa_metrics_histogram_record(metrics, m, slot, mid, n);
+
+        break;
+
+    default:
+        rc = NGX_ABORT;
+        goto error;
+
+        break;
+    }
+
+error:
+
+#if 0
+    if (metrics->shm->eviction != NGX_WASM_EVICTION_NONE) {
+        ngx_wasm_shm_unlock(metrics->shm);
+    }
+#endif
+
+    return rc;
+}

--- a/src/common/metrics/ngx_wa_metrics.h
+++ b/src/common/metrics/ngx_wa_metrics.h
@@ -1,0 +1,81 @@
+#ifndef _NGX_WA_METRICS_H_INCLUDED_
+#define _NGX_WA_METRICS_H_INCLUDED_
+
+
+#include <ngx_wasm_shm_kv.h>
+
+
+typedef struct ngx_wa_metrics_s  ngx_wa_metrics_t;
+
+
+typedef struct {
+    size_t      slab_size;
+    size_t      max_metric_name_length;
+
+    unsigned    initialized:1;
+} ngx_wa_metrics_conf_t;
+
+
+typedef enum {
+    NGX_WA_METRIC_COUNTER,
+    NGX_WA_METRIC_GAUGE,
+    NGX_WA_METRIC_HISTOGRAM,
+} ngx_wa_metric_type_e;
+
+
+typedef struct {
+    ngx_uint_t  value;
+    ngx_msec_t  last_update;
+} ngx_wa_metrics_gauge_t;
+
+
+typedef struct {
+    uint32_t  upper_bound;
+    uint32_t  count;
+} ngx_wa_metrics_bin_t;
+
+
+typedef struct {
+    uint8_t               n_bins;
+    ngx_wa_metrics_bin_t  bins[];
+} ngx_wa_metrics_histogram_t;
+
+
+typedef union {
+    ngx_uint_t                   counter;
+    ngx_wa_metrics_gauge_t       gauge;
+    ngx_wa_metrics_histogram_t  *histogram;
+} ngx_wa_metric_val_t;
+
+
+typedef struct {
+    ngx_wa_metric_type_e  type;
+    ngx_wa_metric_val_t   slots[];
+} ngx_wa_metric_t;
+
+
+struct ngx_wa_metrics_s {
+    ngx_uint_t             workers;
+    ngx_shm_zone_t        *shm_zone;
+    ngx_wasm_shm_t        *shm;
+    ngx_wa_metrics_t      *old_metrics;
+    ngx_wa_metrics_conf_t  config;
+};
+
+
+ngx_wa_metrics_t *ngx_wasmx_metrics(ngx_cycle_t *cycle);
+
+ngx_wa_metrics_t *ngx_wa_metrics_alloc(ngx_cycle_t *cycle);
+ngx_int_t ngx_wa_metrics_init_conf(ngx_wa_metrics_t *metrics, ngx_conf_t *cf);
+ngx_int_t ngx_wa_metrics_init(ngx_wa_metrics_t *metrics, ngx_cycle_t *cycle);
+ngx_int_t ngx_wa_metrics_define(ngx_wa_metrics_t *metrics, ngx_str_t *name,
+    ngx_wa_metric_type_e type, uint32_t *out);
+ngx_int_t ngx_wa_metrics_get(ngx_wa_metrics_t *metrics, uint32_t metric_id,
+    ngx_uint_t *out);
+ngx_int_t ngx_wa_metrics_increment(ngx_wa_metrics_t *metrics,
+    uint32_t metric_id, ngx_int_t val);
+ngx_int_t ngx_wa_metrics_record(ngx_wa_metrics_t *metrics, uint32_t metric_id,
+    ngx_int_t val);
+
+
+#endif /* _NGX_WA_METRICS_H_INCLUDED_ */

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -140,13 +140,11 @@ typedef enum {
 } ngx_proxy_wasm_map_type_e;
 
 
-#if 0
 typedef enum {
     NGX_PROXY_WASM_METRIC_COUNTER = 0,
     NGX_PROXY_WASM_METRIC_GAUGE = 1,
     NGX_PROXY_WASM_METRIC_HISTOGRAM = 2,
 } ngx_proxy_wasm_metric_type_e;
-#endif
 
 
 typedef struct ngx_proxy_wasm_ctx_s  ngx_proxy_wasm_ctx_t;
@@ -240,6 +238,7 @@ struct ngx_proxy_wasm_ctx_s {
     ngx_str_t                                     connection_id;     /* r->connection->number */
     ngx_str_t                                     mtls;              /* ngx.https && ngx.ssl_client_verify */
     ngx_str_t                                     root_id;           /* pwexec->root_id */
+    ngx_str_t                                     worker_id;         /* ngx_worker */
     ngx_str_t                                     call_status;       /* dispatch response status */
     ngx_str_t                                     response_status;   /* response status */
     ngx_uint_t                                    call_code;

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -1279,7 +1279,7 @@ ngx_proxy_wasm_hfuncs_get_shared_data(ngx_wavm_instance_t *instance,
 
     ngx_wasm_shm_lock(resolved.shm);
 
-    rc = ngx_wasm_shm_kv_get_locked(resolved.shm, &key, &value, cas);
+    rc = ngx_wasm_shm_kv_get_locked(resolved.shm, &key, NULL, &value, cas);
 
     ngx_wasm_shm_unlock(resolved.shm);
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -10,6 +10,7 @@
 #include <ngx_proxy_wasm_properties.h>
 #include <ngx_wasm_shm_kv.h>
 #include <ngx_wasm_shm_queue.h>
+#include <ngx_wa_metrics.h>
 #ifdef NGX_WASM_HTTP
 #include <ngx_http_proxy_wasm.h>
 #endif
@@ -1571,7 +1572,210 @@ ngx_proxy_wasm_hfuncs_dequeue_shared_queue(ngx_wavm_instance_t *instance,
 
 
 /* stats/metrics */
-/* NYI */
+
+
+static ngx_int_t
+ngx_proxy_wasm_hfuncs_define_metric(ngx_wavm_instance_t *instance,
+    wasm_val_t args[], wasm_val_t rets[])
+{
+    size_t                         max_len;
+    uint32_t                      *id;
+    ngx_str_t                      name, prefixed_name, *filter_name;
+    ngx_cycle_t                   *cycle = (ngx_cycle_t *) ngx_cycle;
+    ngx_wa_metrics_t              *metrics = ngx_wasmx_metrics(cycle);
+    ngx_wa_metric_type_e           type;
+    ngx_proxy_wasm_exec_t         *pwexec;
+    ngx_proxy_wasm_metric_type_e   pw_type;
+    u_char                         buf[metrics->config.max_metric_name_length];
+    u_char                         trapmsg[NGX_MAX_ERROR_STR];
+
+    pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+
+    pw_type = args[0].of.i32;
+    name.len = args[2].of.i32;
+    name.data = NGX_WAVM_HOST_LIFT_SLICE(instance, args[1].of.i32, name.len);
+    id = NGX_WAVM_HOST_LIFT_SLICE(instance, args[3].of.i32, sizeof(uint32_t));
+    max_len = metrics->config.max_metric_name_length;
+
+    ngx_memzero(trapmsg, NGX_MAX_ERROR_STR);
+
+    switch(pw_type) {
+    case NGX_PROXY_WASM_METRIC_COUNTER:
+        type = NGX_WA_METRIC_COUNTER;
+        break;
+
+    case NGX_PROXY_WASM_METRIC_GAUGE:
+        type = NGX_WA_METRIC_GAUGE;
+        break;
+
+    case NGX_PROXY_WASM_METRIC_HISTOGRAM:
+        type = NGX_WA_METRIC_HISTOGRAM;
+        break;
+
+    default:
+        ngx_sprintf(trapmsg, "could not define metric; unknown type \"%ui\"",
+                    pw_type);
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg,
+                                          rets,  NGX_WAVM_ERROR);
+    }
+
+    filter_name = pwexec->filter->name;
+
+    if (filter_name->len + 4 + name.len > max_len) {
+        ngx_sprintf(trapmsg, "could not define metric; name \"%*s\" too long",
+                    name.len, name.data);
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg,
+                                          rets, NGX_WAVM_ERROR);
+    }
+
+    prefixed_name.data = buf;
+    prefixed_name.len = ngx_sprintf(buf, "pw.%V.%V", filter_name, &name) - buf;
+
+    if (ngx_wa_metrics_define(metrics, &prefixed_name, type, id) != NGX_OK) {
+        ngx_sprintf(trapmsg, "could not define metric \"%*s\"",
+                    name.len, name.data);
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg,
+                                          rets, NGX_WAVM_ERROR);
+    }
+
+    return ngx_proxy_wasm_result_ok(rets);
+}
+
+
+static ngx_int_t
+ngx_proxy_wasm_hfuncs_increment_metric(ngx_wavm_instance_t *instance,
+    wasm_val_t args[], wasm_val_t rets[])
+{
+    u_char                 *p;
+    uint32_t                metric_id;
+    ngx_int_t               rc, offset;
+    ngx_cycle_t            *cycle = (ngx_cycle_t *) ngx_cycle;
+    ngx_wa_metrics_t       *metrics = ngx_wasmx_metrics(cycle);
+    ngx_proxy_wasm_exec_t  *pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+    u_char                  trapmsg[NGX_MAX_ERROR_STR];
+
+    metric_id = args[0].of.i32;
+    offset = args[1].of.i64;
+
+    rc = ngx_wa_metrics_increment(metrics, metric_id, offset);
+
+    if (rc != NGX_OK) {
+        ngx_memzero(trapmsg, NGX_MAX_ERROR_STR);
+        p = ngx_sprintf(trapmsg,
+                        "could not increment by \"%i\" metric with id "
+                        "\"%ui\"; ", offset, metric_id);
+
+        switch (rc) {
+        case NGX_DECLINED:
+            ngx_sprintf(p, "not found");
+            break;
+
+        case NGX_ABORT:
+            ngx_sprintf(p, "can only increment counters");
+            break;
+
+        default:
+            break;
+        }
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg, rets,
+                                          NGX_WAVM_ERROR);
+    }
+
+
+    return ngx_proxy_wasm_result_ok(rets);
+}
+
+
+static ngx_int_t
+ngx_proxy_wasm_hfuncs_record_metric(ngx_wavm_instance_t *instance,
+    wasm_val_t args[], wasm_val_t rets[])
+{
+    u_char                 *p;
+    uint32_t                metric_id;
+    ngx_int_t               rc, value;
+    ngx_cycle_t            *cycle = (ngx_cycle_t *) ngx_cycle;
+    ngx_wa_metrics_t       *metrics = ngx_wasmx_metrics(cycle);
+    ngx_proxy_wasm_exec_t  *pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+    u_char                  trapmsg[NGX_MAX_ERROR_STR];
+
+    metric_id = args[0].of.i32;
+    value = args[1].of.i64;
+
+    rc = ngx_wa_metrics_record(metrics, metric_id, value);
+
+    if (rc != NGX_OK) {
+        ngx_memzero(trapmsg, NGX_MAX_ERROR_STR);
+        p = ngx_sprintf(trapmsg,
+                        "could not record value \"%i\" on metric with id "
+                        "\"%ui\"; ", value, metric_id);
+
+        switch (rc) {
+        case NGX_DECLINED:
+            ngx_sprintf(p, "not found");
+            break;
+
+        case NGX_ABORT:
+            ngx_sprintf(p, "cannot record on counters");
+            break;
+
+        default:
+            break;
+        }
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg,
+                                          rets, NGX_WAVM_ERROR);
+    }
+
+    return ngx_proxy_wasm_result_ok(rets);
+}
+
+
+static ngx_int_t
+ngx_proxy_wasm_hfuncs_get_metric(ngx_wavm_instance_t *instance,
+    wasm_val_t args[], wasm_val_t rets[])
+{
+    u_char                 *p;
+    uint32_t                metric_id;
+    ngx_int_t               rc;
+    ngx_uint_t             *ret_value;
+    ngx_cycle_t            *cycle = (ngx_cycle_t *) ngx_cycle;
+    ngx_wa_metrics_t       *metrics = ngx_wasmx_metrics(cycle);
+    ngx_proxy_wasm_exec_t  *pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+    u_char                  trapmsg[NGX_MAX_ERROR_STR];
+
+    metric_id = args[0].of.i32;
+    ret_value = NGX_WAVM_HOST_LIFT(instance, args[1].of.i32, ngx_uint_t);
+
+    rc = ngx_wa_metrics_get(metrics, metric_id, ret_value);
+
+    if (rc != NGX_OK) {
+        ngx_memzero(trapmsg, NGX_MAX_ERROR_STR);
+        p = ngx_sprintf(trapmsg, "could not retrieve metric with id \"%ui\"; ",
+                        metric_id);
+
+        switch (rc) {
+        case NGX_DECLINED:
+            ngx_sprintf(p, "not found");
+            break;
+
+        case NGX_ABORT:
+            ngx_sprintf(p, "cannot retrieve histograms");
+            break;
+
+        default:
+            break;
+        }
+
+        return ngx_proxy_wasm_result_trap(pwexec, (char *) trapmsg,
+                                          rets, NGX_WAVM_ERROR);
+    }
+
+    return ngx_proxy_wasm_result_ok(rets);
+}
 
 
 /* custom extension points */
@@ -1953,7 +2157,7 @@ static ngx_wavm_host_func_def_t  ngx_proxy_wasm_hfuncs[] = {
       ngx_wavm_arity_i32x4,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_define_metric"),                 /* 0.2.0 && 0.2.1 */
-      &ngx_proxy_wasm_hfuncs_nop,                        /* NYI */
+      &ngx_proxy_wasm_hfuncs_define_metric,
       ngx_wavm_arity_i32x4,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_get_metric_value"),              /* vNEXT */
@@ -1961,7 +2165,7 @@ static ngx_wavm_host_func_def_t  ngx_proxy_wasm_hfuncs[] = {
       ngx_wavm_arity_i32x2,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_get_metric"),                    /* 0.2.0 && 0.2.1 */
-      &ngx_proxy_wasm_hfuncs_nop,                        /* NYI */
+      &ngx_proxy_wasm_hfuncs_get_metric,
       ngx_wavm_arity_i32x2,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_set_metric_value"),              /* vNEXT */
@@ -1969,7 +2173,7 @@ static ngx_wavm_host_func_def_t  ngx_proxy_wasm_hfuncs[] = {
       ngx_wavm_arity_i32_i64,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_record_metric"),                 /* 0.2.0 && 0.2.1 */
-      &ngx_proxy_wasm_hfuncs_nop,                        /* NYI */
+      &ngx_proxy_wasm_hfuncs_record_metric,
       ngx_wavm_arity_i32_i64,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_increment_metric_value"),        /* vNEXT */
@@ -1977,7 +2181,7 @@ static ngx_wavm_host_func_def_t  ngx_proxy_wasm_hfuncs[] = {
       ngx_wavm_arity_i32_i64,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_increment_metric"),              /* 0.2.0 && 0.2.1 */
-      &ngx_proxy_wasm_hfuncs_nop,                        /* NYI */
+      &ngx_proxy_wasm_hfuncs_increment_metric,
       ngx_wavm_arity_i32_i64,
       ngx_wavm_arity_i32 },
     { ngx_string("proxy_delete_metric"),                 /* vNEXT */

--- a/src/common/shm/ngx_wasm_shm.h
+++ b/src/common/shm/ngx_wasm_shm.h
@@ -11,6 +11,7 @@
 typedef enum {
     NGX_WASM_SHM_TYPE_KV,
     NGX_WASM_SHM_TYPE_QUEUE,
+    NGX_WASM_SHM_TYPE_METRICS,
 } ngx_wasm_shm_type_e;
 
 

--- a/src/common/shm/ngx_wasm_shm_kv.h
+++ b/src/common/shm/ngx_wasm_shm_kv.h
@@ -6,12 +6,32 @@
 
 
 typedef struct {
+    ngx_rbtree_t        rbtree;
+    ngx_rbtree_node_t   sentinel;
+    union {
+        ngx_queue_t     lru_queue;
+        ngx_queue_t     slru_queues[0];
+    } eviction;
+} ngx_wasm_shm_kv_t;
+
+
+typedef struct {
     ngx_str_t           namespace;
     ngx_str_t           key;
     ngx_shm_zone_t     *zone;
     ngx_wasm_shm_t     *shm;
 } ngx_wasm_shm_kv_key_t;
 
+
+typedef struct {
+    ngx_str_node_t  key;
+    ngx_str_t       value;
+    uint32_t        cas;
+    ngx_queue_t     queue;
+} ngx_wasm_shm_kv_node_t;
+
+
+ngx_wasm_shm_kv_t * ngx_wasm_shm_get_kv(ngx_wasm_shm_t *shm);
 
 ngx_int_t ngx_wasm_shm_kv_init(ngx_wasm_shm_t *shm);
 ngx_int_t ngx_wasm_shm_kv_get_locked(ngx_wasm_shm_t *shm,

--- a/src/common/shm/ngx_wasm_shm_kv.h
+++ b/src/common/shm/ngx_wasm_shm_kv.h
@@ -15,7 +15,7 @@ typedef struct {
 
 ngx_int_t ngx_wasm_shm_kv_init(ngx_wasm_shm_t *shm);
 ngx_int_t ngx_wasm_shm_kv_get_locked(ngx_wasm_shm_t *shm,
-    ngx_str_t *key, ngx_str_t **value_out, uint32_t *cas);
+    ngx_str_t *key, uint32_t *key_hash, ngx_str_t **value_out, uint32_t *cas);
 ngx_int_t ngx_wasm_shm_kv_set_locked(ngx_wasm_shm_t *shm,
     ngx_str_t *key, ngx_str_t *value, uint32_t cas, ngx_int_t *written);
 ngx_int_t ngx_wasm_shm_kv_resolve_key(ngx_str_t *key,

--- a/src/ngx_wasmx.c
+++ b/src/ngx_wasmx.c
@@ -9,9 +9,6 @@
 #endif
 
 
-#define NGX_WA_CONF_ERR_DUPLICATE  "is duplicate"
-
-
 static char *ngx_wasm_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 #ifdef NGX_WA_IPC
 static char *ngx_ipc_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
@@ -68,6 +65,24 @@ ngx_module_t  ngx_wasmx_module = {
 };
 
 
+ngx_inline ngx_wa_metrics_t *
+ngx_wasmx_metrics(ngx_cycle_t *cycle)
+{
+    ngx_wa_conf_t  *wacf;
+
+    if (!cycle->conf_ctx) {
+        return NULL;
+    }
+
+    wacf = ngx_wa_cycle_get_conf(cycle);
+    if (wacf == NULL) {
+        return NULL;
+    }
+
+    return wacf->metrics;
+}
+
+
 static char *
 ngx_wasmx_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
     ngx_uint_t type, ngx_uint_t conf_type)
@@ -115,6 +130,11 @@ ngx_wasmx_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
             return NGX_CONF_ERROR;
         }
 #endif
+
+        wacf->metrics = ngx_wa_metrics_alloc(cf->cycle);
+        if (wacf->metrics == NULL) {
+            return NGX_CONF_ERROR;
+        }
 
         *(ngx_wa_conf_t **) conf = wacf;
     }
@@ -217,6 +237,10 @@ ngx_wasmx_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf,
         }
     }
 
+    if (ngx_wa_metrics_init_conf(wacf->metrics, cf) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
     return NGX_CONF_OK;
 }
 
@@ -247,6 +271,11 @@ ngx_wasmx_init(ngx_cycle_t *cycle)
     wacf = ngx_wa_cycle_get_conf(cycle);
     if (wacf == NULL) {
         return NGX_OK;
+    }
+
+    rc = ngx_wa_metrics_init(wacf->metrics, cycle);
+    if (rc != NGX_OK) {
+        return rc;
     }
 
     /* NGX_WASM_MODULES + NGX_IPC_MODULES init */

--- a/src/ngx_wasmx.h
+++ b/src/ngx_wasmx.h
@@ -3,6 +3,7 @@
 
 
 #include <ngx_core.h>
+#include <ngx_wa_metrics.h>
 
 
 #if (NGX_DEBUG)
@@ -17,6 +18,8 @@
 #define NGX_WA_WASM_CONF_OFFSET    offsetof(ngx_wa_conf_t, wasm_confs)
 #define NGX_WA_IPC_CONF_OFFSET     offsetof(ngx_wa_conf_t, ipc_confs)
 
+#define NGX_WA_CONF_ERR_DUPLICATE  "is duplicate"
+
 #define ngx_wa_cycle_get_conf(cycle)                                         \
     (ngx_wa_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_wasmx_module)
 
@@ -27,11 +30,12 @@ typedef ngx_int_t (*ngx_wa_init_pt)(ngx_cycle_t *cycle);
 
 
 typedef struct {
-    ngx_uint_t              initialized_types;
-    void                  **wasm_confs;
+    ngx_uint_t               initialized_types;
+    void                   **wasm_confs;
 #ifdef NGX_WA_IPC
-    void                  **ipc_confs;
+    void                   **ipc_confs;
 #endif
+    ngx_wa_metrics_t        *metrics;
 } ngx_wa_conf_t;
 
 

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -18,6 +18,7 @@
 #define NGX_WASMTIME_CONF            0x20000000
 #define NGX_WASMER_CONF              0x40000000
 #define NGX_V8_CONF                  0x80000000
+#define NGX_METRICS_CONF             0x16000000
 
 #define NGX_WASM_DONE_PHASE          15
 #define NGX_WASM_BACKGROUND_PHASE    16
@@ -125,12 +126,16 @@ void ngx_wasm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
 void swap_modules_if_needed(ngx_conf_t *cf, const char *m1, const char *m2);
 #endif
 
-/* directives */
+/* blocks */
 char *ngx_wasm_core_wasmtime_block(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_wasm_core_wasmer_block(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_wasm_core_v8_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+char *ngx_wasm_core_metrics_block(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+/* directives */
 char *ngx_wasm_core_flag_directive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_wasm_core_module_directive(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -139,6 +144,10 @@ char *ngx_wasm_core_shm_kv_directive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_wasm_core_shm_queue_directive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+char *ngx_wasm_core_metrics_slab_size_directive(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+char *ngx_wasm_core_metrics_max_metric_name_length_directive(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 char *ngx_wasm_core_resolver_directive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 char *ngx_wasm_core_pwm_lua_resolver_directive(ngx_conf_t *cf,

--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -5,6 +5,7 @@
 
 #include <ngx_wavm.h>
 #include <ngx_wasm_shm.h>
+#include <ngx_wa_metrics.h>
 
 
 static void *ngx_wasm_core_create_conf(ngx_conf_t *cf);
@@ -39,6 +40,13 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
     { ngx_string("v8"),
       NGX_WASM_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
       ngx_wasm_core_v8_block,
+      NGX_WA_WASM_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("metrics"),
+      NGX_WASM_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+      ngx_wasm_core_metrics_block,
       NGX_WA_WASM_CONF_OFFSET,
       0,
       NULL },
@@ -86,6 +94,20 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
     { ngx_string("shm_kv"),
       NGX_WASM_CONF|NGX_CONF_TAKE23|NGX_CONF_TAKE4,
       ngx_wasm_core_shm_kv_directive,
+      NGX_WA_WASM_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("slab_size"),
+      NGX_METRICS_CONF|NGX_CONF_TAKE1,
+      ngx_wasm_core_metrics_slab_size_directive,
+      NGX_WA_WASM_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("max_metric_name_length"),
+      NGX_METRICS_CONF|NGX_CONF_TAKE1,
+      ngx_wasm_core_metrics_max_metric_name_length_directive,
       NGX_WA_WASM_CONF_OFFSET,
       0,
       NULL },

--- a/t/01-wasm/directives/011-metrics_directives.t
+++ b/t/01-wasm/directives/011-metrics_directives.t
@@ -1,0 +1,135 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(5);
+run_tests();
+
+__DATA__
+
+=== TEST 1: metrics{} - empty block
+--- valgrind
+--- main_config
+    wasm {
+        metrics {}
+    }
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[stub]
+
+
+
+=== TEST 2: metrics{} - duplicated block
+--- main_config
+    wasm {
+        metrics {}
+        metrics {}
+    }
+--- error_log: is duplicate
+--- no_error_log
+[error]
+[crit]
+[stub]
+--- must_die
+
+
+
+=== TEST 3: slab_size directive - sanity
+--- main_config
+    wasm {
+        metrics {
+            slab_size 12k;
+        }
+    }
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[stub]
+
+
+
+=== TEST 4: slab_size directive - too small
+--- main_config
+    wasm {
+        metrics {
+            slab_size 1k;
+        }
+    }
+--- error_log eval
+qr/\[emerg\] .*? \[wasm\] shm size of \d+ bytes is too small, minimum required is 12288 bytes/
+--- no_error_log
+[error]
+[crit]
+[stub]
+--- must_die
+
+
+
+=== TEST 5: slab_size directive - invalid size
+--- main_config
+    wasm {
+        metrics {
+            slab_size 1x;
+        }
+    }
+--- error_log eval
+qr/\[emerg\] .*? \[wasm\] invalid shm size "1x"/
+--- no_error_log
+[error]
+[crit]
+[stub]
+--- must_die
+
+
+
+=== TEST 6: slab_size directive - duplicate
+--- main_config
+    wasm {
+        metrics {
+            slab_size 12k;
+            slab_size 12k;
+        }
+    }
+--- error_log: is duplicate
+--- no_error_log
+[error]
+[crit]
+[stub]
+--- must_die
+
+
+
+=== TEST 7: max_metric_name_length directive - sanity
+--- main_config
+    wasm {
+        metrics {
+            max_metric_name_length 64;
+        }
+    }
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[stub]
+
+
+
+=== TEST 8: max_metric_name_length directive - duplicate
+--- main_config
+    wasm {
+        metrics {
+            max_metric_name_length 64;
+            max_metric_name_length 64;
+        }
+    }
+--- error_log: is duplicate
+--- no_error_log
+[error]
+[crit]
+[stub]
+--- must_die

--- a/t/03-proxy_wasm/hfuncs/contexts/150-proxy_define_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/150-proxy_define_metric.t
@@ -1,0 +1,187 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - define_metric on_vm_start
+--- main_config
+    env WASMTIME_BACKTRACE_DETAILS=1;
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm 'define_metric';
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: proxy_wasm contexts - define_metric - on_configure
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 3: proxy_wasm contexts - define_metric - on_tick
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - define_metric on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=define_metric \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 5: proxy_wasm contexts - define_metric on_request_headers
+--- wasm_modules: context_checks
+--- metrics: 16k
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm contexts - define_metric on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=define_metric';
+        echo ok;
+    }
+--- request
+POST /t
+payload
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - define_metric on_response_headers
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm contexts - define_metric on_response_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=define_metric';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - define_metric on_log
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/151-proxy_increment_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/151-proxy_increment_metric.t
@@ -1,0 +1,185 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - increment_metric on_vm_start
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm 'increment_metric';
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: proxy_wasm contexts - increment_metric - on_configure
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 3: proxy_wasm contexts - increment_metric - on_tick
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - increment_metric on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=increment_metric \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 5: proxy_wasm contexts - increment_metric on_request_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm contexts - increment_metric on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=increment_metric';
+        echo ok;
+    }
+--- request
+POST /t
+payload
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - increment_metric on_response_headers
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm contexts - increment_metric on_response_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=increment_metric';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - increment_metric on_log
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/152-proxy_record_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/152-proxy_record_metric.t
@@ -1,0 +1,185 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - record_metric on_vm_start
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm 'record_metric';
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: proxy_wasm contexts - record_metric - on_configure
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 3: proxy_wasm contexts - record_metric - on_tick
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - record_metric on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=record_metric \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 5: proxy_wasm contexts - record_metric on_request_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm contexts - record_metric on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=record_metric';
+        echo ok;
+    }
+--- request
+POST /t
+payload
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - record_metric on_response_headers
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm contexts - record_metric on_response_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=record_metric';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - record_metric on_log
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/153-proxy_get_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/153-proxy_get_metric.t
@@ -1,0 +1,185 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - get_metric on_vm_start
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm 'get_metric';
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 2: proxy_wasm contexts - get_metric - on_configure
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 3: proxy_wasm contexts - get_metric - on_tick
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - get_metric on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=get_metric \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 5: proxy_wasm contexts - get_metric on_request_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm contexts - get_metric on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=get_metric';
+        echo ok;
+    }
+--- request
+POST /t
+payload
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - get_metric on_response_headers
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm contexts - get_metric on_response_body
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=get_metric';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - get_metric on_log
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/metrics/001-define_metric.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/001-define_metric.t
@@ -1,0 +1,104 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+our $workers = 2;
+
+workers($workers);
+if ($workers > 1) {
+    master_on();
+}
+
+plan_tests(6);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - define_metric() counter
+--- valgrind
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              metrics=c1';
+        echo ok;
+    }
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] defined metric \w+ as \d+/
+--- grep_error_log_out eval
+qr/.*? defined metric c1 as \d+/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 2: proxy_wasm - define_metric() gauge
+--- valgrind
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              metrics=g1';
+        echo ok;
+    }
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] defined metric \w+ as \d+/
+--- grep_error_log_out eval
+qr/.*? defined metric g1 as \d+/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 3: proxy_wasm - define_metric() histogram
+--- valgrind
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              metrics=h1';
+        echo ok;
+    }
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] defined metric \w+ as \d+/
+--- grep_error_log_out eval
+qr/.*? defined metric h1 as \d+/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 4: proxy_wasm - define_metric() redefinition
+Definition happens only once, a second call defining an existing metric simply
+returns its id.
+
+--- skip_no_debug
+--- valgrind
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              metrics=c1,g1,h1';
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              metrics=c1,g1,h1';
+        echo ok;
+    }
+--- error_log
+wasm returning existing metric
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/002-define_metric_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/002-define_metric_edge_cases.t
@@ -1,0 +1,120 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+no_shuffle();
+
+plan_tests(5);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - define_metric() metric name too long
+In SIGHUP mode, this test fails if executed after a test that defined metrics,
+as any existing metric whose name exceeds `max_metric_name_length` won't be
+successfully reallocated causing the reconfiguration to fail.
+
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            max_metric_name_length 4;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/define \
+                              metrics=c1';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not define metric; name "\w+" too long.*/,
+]
+--- no_error_log
+[emerg]
+[alert]
+[stub]
+
+
+
+=== TEST 2: proxy_wasm - define_metric() no memory
+In SIGHUP mode, this test fails if executed after a test that defined more
+metrics than it's possible to fit in `5m`.
+
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 5m;
+            max_metric_name_length 128;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/define \
+                              metrics=c20337 \
+                              metrics_name_len=100';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/\[crit\] .+ \[wasm\] "metrics" shm store: no memory; cannot allocate pair with key size \d+ and value size \d+/,
+    qr/host trap \(internal error\): could not define metric.*/,
+]
+--- no_error_log
+[emerg]
+[alert]
+
+
+
+=== TEST 3: proxy_wasm - define_metric() no memory, histogram
+In SIGHUP mode, this test fails if executed after a test that defined more
+metrics than it's possible to fit in `5m`.
+
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 16k;
+            max_metric_name_length 128;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/define \
+                              metrics=c30,h16';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    "cannot allocate histogram",
+    qr/host trap \(internal error\): could not define metric.*/,
+]
+--- no_error_log
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/101-increment_metric.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/101-increment_metric.t
@@ -1,0 +1,37 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+our $workers = 2;
+
+workers($workers);
+master_on();
+
+plan_tests(6);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - increment_metric() sanity
+A counter's value should reflect increments made by all workers.
+
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              metrics=c1';
+        echo ok;
+    }
+--- error_log eval
+qr/c1: $::workers at Configure/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/102-increment_metric_misuse.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/102-increment_metric_misuse.t
@@ -1,0 +1,56 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(5);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - increment_metric() gauge
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/increment_gauges \
+                              metrics=g1,g2';
+        echo ok;
+    }
+}
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not increment by "[0-9]+" metric with id "[0-9]+"; can only increment counters.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 2: proxy_wasm - increment_metric() invalid metric id
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/increment_invalid_counter';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not increment by "[0-9]+" metric with id "[0-9]+"; not found.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/201-record_metric.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/201-record_metric.t
@@ -1,0 +1,92 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+
+workers(2);
+master_on();
+
+plan_tests(7);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - record_metric() gauge
+A gauge's value is equal to the last value set by any of the workers.
+The first filter, bound to worker 0, sets g1 to 1; the second one, bound to
+worker 1, sets g1 to 2.
+
+--- skip_no_debug
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on_tick=set_gauges \
+                              tick_period=100 \
+                              n_sync_calls=1 \
+                              on_worker=0 \
+                              value=1 \
+                              metrics=g1';
+
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on_tick=set_gauges \
+                              tick_period=500 \
+                              n_sync_calls=1 \
+                              on_worker=1 \
+                              value=2 \
+                              metrics=g1';
+        echo ok;
+    }
+--- wait: 1
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] record \d+ on g1/
+--- grep_error_log_out eval
+qr/.*? record 1 on g1.*
+.*? record 2 on g1.*/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+[stub]
+
+
+
+=== TEST 2: proxy_wasm - record_metric() histogram
+Records values to a histogram so that each of its bins has counter equals to 1.
+
+--- skip_no_debug
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+my $filters;
+
+foreach my $exp (0 .. 17) {
+    my $v = 2 ** $exp;
+    $filters .= "
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              test=/t/metrics/record_histograms \
+                              metrics=h1 \
+                              value=$v';";
+}
+qq{
+    location /t {
+        $filters
+
+        echo ok;
+    }
+}
+--- error_log eval
+[
+    "growing histogram",
+    qr/histogram "\d+": 1: 1; 2: 1; 4: 1; 8: 1; 16: 1; 32: 1; 64: 1; 128: 1; 256: 1; 512: 1; 1024: 1; 2048: 1; 4096: 1; 8192: 1; 16384: 1; 32768: 1; 65536: 1; 4294967295: 1;/
+]
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/202-record_metric_misuse.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/202-record_metric_misuse.t
@@ -1,0 +1,54 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(5);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - record_metric() counter
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/toggle_counters \
+                              metrics=c1,c2';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not record value "[0-9]+" on metric with id "[0-9]+"; cannot record on counters.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 2: proxy_wasm - record_metric() invalid metric id
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/set_invalid_gauge';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not record value "[0-9]+" on metric with id "[0-9]+"; not found.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/metrics/203-record_metric_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/203-record_metric_edge_cases.t
@@ -1,0 +1,85 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+no_shuffle();
+
+plan_tests(7);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - record_metric() cannot expand histogram
+In SIGHUP mode, this test fails if executed after a test that defined more
+metrics than it's possible to fit in `5m`.
+
+This test creates 16256 histograms and records on them the values 1, 2, 4, 8
+and 16. The histograms cannot be expanded to include the bin associated with the
+value 16, so its occurrance is recorded in the bin whose upper bound is
+4294967295.
+
+--- skip_no_debug
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 5m;
+            max_metric_name_length 128;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h16256 \
+                              value=1 \
+                              metrics_name_len=115';
+
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h16256 \
+                              value=2 \
+                              metrics_name_len=115';
+
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h16256 \
+                              value=4 \
+                              metrics_name_len=115';
+
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h16256 \
+                              value=8 \
+                              metrics_name_len=115';
+
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h16256 \
+                              value=16 \
+                              metrics_name_len=115';
+        echo ok;
+    }
+--- error_log eval
+[
+    "cannot expand histogram",
+    qr/histogram \"\d+\": 1: 1; 2: 1; 4: 1; 8: 1; 4294967295: 1/,
+]
+--- no_error_log
+[emerg]
+[alert]
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/metrics/301-get_metric.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/301-get_metric.t
@@ -1,0 +1,54 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(6);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm metrics - get_metric() counter
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              metrics=c1 \
+                              on=request_headers \
+                              test=/t/log/metrics';
+        echo ok;
+    }
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] c1: 1.*/
+--- grep_error_log_out eval
+qr/.*? c1: 1 .*/
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+[stub]
+
+
+
+=== TEST 2: proxy_wasm metrics - get_metric() gauge
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_toggle_gauges \
+                              metrics=g1 \
+                              on=request_headers \
+                              test=/t/log/metrics';
+        echo ok;
+    }
+--- grep_error_log eval: qr/\["hostcalls" \#\d\] g1: 1.*/
+--- grep_error_log_out eval
+qr/.*? g1: 1 .*/
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+[stub]

--- a/t/03-proxy_wasm/hfuncs/metrics/302-get_metric_misuse.t
+++ b/t/03-proxy_wasm/hfuncs/metrics/302-get_metric_misuse.t
@@ -1,0 +1,54 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(6);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm metrics - get_metric() invalid metric id
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/get_invalid_metric';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not retrieve metric with id "[0-9]+"; not found.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+[stub]
+
+
+
+=== TEST 2: proxy_wasm metrics - get_metric() histogram
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/metrics/get_histogram';
+        echo ok;
+    }
+--- error_code: 500
+--- error_log eval
+[
+    qr/host trap \(internal error\): could not retrieve metric with id "[0-9]+"; cannot retrieve histograms.*/,
+]
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+[stub]

--- a/t/07-metrics/001-metrics_sighup.t
+++ b/t/07-metrics/001-metrics_sighup.t
@@ -1,0 +1,199 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_no_hup();
+
+our $workers = 2;
+
+our $metrics = "c2,g2,h2";
+
+workers($workers);
+if ($workers > 1) {
+    master_on();
+}
+
+no_shuffle();
+plan_tests(8);
+run_tests();
+
+__DATA__
+
+=== TEST 1: SIGHUP metrics - define metrics and increment counters
+Evaluating counters values in error_log rather than in response headers as some
+worker(s) might not have done their increment by the time response_headers phase
+is invoked.
+
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- error_log eval
+qr/c2: $::workers.*/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+[stub]
+[stub]
+
+
+
+=== TEST 2: SIGHUP metrics - shm preserved, no realloc
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              on=response_headers \
+                              test=/t/metrics/get \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- response_headers
+c1: 4
+c2: 4
+--- no_error_log
+reallocating metric
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 3: SIGHUP metrics - increased worker_processes - shm preserved, realloc
+--- workers: 4
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              on=response_headers \
+                              test=/t/metrics/get \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- response_headers
+c1: 8
+c2: 8
+--- error_log: reallocating metric
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 4: SIGHUP metrics - decreased worker_processes - shm preserved, realloc
+--- workers: 2
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              on=response_headers \
+                              test=/t/metrics/get \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- response_headers
+c1: 10
+c2: 10
+--- error_log: reallocating metric
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 5: SIGHUP metrics - decreased slab_size - shm preserved, realloc
+--- workers: 2
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 4m;
+        }
+    }
+}
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              on=response_headers \
+                              test=/t/metrics/get \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- response_headers
+c1: 12
+c2: 12
+--- error_log: reallocating metric
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 6: SIGHUP metrics - increased slab_size - shm preserved, realloc
+--- workers: 2
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 5m;
+        }
+    }
+}
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_increment_counters \
+                              on=response_headers \
+                              test=/t/metrics/get \
+                              metrics=$::metrics';
+        echo ok;
+    }
+}
+--- response_headers
+c1: 14
+c2: 14
+--- error_log: reallocating metric
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]

--- a/t/07-metrics/002-histograms_sighup.t
+++ b/t/07-metrics/002-histograms_sighup.t
@@ -1,0 +1,186 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_no_hup();
+
+our $workers = 2;
+our $total = 0;
+
+workers($workers);
+if ($workers > 1) {
+    master_on();
+}
+
+no_shuffle();
+plan_tests(6);
+run_tests();
+
+__DATA__
+
+=== TEST 1: SIGHUP metrics - define metrics and record histograms
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_record_histograms \
+                              metrics=c2,g2,h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += $::workers;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 2: SIGHUP metrics - shm preserved, no realloc
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_record_histograms \
+                              metrics=h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += $::workers;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 3: SIGHUP metrics - increased worker_processes - shm preserved, realloc
+--- workers: 4
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_record_histograms \
+                              metrics=h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += 4;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 4: SIGHUP metrics - decreased worker_processes - shm preserved, realloc
+--- workers: 2
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_and_record_histograms \
+                              metrics=h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += 2;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 5: SIGHUP metrics - decreased slab_size - shm preserved, realloc
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 120k;
+        }
+    }
+}
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=request_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += 1;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]
+
+
+
+=== TEST 6: SIGHUP metrics - increased slab_size - shm preserved, realloc
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $ENV{TEST_NGINX_CRATES_DIR}/hostcalls.wasm;
+
+        metrics {
+            slab_size 16k;
+        }
+    }
+}
+--- config eval
+qq{
+    location /t {
+        proxy_wasm hostcalls 'on_configure=define_metrics \
+                              on=response_headers \
+                              test=/t/metrics/record_histograms \
+                              metrics=h2';
+        echo ok;
+    }
+}
+--- grep_error_log eval: qr/histogram "\d+":( \d+: \d+;)+/
+--- grep_error_log_out eval
+$::total += 1;
+qr/histogram "\d+": 1: $::total; 4294967295: 0;/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+[alert]

--- a/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
@@ -381,3 +381,77 @@ pub fn dispatch_http_call(_ctx: &TestContext) {
         info!("dispatch_http_call status: {}", status as u32);
     }
 }
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn proxy_define_metric(
+        metric_type: MetricType,
+        name_data: *const u8,
+        name_size: usize,
+        return_id: *mut u32,
+    ) -> Status;
+}
+
+pub fn define_metric(_ctx: &TestContext) {
+    let name = "a_counter";
+    let metric_type = MetricType::Counter;
+    let mut return_id: u32 = 0;
+
+    unsafe {
+        let status = proxy_define_metric(metric_type, name.as_ptr(), name.len(), &mut return_id);
+
+        info!("define_metric status: {}", status as u32);
+    }
+}
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn proxy_get_metric(metric_id: u32, return_value: *mut u64) -> Status;
+}
+
+pub fn get_metric(_ctx: &TestContext) {
+    let name = "a_counter";
+    let metric_type = MetricType::Counter;
+    let mut metric_id: u32 = 0;
+    let mut value: u64 = 0;
+
+    unsafe {
+        proxy_define_metric(metric_type, name.as_ptr(), name.len(), &mut metric_id);
+        let status = proxy_get_metric(metric_id, &mut value);
+        info!("get_metric status: {}", status as u32);
+    }
+}
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn proxy_record_metric(metric_id: u32, value: u64) -> Status;
+}
+
+pub fn record_metric(_ctx: &TestContext) {
+    let name = "a_gauge";
+    let metric_type = MetricType::Gauge;
+    let mut metric_id: u32 = 0;
+
+    unsafe {
+        proxy_define_metric(metric_type, name.as_ptr(), name.len(), &mut metric_id);
+        let status = proxy_record_metric(metric_id, 1);
+        info!("record_metric status: {}", status as u32);
+    }
+}
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn proxy_increment_metric(metric_id: u32, offset: i64) -> Status;
+}
+
+pub fn increment_metric(_ctx: &TestContext) {
+    let name = "a_counter";
+    let metric_type = MetricType::Counter;
+    let mut metric_id: u32 = 0;
+
+    unsafe {
+        proxy_define_metric(metric_type, name.as_ptr(), name.len(), &mut metric_id);
+        let status = proxy_increment_metric(metric_id, 1);
+        info!("increment_metric status: {}", status as u32);
+    }
+}

--- a/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
@@ -19,6 +19,10 @@ impl TestContext {
         let (name, arg) = name.split_once('|').unwrap_or_else(|| (name, ""));
         match name {
             "proxy_log" => log_something(self),
+            "define_metric" => define_metric(self),
+            "increment_metric" => increment_metric(self),
+            "record_metric" => record_metric(self),
+            "get_metric" => get_metric(self),
             "set_tick_period" => set_tick_period(self),
             "add_request_header" => add_request_header(self, arg),
             "add_response_header" => add_response_header(self, arg),

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -7,13 +7,14 @@ mod types;
 use crate::{tests::*, types::test_http::*, types::test_root::*, types::*};
 use log::*;
 use proxy_wasm::{traits::*, types::*};
-use std::{collections::HashMap, time::Duration};
+use std::{collections::BTreeMap, collections::HashMap, time::Duration};
 
 proxy_wasm::main! {{
     proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
         Box::new(TestRoot {
             config: HashMap::new(),
+            metrics: BTreeMap::new(),
             n_sync_calls: 0,
         })
     });
@@ -27,11 +28,13 @@ impl RootContext for TestRoot {
             if let Ok(text) = std::str::from_utf8(&config) {
                 info!("vm config: {}", text);
 
-                if text == "do_trap" {
-                    panic!("trap on_vm_start");
-                } else if text == "do_false" {
-                    info!("on_vm_start returning false");
-                    return false;
+                match text {
+                    "do_trap" => panic!("trap on_vm_start"),
+                    "do_false" => {
+                        info!("on_vm_start returning false");
+                        return false;
+                    }
+                    _ => ()
                 }
             } else {
                 info!("cannot parse vm config");
@@ -63,12 +66,23 @@ impl RootContext for TestRoot {
             ));
         }
 
-        if let Some(on_configure) = self.get_config("on_configure") {
-            match on_configure {
-                "do_trap" => panic!("trap on_configure"),
-                "do_return_false" => return false,
-                _ => (),
+        match self.get_config("on_configure").unwrap_or("") {
+            "do_trap" => panic!("trap on_configure"),
+            "do_return_false" => return false,
+            "define_metrics" => test_define_metrics(self),
+            "define_and_increment_counters" => {
+                test_define_metrics(self);
+                test_increment_counters(self, TestPhase::Configure, None);
             }
+            "define_and_toggle_gauges" => {
+                test_define_metrics(self);
+                test_toggle_gauges(self, TestPhase::Configure, None);
+            }
+            "define_and_record_histograms" => {
+                test_define_metrics(self);
+                test_record_metric(self, TestPhase::Configure);
+            }
+            _ => (),
         }
 
         true
@@ -84,15 +98,23 @@ impl RootContext for TestRoot {
             self.get_config("tick_period").unwrap()
         );
 
+        let n_sync_calls = self
+            .config
+            .get("n_sync_calls")
+            .map_or(1, |v| v.parse().expect("bad n_sync_calls value"));
+
+        if self.n_sync_calls >= n_sync_calls {
+            return;
+        }
+
         match self.get_config("on_tick").unwrap_or("") {
             "log_property" => test_log_property(self),
+            "set_gauges" => {
+                test_record_metric(self, TestPhase::Tick);
+                self.n_sync_calls += 1;
+            }
             "set_property" => test_set_property(self),
             "dispatch" => {
-                let n_sync_calls = self
-                    .config
-                    .get("n_sync_calls")
-                    .map_or(1, |v| v.parse().expect("bad n_sync_calls value"));
-
                 if self.n_sync_calls >= n_sync_calls {
                     return;
                 }
@@ -172,6 +194,7 @@ impl RootContext for TestRoot {
         Some(Box::new(TestHttp {
             config: self.config.clone(),
             on_phases: phases,
+            metrics: self.metrics.clone(),
             n_sync_calls: 0,
         }))
     }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
@@ -6,16 +6,21 @@ use crate::*;
 #[derive(Debug, Eq, PartialEq, enum_utils::FromStr)]
 #[enumeration(rename_all = "snake_case")]
 pub enum TestPhase {
+    Configure,
+    Tick,
     RequestHeaders,
     RequestBody,
     ResponseHeaders,
     ResponseBody,
     ResponseTrailers,
+    HTTPCallResponse,
     Log,
 }
 
 pub trait TestContext {
     fn get_config(&self, name: &str) -> Option<&str>;
+    fn get_metrics_mapping(&self) -> &BTreeMap<String, u32>;
+    fn save_metric_mapping(&mut self, name: &str, metric_id: u32) -> Option<u32>;
 }
 
 impl Context for dyn TestContext {}
@@ -24,10 +29,26 @@ impl TestContext for TestRoot {
     fn get_config(&self, name: &str) -> Option<&str> {
         self.config.get(name).map(|s| s.as_str())
     }
+
+    fn get_metrics_mapping(&self) -> &BTreeMap<String, u32> {
+        &self.metrics
+    }
+
+    fn save_metric_mapping(&mut self, name: &str, metric_id: u32) -> Option<u32> {
+        self.metrics.insert(name.to_string(), metric_id)
+    }
 }
 
 impl TestContext for TestHttp {
     fn get_config(&self, name: &str) -> Option<&str> {
         self.config.get(name).map(|s| s.as_str())
+    }
+
+    fn get_metrics_mapping(&self) -> &BTreeMap<String, u32> {
+        &self.metrics
+    }
+
+    fn save_metric_mapping(&mut self, name: &str, metric_id: u32) -> Option<u32> {
+        self.metrics.insert(name.to_string(), metric_id)
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_root.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_root.rs
@@ -2,5 +2,6 @@ use crate::*;
 
 pub struct TestRoot {
     pub config: HashMap<String, String>,
+    pub metrics: BTreeMap<String, u32>,
     pub n_sync_calls: usize,
 }

--- a/util/morestyle.pl
+++ b/util/morestyle.pl
@@ -202,6 +202,8 @@ for my $file (@ARGV) {
                     $var_line = $line;
                     save_var();
 
+                } elsif ($line =~ /^\s+[\+\-\*\/] [\s\w\(\)\+\-\*\/\.\-\>]/) {
+                    # ignoring line with a portion of a wrapped expression
                 } elsif (!$cur_line_is_empty) {
                     if ($n_vars > 0 && $min_var_space - $max_var_type > 3) {
                         var_output "excessive spacing in variable alignment: needs 2 spaces from longest type to first name/pointer.";

--- a/util/setup_dev.sh
+++ b/util/setup_dev.sh
@@ -137,6 +137,30 @@ EOF
          use_http3
          env_to_nginx
 EOF
+    patch --forward --ignore-whitespace lib/perl5/Test/Nginx/Util.pm <<'EOF'
+    @@ -977,6 +977,11 @@
+         my $post_main_config = $block->post_main_config;
+         my $err_log_file = $block->error_log_file;
+         my $server_name = $block->server_name;
+    +    my $workers = $block->workers;
+    +
+    +    if (!$workers) {
+    +        $workers = $Workers;
+    +    }
+
+         if ($UseHup) {
+             master_on(); # config reload is buggy when master is off
+    @@ -1054,7 +1059,7 @@
+             bail_out "Can't open $ConfFile for writing: $!\n";
+         print $out "daemon $DaemonEnabled;" if ($DaemonEnabled eq 'off');
+         print $out <<_EOC_;
+    -worker_processes  $Workers;
+    +worker_processes  $workers;
+     master_process $MasterProcessEnabled;
+     error_log $err_log_file $LogLevel;
+     pid       $PidFile;
+
+EOF
     set -e
 popd
 


### PR DESCRIPTION
This PR adds support for storing metrics in WasmX shared-memory key-value store facility.

The workflow users are expected to perform follows from Proxy-Wasm metrics ABI itself: users define metrics before using them; when a metric is defined a numeric ID is returned which can later be used for reading or updating its respective metric. If the system is out of metrics memory when defining a new metric, the metric definition fails as eviction support hasn't been implemented.

The implemented design, described at [1], allows users to perform most metric updates without synchronizing Nginx workers, i.e. without the aid of locks.

Users can refer to [2] for a description of how metrics are represented in memory and how to estimate the size of the shared-memory used for metrics storage.

Two configuration directives, `slab_size` and `max_metric_name_length`, are added to configure the size of the shared-memory zone dedicated to metrics and the maximum length of a metric name, respectively.

[1] docs/adr/005-metrics.md
[2] docs/METRICS.md