### PR TITLE
feat(http) implement 'postpone_rewrite' + 'postpone_access' directives

### DIFF
--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -26,6 +26,8 @@ By alphabetical order:
 - [tls_verify_cert](#tls_verify_cert)
 - [tls_verify_host](#tls_verify_host)
 - [wasm_call](#wasm_call)
+- [wasm_postpone_access](#wasm_postpone_access)
+- [wasm_postpone_rewrite](#wasm_postpone_rewrite)
 - [wasm_response_body_buffers](#wasm_response_body_buffers)
 - [wasm_socket_buffer_reuse](#wasm_socket_buffer_reuse)
 - [wasm_socket_buffer_size](#wasm_socket_buffer_size)
@@ -67,6 +69,8 @@ By context:
     - [proxy_wasm_request_headers_in_access](#proxy_wasm_request_headers_in_access)
     - [resolver_add](#resolver_add)
     - [wasm_call](#wasm_call)
+    - [wasm_postpone_access](#wasm_postpone_access)
+    - [wasm_postpone_rewrite](#wasm_postpone_rewrite)
     - [wasm_response_body_buffers](#wasm_response_body_buffers)
     - [wasm_socket_buffer_reuse](#wasm_socket_buffer_reuse)
     - [wasm_socket_buffer_size](#wasm_socket_buffer_size)
@@ -757,6 +761,62 @@ to start (e.g. invalid `phase`, `module` or `function`).
 
 If there was an error during runtime execution, stop the Nginx runloop and
 return `HTTP 500`.
+
+[Back to TOC](#directives)
+
+wasm_postpone_access
+--------------------
+
+**usage**    | `wasm_postpone_access <on\|off>;`
+------------:|:----------------------------------------------------------------
+**contexts** | `http{}`, `server{}`, `location{}`
+**default**  | `off`
+**example**  | `wasm_postpone_access on;`
+
+Enable the postponing of the Wasm module access phase handler.
+
+If enabled, this module's access handler will be postponed to the end of the
+access phase (i.e. after all other modules access handlers). This is mostly
+useful in OpenResty builds when wanting filter chains to run after
+`access_by_lua` blocks.
+
+If disabled, this module's access handler will run as per the order configured
+during Nginx/OpenResty compilation.
+
+> Notes
+
+This directive is auto-enabled in OpenResty builds when postponing of the Lua
+access phase is enabled (this is the default behavior, see
+[access_by_lua_no_postpone](https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#access_by_lua_no_postpone)).
+This can be disabled by explicitly specifying `wasm_postpone_access off;`.
+
+[Back to TOC](#directives)
+
+wasm_postpone_rewrite
+---------------------
+
+**usage**    | `wasm_postpone_rewrite <on\|off>;`
+------------:|:----------------------------------------------------------------
+**contexts** | `http{}`, `server{}`, `location{}`
+**default**  | `off`
+**example**  | `wasm_postpone_rewrite on;`
+
+Enable the postponing of the Wasm module rewrite phase handler.
+
+If enabled, this module's rewrite handler will be postponed to the end of the
+rewrite phase (i.e. after all other modules rewrite handlers). This is mostly
+useful in OpenResty builds when wanting filter chains to run after
+`rewrite_by_lua` blocks.
+
+If disabled, this module's rewrite handler will run as per the order configured
+during Nginx/OpenResty compilation.
+
+> Notes
+
+This directive is auto-enabled in OpenResty builds when postponing of the Lua
+rewrite phase is enabled (this is the default behavior, see
+[rewrite_by_lua_no_postpone](https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#rewrite_by_lua_no_postpone)).
+This can be disabled by explicitly specifying `wasm_postpone_rewrite off;`.
 
 [Back to TOC](#directives)
 

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -97,6 +97,9 @@ typedef struct {
     ngx_flag_t                         pwm_req_headers_in_access;
     ngx_flag_t                         pwm_lua_resolver;
 
+    ngx_flag_t                         postpone_rewrite;
+    ngx_flag_t                         postpone_access;
+
     ngx_queue_t                        q;                      /* main_conf */
 } ngx_http_wasm_loc_conf_t;
 

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -97,6 +97,7 @@ typedef struct {
 
     ngx_resolver_t                    *resolver;
     ngx_resolver_t                    *user_resolver;
+
     ngx_flag_t                         pwm_lua_resolver;
 } ngx_wasm_core_conf_t;
 
@@ -120,6 +121,9 @@ ngx_msec_t ngx_wasm_monotonic_time();
 void ngx_wasm_wall_time(void *rtime);
 void ngx_wasm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     const char *fmt, ...);
+#if (NGX_WASM_DYNAMIC_MODULE && (NGX_WASM_LUA || NGX_WASM_HTTP))
+void swap_modules_if_needed(ngx_conf_t *cf, const char *m1, const char *m2);
+#endif
 
 /* directives */
 char *ngx_wasm_core_wasmtime_block(ngx_conf_t *cf, ngx_command_t *cmd,

--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -260,46 +260,6 @@ ngx_wasm_core_cleanup_pool(void *data)
 }
 
 
-#if (NGX_WASM_DYNAMIC_MODULE && (NGX_WASM_LUA || NGX_WASM_HTTP))
-static unsigned
-get_module_index(ngx_cycle_t *cycle, const char *module_name, ngx_uint_t *out)
-{
-    size_t  i;
-
-    for (i = 0; cycle->modules[i]; i++) {
-        if (ngx_str_eq(cycle->modules[i]->name, -1, module_name, -1)) {
-            *out = i;
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-
-static void
-swap_modules_if_needed(ngx_conf_t *cf, const char *m1, const char *m2)
-{
-    ngx_uint_t     m1_idx, m2_idx;
-    ngx_cycle_t   *cycle = cf->cycle;
-    ngx_module_t  *tmp;
-
-    if (get_module_index(cycle, m1, &m1_idx)
-        && get_module_index(cycle, m2, &m2_idx)
-        && m1_idx < m2_idx)
-    {
-        ngx_wasm_log_error(NGX_LOG_NOTICE, cf->log, 0,
-                           "swapping modules: \"%s\" (index: %l) and \"%s\" "
-                           "(index: %l)", m1, m1_idx, m2, m2_idx);
-
-        tmp = cycle->modules[m1_idx];
-        cycle->modules[m1_idx] = cycle->modules[m2_idx];
-        cycle->modules[m2_idx] = tmp;
-    }
-}
-#endif
-
-
 static void *
 ngx_wasm_core_create_conf(ngx_conf_t *cf)
 {
@@ -396,6 +356,7 @@ ngx_wasm_core_create_conf(ngx_conf_t *cf)
     wcf->connect_timeout = NGX_CONF_UNSET_MSEC;
     wcf->send_timeout = NGX_CONF_UNSET_MSEC;
     wcf->recv_timeout = NGX_CONF_UNSET_MSEC;
+
     wcf->pwm_lua_resolver = NGX_CONF_UNSET;
 
     wcf->socket_buffer_size = NGX_CONF_UNSET_SIZE;

--- a/src/wasm/ngx_wasm_util.c
+++ b/src/wasm/ngx_wasm_util.c
@@ -521,3 +521,43 @@ ngx_wasm_log_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
 
     ngx_log_error_core(level, log, err, "[wasm] %*s", p - errstr, errstr);
 }
+
+
+#if (NGX_WASM_DYNAMIC_MODULE && (NGX_WASM_LUA || NGX_WASM_HTTP))
+static unsigned
+get_module_index(ngx_cycle_t *cycle, const char *module_name, ngx_uint_t *out)
+{
+    size_t  i;
+
+    for (i = 0; cycle->modules[i]; i++) {
+        if (ngx_str_eq(cycle->modules[i]->name, -1, module_name, -1)) {
+            *out = i;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+void
+swap_modules_if_needed(ngx_conf_t *cf, const char *m1, const char *m2)
+{
+    ngx_uint_t     m1_idx, m2_idx;
+    ngx_cycle_t   *cycle = cf->cycle;
+    ngx_module_t  *tmp;
+
+    if (get_module_index(cycle, m1, &m1_idx)
+        && get_module_index(cycle, m2, &m2_idx)
+        && m1_idx < m2_idx)
+    {
+        ngx_wasm_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                           "swapping modules: \"%s\" (index: %l) and \"%s\" "
+                           "(index: %l)", m1, m1_idx, m2, m2_idx);
+
+        tmp = cycle->modules[m1_idx];
+        cycle->modules[m1_idx] = cycle->modules[m2_idx];
+        cycle->modules[m2_idx] = tmp;
+    }
+}
+#endif

--- a/t/02-http/004-postpone_rewrite.t
+++ b/t/02-http/004-postpone_rewrite.t
@@ -1,0 +1,107 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup(); # HUP mode /ver requests trigger many rewrite handler calls
+skip_no_debug();
+
+plan_tests(3);
+run_tests();
+
+__DATA__
+
+=== TEST 1: wasm_postpone_rewrite - default (disabled)
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler
+
+
+
+=== TEST 2: wasm_postpone_rewrite - disabled
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        wasm_postpone_rewrite off;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler
+
+
+
+=== TEST 3: wasm_postpone_rewrite - enabled
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        wasm_postpone_rewrite on;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 4: wasm_postpone_rewrite - enabled in server{} block
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    wasm_postpone_rewrite on;
+
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 5: wasm_postpone_rewrite - enabled in http{} block
+--- load_nginx_modules: ngx_http_echo_module
+--- http_config
+    wasm_postpone_rewrite on;
+--- config
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 6: wasm_postpone_rewrite - enabled in http{} block, disabled in location{}
+--- load_nginx_modules: ngx_http_echo_module
+--- http_config
+    wasm_postpone_rewrite on;
+--- config
+    location /t {
+        wasm_postpone_rewrite off;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm rewrite handler/
+--- grep_error_log_out
+wasm rewrite handler

--- a/t/02-http/005-postpone_access.t
+++ b/t/02-http/005-postpone_access.t
@@ -1,0 +1,106 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_no_debug();
+
+plan_tests(3);
+run_tests();
+
+__DATA__
+
+=== TEST 1: wasm_postpone_access - default (disabled)
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler
+
+
+
+=== TEST 2: wasm_postpone_access - disabled
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        wasm_postpone_access off;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler
+
+
+
+=== TEST 3: wasm_postpone_access - enabled
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+location /t {
+    wasm_postpone_access on;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler
+wasm access handler
+
+
+
+=== TEST 4: wasm_postpone_access - enabled in server{} block
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    wasm_postpone_access on;
+
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler
+wasm access handler
+
+
+
+=== TEST 5: wasm_postpone_access - enabled in http{} block
+--- load_nginx_modules: ngx_http_echo_module
+--- http_config
+    wasm_postpone_access on;
+--- config
+    location /t {
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler
+wasm access handler
+
+
+
+=== TEST 6: wasm_postpone_access - enabled in http{} block, disabled in location{}
+--- load_nginx_modules: ngx_http_echo_module
+--- http_config
+    wasm_postpone_access on;
+--- config
+    location /t {
+        wasm_postpone_access off;
+        echo "ok";
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/wasm access handler/
+--- grep_error_log_out
+wasm access handler

--- a/t/04-openresty/003-postpone_rewrite.t
+++ b/t/04-openresty/003-postpone_rewrite.t
@@ -1,0 +1,153 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX::Lua;
+
+skip_hup(); # HUP mode /ver requests trigger many rewrite handler calls
+skip_no_openresty();
+skip_no_debug();
+
+plan_tests(3);
+run_tests();
+
+__DATA__
+
+=== TEST 1: wasm_postpone_rewrite - default (Lua on), auto-enabled
+Note: This suite assumes the Lua module be specified first in compilation order.
+--- config
+    location /t {
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+lua rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 2: wasm_postpone_rewrite - default (Lua off)
+--- http_config
+    rewrite_by_lua_no_postpone on;
+--- config
+    location /t {
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 3: wasm_postpone_rewrite - disabled (Lua on)
+--- config
+    location /t {
+        wasm_postpone_rewrite off;
+
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+lua rewrite handler
+
+
+
+=== TEST 4: wasm_postpone_rewrite - disabled (Lua off)
+--- http_config
+    rewrite_by_lua_no_postpone on;
+--- config
+    location /t {
+        wasm_postpone_rewrite off;
+
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 5: wasm_postpone_rewrite - enabled (Lua on)
+--- config
+    location /t {
+        wasm_postpone_rewrite on;
+
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+lua rewrite handler
+wasm rewrite handler
+
+
+
+=== TEST 6: wasm_postpone_rewrite - enabled (Lua off)
+--- http_config
+    rewrite_by_lua_no_postpone on;
+--- config
+    location /t {
+        wasm_postpone_rewrite on;
+
+        rewrite_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) rewrite handler/
+--- grep_error_log_out
+lua rewrite handler
+wasm rewrite handler
+wasm rewrite handler

--- a/t/04-openresty/004-postpone_access.t
+++ b/t/04-openresty/004-postpone_access.t
@@ -1,0 +1,152 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX::Lua;
+
+skip_no_openresty();
+skip_no_debug();
+
+plan_tests(3);
+run_tests();
+
+__DATA__
+
+=== TEST 1: wasm_postpone_access - default (Lua on), auto-enabled
+Note: This suite assumes the Lua module be specified first in compilation order.
+--- config
+    location /t {
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+lua access handler
+wasm access handler
+
+
+
+=== TEST 2: wasm_postpone_access - default (Lua off)
+--- http_config
+    access_by_lua_no_postpone on;
+--- config
+    location /t {
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+
+
+
+=== TEST 3: wasm_postpone_access - disabled (Lua on)
+--- config
+    location /t {
+        wasm_postpone_access off;
+
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+lua access handler
+
+
+
+=== TEST 4: wasm_postpone_access - disabled (Lua off)
+--- http_config
+    access_by_lua_no_postpone on;
+--- config
+    location /t {
+        wasm_postpone_access off;
+
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+
+
+
+=== TEST 5: wasm_postpone_access - enabled (Lua on)
+--- config
+    location /t {
+        wasm_postpone_access on;
+
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+lua access handler
+wasm access handler
+
+
+
+=== TEST 6: wasm_postpone_access - enabled (Lua off)
+--- http_config
+    access_by_lua_no_postpone on;
+--- config
+    location /t {
+        wasm_postpone_access on;
+
+        access_by_lua_block {
+
+        }
+
+        content_by_lua_block {
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- grep_error_log eval: qr/(wasm|lua) access handler/
+--- grep_error_log_out
+lua access handler
+wasm access handler
+wasm access handler

--- a/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
+++ b/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
@@ -51,16 +51,6 @@ ok
 
 === TEST 2: set_property() - setting ngx properties works on rewrite_by_lua
 --- wasm_modules: hostcalls
---- http_config
-    init_worker_by_lua_block {
-        local proxy_wasm = require "resty.wasmx.proxy_wasm"
-        local filters = {
-            { name = "hostcalls" },
-        }
-
-        _G.c_plan = assert(proxy_wasm.new(filters))
-        assert(proxy_wasm.load(_G.c_plan))
-    }
 --- config
     set $my_var 456;
 
@@ -71,11 +61,7 @@ ok
 
         rewrite_by_lua_block {
             local proxy_wasm = require "resty.wasmx.proxy_wasm"
-            assert(proxy_wasm.attach(_G.c_plan))
-
             assert(proxy_wasm.set_property("ngx.my_var", "123"))
-
-            assert(proxy_wasm.start())
             ngx.say("ok")
         }
     }

--- a/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
+++ b/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
@@ -49,16 +49,6 @@ ok
 
 === TEST 2: set_property() - setting host properties works on rewrite_by_lua
 --- wasm_modules: hostcalls
---- http_config
-    init_worker_by_lua_block {
-        local proxy_wasm = require "resty.wasmx.proxy_wasm"
-        local filters = {
-            { name = "hostcalls" },
-        }
-
-        _G.c_plan = assert(proxy_wasm.new(filters))
-        assert(proxy_wasm.load(_G.c_plan))
-    }
 --- config
     location /t {
         proxy_wasm hostcalls 'on=response_body \
@@ -67,11 +57,7 @@ ok
 
         rewrite_by_lua_block {
             local proxy_wasm = require "resty.wasmx.proxy_wasm"
-            assert(proxy_wasm.attach(_G.c_plan))
-
             assert(proxy_wasm.set_property("wasmx.my_property", "my_value"))
-
-            assert(proxy_wasm.start())
             ngx.say("ok")
         }
     }

--- a/t/TestWasmX.pm
+++ b/t/TestWasmX.pm
@@ -238,6 +238,12 @@ add_block_preprocessor(sub {
         push @block_skip, $2;
     }
 
+    # --- skip_hup
+
+    if (defined $block->skip_hup && $ENV{TEST_NGINX_USE_HUP}) {
+        push @block_skip, '$ENV{TEST_NGINX_USE_HUP}';
+    }
+
     # --- skip_no_debug
 
     if (defined $block->skip_no_debug) {


### PR DESCRIPTION
Our module *must* run after the Lua module for the ongoing refactor of the Lua bridge. When the Lua module postpones its handlers, we postpone ours as well. This behavior assumes ngx_wasmx_module is declared after ngx_http_lua_module during compilation (static or dynamic). This could be enforced in the future in dynamic builds, and caught at runtime with a warning for static builds.

TODO
- [x] Docs