### PR TITLE
feat(proxy-wasm) allow setting ":status" header

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -623,45 +623,47 @@ ngx_proxy_wasm_hfuncs_get_header_map_value(ngx_wavm_instance_t *instance,
 
 
 static ngx_int_t
-ngx_proxy_wasm_hfuncs_set_header_map_pairs(ngx_wavm_instance_t *instance,
-    wasm_val_t args[], wasm_val_t rets[])
+ngx_proxy_wasm_hfuncs_set_header_check(ngx_wavm_instance_t *instance,
+    ngx_proxy_wasm_map_type_e map_type, wasm_val_t rets[])
 {
-    ngx_int_t                         rc = NGX_ERROR;
-    ngx_proxy_wasm_map_type_e         map_type;
-    ngx_array_t                       headers;
-    ngx_proxy_wasm_marshalled_map_t   map;
-    ngx_proxy_wasm_exec_t            *pwexec;
-    ngx_proxy_wasm_ctx_t             *pwctx;
 #ifdef NGX_WASM_HTTP
-    ngx_http_wasm_req_ctx_t          *rctx;
+    ngx_proxy_wasm_exec_t    *pwexec;
+    ngx_proxy_wasm_ctx_t     *pwctx;
+    ngx_http_wasm_req_ctx_t  *rctx;
 
     rctx = ngx_http_proxy_wasm_get_rctx(instance);
-#endif
 
     pwexec = ngx_proxy_wasm_instance2pwexec(instance);
     pwctx = pwexec->parent;
-
-    map_type = args[0].of.i32;
-    map.len = args[2].of.i32;
-    map.data = NGX_WAVM_HOST_LIFT_SLICE(instance, args[1].of.i32, map.len);
-
-    if (ngx_proxy_wasm_pairs_unmarshal(pwexec, &headers, &map) != NGX_OK) {
-        return ngx_proxy_wasm_result_err(rets);
-    }
+#endif
 
     switch (map_type) {
 
 #ifdef NGX_WASM_HTTP
     case NGX_PROXY_WASM_MAP_HTTP_REQUEST_HEADERS:
-        if (rctx->entered_header_filter) {
-            ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                               "cannot set request headers: response produced");
 
-            return ngx_proxy_wasm_result_ok(rets);
+        /* check context */
+
+        switch (pwctx->step) {
+        case NGX_PROXY_WASM_STEP_REQ_HEADERS:
+        case NGX_PROXY_WASM_STEP_REQ_BODY:
+        case NGX_PROXY_WASM_STEP_REQ_TRAILERS:
+            break;
+
+        case NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE:
+            if (!rctx->entered_header_filter) {
+                return NGX_OK;
+            }
+            /* fallthrough */
+
+        default:
+            return ngx_proxy_wasm_result_trap(pwexec,
+                                              "can only set request headers "
+                                              "before response is produced",
+                                              rets, NGX_WAVM_BAD_USAGE);
         }
 
-        rc = ngx_http_wasm_clear_req_headers(
-                 ngx_http_proxy_wasm_get_req(instance));
+        ngx_wa_assert(!rctx->entered_header_filter);
         break;
 
     case NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS:
@@ -674,6 +676,13 @@ ngx_proxy_wasm_hfuncs_set_header_map_pairs(ngx_wavm_instance_t *instance,
         case NGX_PROXY_WASM_STEP_REQ_TRAILERS:
         case NGX_PROXY_WASM_STEP_RESP_HEADERS:
             break;
+
+        case NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE:
+            if (!rctx->r->header_sent) {
+                return NGX_OK;
+            }
+            /* fallthrough */
+
         default:
             return ngx_proxy_wasm_result_trap(pwexec,
                                               "can only set response headers "
@@ -682,14 +691,54 @@ ngx_proxy_wasm_hfuncs_set_header_map_pairs(ngx_wavm_instance_t *instance,
                                               rets, NGX_WAVM_BAD_USAGE);
         }
 
-        if (rctx->r->header_sent) {
-            ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                               "cannot set response headers: "
-                               "headers already sent");
+        ngx_wa_assert(!rctx->r->header_sent);
+        break;
+#endif
 
-            return ngx_proxy_wasm_result_ok(rets);
-        }
+    default:
+        ngx_wasm_log_error(NGX_LOG_WASM_NYI, instance->log, 0,
+                           "NYI - set_map bad map_type: %d", map_type);
+        return ngx_proxy_wasm_result_badarg(rets);
+    }
 
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_proxy_wasm_hfuncs_set_header_map_pairs(ngx_wavm_instance_t *instance,
+    wasm_val_t args[], wasm_val_t rets[])
+{
+    ngx_int_t                         rc = NGX_ERROR;
+    ngx_proxy_wasm_map_type_e         map_type;
+    ngx_array_t                       headers;
+    ngx_proxy_wasm_marshalled_map_t   map;
+    ngx_proxy_wasm_exec_t            *pwexec;
+
+    pwexec = ngx_proxy_wasm_instance2pwexec(instance);
+
+    map_type = args[0].of.i32;
+    map.len = args[2].of.i32;
+    map.data = NGX_WAVM_HOST_LIFT_SLICE(instance, args[1].of.i32, map.len);
+
+    if (ngx_proxy_wasm_pairs_unmarshal(pwexec, &headers, &map) != NGX_OK) {
+        return ngx_proxy_wasm_result_err(rets);
+    }
+
+    rc = ngx_proxy_wasm_hfuncs_set_header_check(instance, map_type, rets);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    switch (map_type) {
+
+#ifdef NGX_WASM_HTTP
+    case NGX_PROXY_WASM_MAP_HTTP_REQUEST_HEADERS:
+        rc = ngx_http_wasm_clear_req_headers(
+                 ngx_http_proxy_wasm_get_req(instance));
+        break;
+
+    case NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS:
         rc = ngx_http_wasm_clear_resp_headers(
                  ngx_http_proxy_wasm_get_req(instance));
         break;
@@ -727,11 +776,6 @@ ngx_proxy_wasm_hfuncs_add_header_map_value(ngx_wavm_instance_t *instance,
     ngx_int_t                   rc;
     ngx_str_t                   key, value;
     ngx_proxy_wasm_map_type_e   map_type;
-#ifdef NGX_WASM_HTTP
-    ngx_http_wasm_req_ctx_t    *rctx;
-
-    rctx = ngx_http_proxy_wasm_get_rctx(instance);
-#endif
 
     map_type = args[0].of.i32;
     key.len = args[2].of.i32;
@@ -739,25 +783,10 @@ ngx_proxy_wasm_hfuncs_add_header_map_value(ngx_wavm_instance_t *instance,
     value.len = args[4].of.i32;
     value.data = NGX_WAVM_HOST_LIFT_SLICE(instance, args[3].of.i32, value.len);
 
-#ifdef NGX_WASM_HTTP
-    if (map_type == NGX_PROXY_WASM_MAP_HTTP_REQUEST_HEADERS
-        && rctx->entered_header_filter)
-    {
-        ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                           "cannot add request header: response produced");
-
-        return ngx_proxy_wasm_result_ok(rets);
-
-    } else if (map_type == NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS
-               && rctx->r->header_sent)
-    {
-        ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                           "cannot add response header: "
-                           "headers already sent");
-
-        return ngx_proxy_wasm_result_ok(rets);
+    rc = ngx_proxy_wasm_hfuncs_set_header_check(instance, map_type, rets);
+    if (rc != NGX_OK) {
+        return rc;
     }
-#endif
 
     dd("adding '%.*s: %.*s' to map of type '%d'",
        (int) key.len, key.data, (int) value.len, value.data, map_type);
@@ -781,11 +810,6 @@ ngx_proxy_wasm_hfuncs_replace_header_map_value(ngx_wavm_instance_t *instance,
     ngx_int_t                   rc;
     ngx_str_t                   key, value;
     ngx_proxy_wasm_map_type_e   map_type;
-#ifdef NGX_WASM_HTTP
-    ngx_http_wasm_req_ctx_t    *rctx;
-
-    rctx = ngx_http_proxy_wasm_get_rctx(instance);
-#endif
 
     map_type = args[0].of.i32;
     key.len = args[2].of.i32;
@@ -793,25 +817,10 @@ ngx_proxy_wasm_hfuncs_replace_header_map_value(ngx_wavm_instance_t *instance,
     value.len = args[4].of.i32;
     value.data = NGX_WAVM_HOST_LIFT_SLICE(instance, args[3].of.i32, value.len);
 
-#ifdef NGX_WASM_HTTP
-    if (map_type == NGX_PROXY_WASM_MAP_HTTP_REQUEST_HEADERS
-        && rctx->entered_header_filter)
-    {
-        ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                           "cannot set request header: response produced");
-
-        return ngx_proxy_wasm_result_ok(rets);
-
-    } else if (map_type == NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS
-               && rctx->r->header_sent)
-    {
-        ngx_wavm_log_error(NGX_LOG_ERR, instance->log, NULL,
-                           "cannot set response header: "
-                           "headers already sent");
-
-        return ngx_proxy_wasm_result_ok(rets);
+    rc = ngx_proxy_wasm_hfuncs_set_header_check(instance, map_type, rets);
+    if (rc != NGX_OK) {
+        return rc;
     }
-#endif
 
     dd("setting '%.*s: %.*s' into map of type '%d'",
        (int) key.len, key.data, (int) value.len, value.data, map_type);
@@ -841,6 +850,11 @@ ngx_proxy_wasm_hfuncs_remove_header_map_value(ngx_wavm_instance_t *instance,
     map_type = args[0].of.i32;
     klen = args[2].of.i32;
     key = NGX_WAVM_HOST_LIFT_SLICE(instance, args[1].of.i32, klen);
+
+    rc = ngx_proxy_wasm_hfuncs_set_header_check(instance, map_type, rets);
+    if (rc != NGX_OK) {
+        return rc;
+    }
 
     dd("removing '%.*s' from map of type '%d'",
        (int) klen, (u_char *) key, map_type);

--- a/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
@@ -32,6 +32,9 @@ static ngx_str_t *ngx_proxy_wasm_maps_get_authority(
     ngx_wavm_instance_t *instance, ngx_proxy_wasm_map_type_e map_type);
 static ngx_str_t *ngx_proxy_wasm_maps_get_response_status(
     ngx_wavm_instance_t *instance, ngx_proxy_wasm_map_type_e map_type);
+static ngx_int_t ngx_proxy_wasm_maps_set_response_status(
+    ngx_wavm_instance_t *instance, ngx_str_t *value,
+    ngx_proxy_wasm_map_type_e map_type);
 static ngx_str_t *ngx_proxy_wasm_maps_get_dispatch_status(
     ngx_wavm_instance_t *instance, ngx_proxy_wasm_map_type_e map_type);
 #endif
@@ -67,7 +70,7 @@ static ngx_proxy_wasm_maps_key_t  ngx_proxy_wasm_maps_special_keys[] = {
     { ngx_string(":status"),
       NGX_PROXY_WASM_MAP_HTTP_RESPONSE_HEADERS,
       ngx_proxy_wasm_maps_get_response_status,
-      NULL },
+      ngx_proxy_wasm_maps_set_response_status },
 
     /* dispatch response */
 
@@ -699,6 +702,34 @@ ngx_proxy_wasm_maps_get_response_status(ngx_wavm_instance_t *instance,
     ngx_wa_assert(pwctx->response_status.len);
 
     return &pwctx->response_status;
+}
+
+
+static ngx_int_t
+ngx_proxy_wasm_maps_set_response_status(ngx_wavm_instance_t *instance,
+    ngx_str_t *value, ngx_proxy_wasm_map_type_e map_type)
+{
+    ngx_uint_t                status;
+    ngx_http_wasm_req_ctx_t  *rctx;
+
+    rctx = ngx_http_proxy_wasm_get_rctx(instance);
+
+    status = ngx_atoi(value->data, value->len);
+
+    if (status > 999) {
+        /*
+        Ideally we would like to return NGX_ERROR here,
+        but the proxy-wasm-rust-sdk causes a panic when
+        the host returns an error code. So we ignore invalid
+        values here. This allows the application code to
+        gracefully check success by setting then getting.
+        */
+        return NGX_OK;
+    }
+
+    ngx_http_wasm_set_resp_status(rctx, status, NULL, 0);
+
+    return NGX_OK;
 }
 
 

--- a/t/03-proxy_wasm/hfuncs/110-proxy_set_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/110-proxy_set_http_response_headers.t
@@ -140,3 +140,118 @@ testing in "Log".*
 --- no_error_log
 [warn]
 [crit]
+
+
+
+=== TEST 5: proxy_wasm - set_http_response_headers() sets :status response header at request_headers
+--- load_nginx_modules: ngx_http_headers_more_filter_module
+--- wasm_modules: ngx_rust_tests hostcalls
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/set_response_headers \
+                              value=:status:201';
+    }
+--- error_code: 201
+--- response_body
+--- raw_response_headers_like
+HTTP\/.*? 201 .*?
+Connection: close\r
+Content-Length: 0\r
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm - set_http_response_headers() sets :status response header
+--- load_nginx_modules: ngx_http_headers_more_filter_module
+--- wasm_modules: ngx_rust_tests hostcalls
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm hostcalls 'on=response_headers \
+                              test=/t/set_response_headers \
+                              value=:status:201';
+    }
+--- error_code: 201
+--- response_body
+--- raw_response_headers_like
+HTTP\/.*? 201 .*?
+Transfer-Encoding: chunked\r
+Connection: close\r
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm - set_http_response_headers() ignores :status out of range
+--- load_nginx_modules: ngx_http_headers_more_filter_module
+--- wasm_modules: ngx_rust_tests hostcalls
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm hostcalls 'on=response_headers \
+                              test=/t/set_response_headers \
+                              value=:status:999999';
+    }
+--- error_code: 200
+--- response_body
+--- raw_response_headers_like
+HTTP\/.*? 200 .*?
+Transfer-Encoding: chunked\r
+Connection: close\r
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm - set_http_response_headers() ignores invalid :status
+--- load_nginx_modules: ngx_http_headers_more_filter_module
+--- wasm_modules: ngx_rust_tests hostcalls
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm hostcalls 'on=response_headers \
+                              test=/t/set_response_headers \
+                              value=:status:xyz';
+    }
+--- error_code: 200
+--- response_body
+--- raw_response_headers_like
+HTTP\/.*? 200 .*?
+Transfer-Encoding: chunked\r
+Connection: close\r
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm - set_http_response_headers() ignores empty :status
+--- load_nginx_modules: ngx_http_headers_more_filter_module
+--- wasm_modules: ngx_rust_tests hostcalls
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm hostcalls 'on=response_headers \
+                              test=/t/set_response_headers \
+                              value=:status:';
+    }
+--- error_code: 200
+--- response_body
+--- raw_response_headers_like
+HTTP\/.*? 200 .*?
+Transfer-Encoding: chunked\r
+Connection: close\r
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/117-proxy_set_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/117-proxy_set_http_response_headers.t
@@ -1,0 +1,252 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+skip_hup();
+skip_no_debug();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - set_http_response_headers on_vm_start
+'daemon off' must be set to check exit_code is 2
+Valgrind mode already writes 'daemon off'
+HUP mode does not catch the worker exit_code
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
+--- main_config eval
+qq{
+    wasm {
+        module context_checks $ENV{TEST_NGINX_CRATES_DIR}/context_checks.wasm 'set_response_headers|foo=bar';
+    }
+}.($ENV{TEST_NGINX_USE_VALGRIND} ? '' : 'daemon off;')
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+[emerg]
+can only set response headers on request path before "on_response_body"
+--- no_error_log
+--- must_die: 2
+
+
+
+=== TEST 2: proxy_wasm contexts - set_http_response_headers on_configure
+'daemon off' must be set to check exit_code is 2
+Valgrind mode already writes 'daemon off'
+HUP mode does not catch the worker exit_code
+--- skip_eval: 4: $ENV{TEST_NGINX_USE_HUP} == 1
+--- main_config eval
+qq{
+    wasm {
+        module context_checks $ENV{TEST_NGINX_CRATES_DIR}/context_checks.wasm;
+    }
+}.($ENV{TEST_NGINX_USE_VALGRIND} ? '' : 'daemon off;')
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=set_response_headers|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+[emerg]
+can only set response headers on request path before "on_response_body"
+--- must_die: 2
+
+
+
+=== TEST 3: proxy_wasm contexts - set_http_response_headers on_tick
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=set_response_headers|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers on request path before "on_response_body"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - set_http_response_headers on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=set_response_headers|foo=bar \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- request
+POST /t
+
+body
+--- error_code: 200
+--- response_headers
+foo: bar
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: proxy_wasm contexts - set_http_response_headers on_request_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=set_response_headers|foo=bar';
+        return 200;
+    }
+--- error_code: 200
+--- response_headers
+foo: bar
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: proxy_wasm contexts - set_http_response_headers on_request_headers :status
+--- wasm_modules: ngx_rust_tests context_checks
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm context_checks 'on_request_headers=set_response_headers|:status=201';
+    }
+--- error_code: 201
+--- ignore_response_body
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - set_http_response_headers on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=set_response_headers|foo=bar';
+        echo ok;
+    }
+--- request
+POST /t
+
+body
+--- error_code: 200
+--- response_headers
+foo: bar
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: proxy_wasm contexts - set_http_response_headers on_request_body :status
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: ngx_rust_tests context_checks
+--- SKIP -- this pases but the status code gets clobbered by 'echo'
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=set_response_headers|:status=201';
+
+        echo ok;
+    }
+--- request
+POST /t
+
+body
+--- error_code: 200
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - set_http_response_headers on_response_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=set_response_headers|foo=bar';
+        return 200;
+    }
+--- error_code: 200
+--- response_headers
+foo: bar
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_response_headers on_response_headers :status
+--- wasm_modules: ngx_rust_tests context_checks
+--- config
+    location /t {
+        wasm_call content ngx_rust_tests say_nothing;
+
+        proxy_wasm context_checks 'on_response_headers=set_response_headers|:status=201';
+    }
+--- error_code: 201
+--- ignore_response_body
+--- error_log
+set_response_headers status: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 11: proxy_wasm contexts - set_http_response_headers on_response_body
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=set_response_headers|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers on request path before "on_response_body"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 12: proxy_wasm contexts - set_http_response_headers on_log
+should not be retrievable after on_response_body since buffers are consumed
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=set_response_headers|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers on request path before "on_response_body"
+--- no_error_log
+[crit]

--- a/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
@@ -16,11 +16,13 @@ impl TestContext {
     }
 
     fn check_host_function(&self, name: &str) {
+        let (name, arg) = name.split_once('|').unwrap_or_else(|| (name, ""));
         match name {
             "proxy_log" => log_something(self),
             "set_tick_period" => set_tick_period(self),
             "set_request_body_buffer" => set_request_body_buffer(self),
             "set_response_body_buffer" => set_response_body_buffer(self),
+            "set_response_headers" => set_response_headers(self, arg),
             "get_request_body_buffer" => get_request_body_buffer(self),
             "get_response_body_buffer" => get_response_body_buffer(self),
             "get_dispatch_response_body_buffer" => get_dispatch_response_body_buffer(self),


### PR DESCRIPTION
Since #484, we now have an easy way to implement support for setting the ":status" pseudo-header.