### PR TITLE
feat(wasmtime) expose cache_config directive

### DIFF
--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -52,6 +52,14 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
       0,
       NULL },
 
+    { ngx_string("cache_config"),
+      NGX_WASMTIME_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_WA_WASM_CONF_OFFSET,
+      offsetof(ngx_wasm_core_conf_t, vm_conf)
+      + offsetof(ngx_wavm_conf_t, cache_config),
+      NULL },
+
     { ngx_string("compiler"),
       NGX_WASM_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,

--- a/src/wasm/wrt/ngx_wrt.h
+++ b/src/wasm/wrt/ngx_wrt.h
@@ -16,6 +16,7 @@ typedef struct ngx_wavm_instance_s  ngx_wavm_instance_t;
 typedef struct {
     const ngx_str_t               *vm_name;
     const ngx_str_t               *runtime_name;
+    ngx_str_t                      cache_config;
     ngx_str_t                      compiler;
     ngx_flag_t                     backtraces;
     ngx_array_t                    flags;

--- a/src/wasm/wrt/ngx_wrt_wasmtime.c
+++ b/src/wasm/wrt/ngx_wrt_wasmtime.c
@@ -17,6 +17,10 @@ typedef void (*wasmtime_config_set_int_pt)(wasm_config_t *config,
 typedef void (*wasmtime_config_set_bool_pt)(wasm_config_t *config, bool value);
 
 
+static u_char * ngx_wasmtime_log_handler(ngx_wrt_res_t *res, u_char *buf,
+    size_t len);
+
+
 static ngx_int_t
 size_flag_handler(wasm_config_t *config, ngx_str_t *name, ngx_str_t *value,
     ngx_log_t *log, void *wrt_setter)
@@ -129,7 +133,10 @@ profiler_flag_handler(wasm_config_t *config, ngx_str_t *name, ngx_str_t *value,
 static wasm_config_t *
 ngx_wasmtime_init_conf(ngx_wavm_conf_t *conf, ngx_log_t *log)
 {
-    wasm_config_t  *config;
+    wasm_config_t     *config;
+    char              *pathname;
+    u_char            *errmsg;
+    wasmtime_error_t  *err;
 #if 0
     wasm_name_t        msg;
     wasmtime_error_t  *err = NULL;
@@ -159,6 +166,39 @@ ngx_wasmtime_init_conf(ngx_wavm_conf_t *conf, ngx_log_t *log)
     wasmtime_config_cranelift_opt_level_set(config, WASMTIME_OPT_LEVEL_NONE);
     wasmtime_config_static_memory_maximum_size_set(config, 0);
 #endif
+
+    if (conf->cache_config.len) {
+        ngx_wavm_log_error(NGX_LOG_INFO, log, NULL,
+                           "setting wasmtime cache config file: \"%V\"",
+                           &conf->cache_config);
+
+        pathname = ngx_calloc(conf->cache_config.len + 1, log);
+        if (pathname == NULL) {
+            goto error;
+        }
+
+        ngx_memcpy(pathname, conf->cache_config.data, conf->cache_config.len);
+
+        err = wasmtime_config_cache_config_load(config, pathname);
+
+        ngx_free(pathname);
+
+        if (err) {
+            errmsg = ngx_calloc(NGX_MAX_ERROR_STR + 1, log);
+            if (errmsg == NULL) {
+                goto error;
+            }
+
+            ngx_wasmtime_log_handler((ngx_wrt_res_t *) err, errmsg,
+                                     NGX_MAX_ERROR_STR);
+
+            ngx_log_error(NGX_LOG_EMERG, log, 0,
+                          "failed configuring wasmtime cache; %s",
+                          errmsg);
+
+            goto error;
+        }
+    }
 
     if (conf->compiler.len) {
         if (ngx_str_eq(conf->compiler.data, conf->compiler.len,

--- a/t/01-wasm/directives/011-wasmtime_cache_config_directive.t
+++ b/t/01-wasm/directives/011-wasmtime_cache_config_directive.t
@@ -1,0 +1,124 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+our $nginxV = $t::TestWasmX::nginxV;
+our $osname = $t::TestWasmX::osname;
+
+add_cleanup_handler(sub {
+    my @jit_dumps = glob("$::pwd/jit-*.dump");
+
+    foreach my $file (@jit_dumps) {
+        #warn "\n", $file, "\n";
+        unlink($file);
+    }
+});
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: wasmtime cache_config - missing file
+--- skip_eval: 4: $::nginxV !~ m/wasmtime/
+--- main_config
+    wasm {
+        wasmtime {
+            cache_config missing_file;
+        }
+    }
+--- error_log eval
+qr/\[emerg\] .*? failed configuring wasmtime cache; failed to read config file: missing_file/
+--- no_error_log
+[error]
+[crit]
+--- must_die
+
+
+
+=== TEST 2: wasmtime cache_config - bad file
+--- skip_eval: 4: $::nginxV !~ m/wasmtime/
+--- user_files
+>>> wasmtime_config.toml
+invalid contents
+--- main_config
+    wasm {
+        wasmtime {
+            cache_config $TEST_NGINX_HTML_DIR/wasmtime_config.toml;
+        }
+    }
+--- error_log eval
+qr@\[emerg\] .*? failed configuring wasmtime cache; failed to parse config file: .*/wasmtime_config.toml@
+--- no_error_log
+[error]
+[crit]
+--- must_die
+
+
+
+=== TEST 3: wasmtime cache_config - good file, cache disabled
+--- skip_eval: 4: $::nginxV !~ m/wasmtime/
+--- user_files
+>>> wasmtime_config.toml
+[cache]
+enabled = false
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $t::TestWasmX::crates/hostcalls.wasm;
+
+        wasmtime {
+            cache_config $ENV{TEST_NGINX_HTML_DIR}/wasmtime_config.toml;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/set_request_header \
+                              value=Hello:wasm';
+        proxy_wasm hostcalls 'test=/t/echo/headers';
+    }
+--- response_body
+Host: localhost
+Connection: close
+Hello: wasm
+--- error_log eval
+qr@setting wasmtime cache config file: ".*/wasmtime_config.toml"@
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: wasmtime cache_config - good file, cache enabled
+--- skip_eval: 4: $::nginxV !~ m/wasmtime/
+--- user_files
+>>> wasmtime_config.toml
+[cache]
+enabled = true
+directory = "/tmp/ngx_wasm_module/cache/wasmtime"
+--- main_config eval
+qq{
+    wasm {
+        module hostcalls $t::TestWasmX::crates/hostcalls.wasm;
+
+        wasmtime {
+            cache_config $ENV{TEST_NGINX_HTML_DIR}/wasmtime_config.toml;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/set_request_header \
+                              value=Hello:wasm';
+        proxy_wasm hostcalls 'test=/t/echo/headers';
+    }
+--- response_body
+Host: localhost
+Connection: close
+Hello: wasm
+--- error_log eval
+qr@setting wasmtime cache config file: ".*/wasmtime_config.toml"@
+--- no_error_log
+[error]


### PR DESCRIPTION
This adds support for `wasmtime { flag cache_config_load <config.toml>; }`, for enabling disk caching of ahead-of-time compilation of .wasm files.

This should alleviate noticeable CPU spikes when starting up workers using Wasmtime and Wasm modules larger than a few megabytes.

Implementation notes:

* Added error checking to the config directive, even though not all wasmtime config checks do, because this one reports various errors such as file not found and parse errors in the config file.
* Kept the same name `cache_config_load` as documented in https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cache_config_load since that is the reference we point to in our documentation.