### PR TITLE
tests(proxy_wasm) check parallel calls with failing connections

### DIFF
--- a/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
@@ -373,3 +373,26 @@ qr/\A.*? on_request_headers.*
 [error]
 [crit]
 [emerg]
+
+
+
+=== TEST 11: proxy_wasm - dispatch_http_call() 2 failing parallel calls
+--- valgrind
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on=request_headers \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:1 \
+                              path=/bad_port \
+                              ncalls=2';
+        echo ok;
+    }
+--- error_code: 500
+--- no_error_log
+[crit]
+[emerg]
+[alert]
+[stub1]
+[stub2]


### PR DESCRIPTION
This is a minimal reproducer to a segfault I originally triggered with Datakit, where you can get a crash when performing multiple dispatch calls with failing connections. The first dispatch is terminated with `dispatch failed: tcp socket - Connection refused`, and this seems to free resources that are still being used by the second dispatch, leading to [memory corruption and a segfault](https://github.com/Kong/ngx_wasm_module/actions/runs/8972623154/job/24641007935).

This looks similar to #528 (both include multiple dispatches and the Valgrind errors refer to accessing data freed by `ngx_http_finalize_connection`, etc.; both might have the same root cause), but in [that case](https://github.com/Kong/ngx_wasm_module/files/14924491/full_log.txt) I didn't get `dispatch failed: tcp socket` in the full log.