### PR TITLE
fix(proxy-wasm) only inject shim headers after on_response_headers

### DIFF
--- a/t/03-proxy_wasm/hfuncs/104-proxy_get_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/104-proxy_get_http_response_headers.t
@@ -46,8 +46,6 @@ response
 --- grep_error_log eval: qr/(testing in|resp) .*/
 --- grep_error_log_out eval
 qr/testing in "RequestHeaders".*
-resp Transfer-Encoding: chunked.*
-resp Connection: close.*
 testing in "ResponseHeaders".*
 resp :status: 200.*
 resp Content-Type: text\/plain.*


### PR DESCRIPTION
Due to some Nginx internals (some response headers are added after our module is executed but before the response is sent) we inject "shim headers" into the `get_http_response_headers()` API. Some heuristics are used to determine whether or not `Transfer-Encoding`, `Connection`, or other "last minute" headers will be injected or not.

The issue is that the heuristics used are only valid during response production and after (e.g. `r->chunked` or
`r->headers_out.content_length_n` may only be relevant during and after response production). If a user uses `get_http_response_headers()` in request phases, the returned headers may include elements that will not actually be included in the response (e.g. `Transfer-Encoding`).

We now enforce that shim response headers should only be injected during and after `on_http_response_headers`.