### PR TITLE
fix(*) resolve a potential memleak in Lua bridge resolver

### DIFF
--- a/src/common/lua/ngx_wasm_lua.h
+++ b/src/common/lua/ngx_wasm_lua.h
@@ -50,6 +50,7 @@ struct ngx_wasm_lua_ctx_s {
     unsigned                        entry:1;        /* is entry lctx */
     unsigned                        yielded:1;      /* has yielded at least once */
     unsigned                        finished:1;     /* has finished */
+    unsigned                        cancelled:1;    /* cancelled */
 };
 
 
@@ -58,6 +59,7 @@ ngx_wasm_lua_ctx_t *ngx_wasm_lua_thread_new(const char *tag, const char *src,
     ngx_wasm_lua_handler_pt success_handler,
     ngx_wasm_lua_handler_pt error_handler);
 ngx_int_t ngx_wasm_lua_thread_run(ngx_wasm_lua_ctx_t *lctx);
+void ngx_wasm_lua_thread_cancel(ngx_wasm_lua_ctx_t *lctx);
 ngx_int_t ngx_wasm_lua_resume(ngx_wasm_subsys_env_t *env);
 
 

--- a/src/common/lua/ngx_wasm_lua_resolver.c
+++ b/src/common/lua/ngx_wasm_lua_resolver.c
@@ -101,10 +101,15 @@ ngx_wasm_lua_resolver_error_handler(ngx_wasm_lua_ctx_t *lctx)
 
     dd("enter");
 
-    ngx_wa_assert(lctx->co_ctx->co_status == NGX_HTTP_LUA_CO_DEAD);
-    ngx_wa_assert(!rslv_ctx->naddrs);
+#if (DDEBUG)
+    if (!lctx->cancelled) {
+        ngx_wa_assert(lctx->co_ctx->co_status == NGX_HTTP_LUA_CO_DEAD);
+    }
 
-    if (lctx->yielded) {
+    ngx_wa_assert(!rslv_ctx->naddrs);
+#endif
+
+    if (lctx->yielded || lctx->cancelled) {
         /* re-enter normal resolver path (handler) if we yielded */
         rslv_ctx->state = NGX_WASM_LUA_RESOLVE_ERR;
 
@@ -164,6 +169,8 @@ ngx_wasm_lua_resolver_resolve(ngx_resolver_ctx_t *rslv_ctx)
     if (lctx == NULL) {
         return NGX_ERROR;
     }
+
+    sock->lctx = lctx;
 
     /* args */
 

--- a/src/common/ngx_wasm_socket_tcp.h
+++ b/src/common/ngx_wasm_socket_tcp.h
@@ -40,6 +40,9 @@ struct ngx_wasm_socket_tcp_s {
 
     ngx_wasm_socket_tcp_resume_handler_pt    resume_handler;
     void                                    *data;
+#if (NGX_WASM_LUA)
+    ngx_wasm_lua_ctx_t                      *lctx;
+#endif
 
     ngx_str_t                                host;
     ngx_wasm_upstream_resolved_t             resolved;

--- a/t/04-openresty/lua-bridge/001-sanity.t
+++ b/t/04-openresty/lua-bridge/001-sanity.t
@@ -155,3 +155,21 @@ sleeping for 250ms
 ]
 --- no_error_log
 [crit]
+
+
+
+=== TEST 9: Lua bridge - Lua thread can be cancelled
+--- valgrind
+--- skip_no_debug
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        wasm_call access ngx_lua_tests test_lua_cancel;
+        echo ok;
+    }
+--- error_log eval
+[
+    qr/\[debug\] .*? cancelling lua user thread/,
+    qr/\[debug\] .*? cancelling lua entry thread/,
+    qr/\[debug\] .*? wasm lua thread cancelled: 1/
+]

--- a/t/lib/ngx-lua-tests/src/lua_bridge.rs
+++ b/t/lib/ngx-lua-tests/src/lua_bridge.rs
@@ -3,6 +3,7 @@ extern "C" {
     fn ngx_wasm_lua_test_bad_chunk();
     fn ngx_wasm_lua_test_error();
     fn ngx_wasm_lua_test_sleep();
+    fn ngx_wasm_lua_test_cancel();
 }
 
 #[no_mangle]
@@ -23,4 +24,9 @@ pub fn test_lua_error() {
 #[no_mangle]
 pub fn test_lua_sleep() {
     unsafe { ngx_wasm_lua_test_sleep() }
+}
+
+#[no_mangle]
+pub fn test_lua_cancel() {
+    unsafe { ngx_wasm_lua_test_cancel() }
 }


### PR DESCRIPTION
An occasional memory leak of Proxy-Wasm dispatch with Lua bridge resolver, spotted by CI:

https://github.com/Kong/ngx_wasm_module/actions/runs/9884094484/job/27299927250

    ==19824== 224 bytes in 1 blocks are definitely lost in loss record 13 of 33
    ==19824==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==19824==    by 0x1E56AA: ngx_alloc (ngx_alloc.c:22)
    ==19824==    by 0x1CF926: ngx_resolver_alloc (ngx_resolver.c:4400)
    ==19824==    by 0x1CF926: ngx_resolver_calloc.isra.0 (ngx_resolver.c:4413)
    ==19824==    by 0x1D1EFD: ngx_resolve_start (ngx_resolver.c:661)
    ==19824==    by 0x392C80: ngx_wasm_socket_tcp_connect (ngx_wasm_socket_tcp.c:360)
    ==19824==    by 0x3BC984: ngx_http_proxy_wasm_dispatch_resume_handler (ngx_http_proxy_wasm_dispatch.c:745)
    ==19824==    by 0x3BD4C3: ngx_http_proxy_wasm_dispatch_handler (ngx_http_proxy_wasm_dispatch.c:477)
    ==19824==    by 0x1DFBE9: ngx_event_process_posted (ngx_event_posted.c:35)
    ==19824==    by 0x1DF0E6: ngx_process_events_and_timers (ngx_event.c:273)
    ==19824==    by 0x1EE697: ngx_single_process_cycle (ngx_process_cycle.c:323)
    ==19824==    by 0x1A9078: main (nginx.c:384)

This was caused by having 2 parallel dispatch calls using `pwm_lua_resolver` DNS resolution. When the first call responds and produces a downstream response, it causes pending calls to be cancelled.

However when a cancelled call had not yet finished the Lua-bridge DNS resolution, its associated `rslv_ctx` was never freed.

This adds a "cancel" feature to Lua bridge threads, which is invoked by TCP sockets when they are closed while having a pending Lua resolver thread.