### PR TITLE
feat(proxy-wasm) allow cancelling background ticks

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -219,6 +219,12 @@ ngx_proxy_wasm_filter_tick_handler(ngx_event_t *ev)
     (void) ngx_proxy_wasm_run_step(rexec, NGX_PROXY_WASM_STEP_TICK);
 
     if (!ngx_exiting) {
+        if (!rexec->tick_period) {
+            ngx_log_debug0(NGX_LOG_DEBUG_WASM, log, 0,
+                           "proxy_wasm cancelling tick");
+            return;
+        }
+
         rexec->ev = ngx_calloc(sizeof(ngx_event_t), log);
         if (rexec->ev == NULL) {
             goto nomem;

--- a/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/on-phases/src/filter.rs
@@ -72,6 +72,9 @@ impl RootContext for HttpHeadersRoot {
         #[allow(clippy::single_match)]
         match self.config.get("on_tick").map(|s| s.as_str()).unwrap_or("") {
             "trap" => panic!("on_tick trap"),
+            "cancel" => {
+                self.set_tick_period(Duration::from_millis(0));
+            }
             _ => (),
         }
     }

--- a/t/lib/proxy-wasm-tests/on-tick/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/on-tick/src/filter.rs
@@ -5,10 +5,13 @@ use std::time::Duration;
 
 proxy_wasm::main! {{
     proxy_wasm::set_log_level(LogLevel::Debug);
-    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(OnTick) });
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(OnTick { cancel: false }) });
 }}
 
-struct OnTick;
+struct OnTick {
+    cancel: bool,
+}
+
 impl Context for OnTick {}
 impl RootContext for OnTick {
     fn get_type(&self) -> Option<ContextType> {


### PR DESCRIPTION
Passing `0` to `set_tick_period` signifies "cancel the tick".