### PR TITLE
perf(http) stash local response in request pool

### DIFF
--- a/src/http/ngx_http_wasm_local_response.c
+++ b/src/http/ngx_http_wasm_local_response.c
@@ -150,7 +150,7 @@ ngx_http_wasm_stash_local_response(ngx_http_wasm_req_ctx_t *rctx,
             b->sync = 1;
         }
 
-        cl = ngx_wasm_chain_get_free_buf(r->connection->pool,
+        cl = ngx_wasm_chain_get_free_buf(rctx->pool,
                                          &rctx->free_bufs, len,
                                          buf_tag, 1);
         if (cl == NULL) {


### PR DESCRIPTION
This is to avoid mounting memory pressure as a longer-lived connection gets reused across many requests.

Before:
![image](https://github.com/user-attachments/assets/7210390a-dc06-4f45-ac7a-b8bba3e3b5c7)

After:
![image](https://github.com/user-attachments/assets/76379c8f-5955-4cff-b931-8708415e1a1e)

(The initial peak in both graphs is the Cranelift compilation process.)