### PR TITLE
fix(ffi) correct usage of 'n_bins' when parsing a histogram

### DIFF
--- a/lib/resty/wasmx/shm.lua
+++ b/lib/resty/wasmx/shm.lua
@@ -438,7 +438,7 @@ local function parse_cmetric(cmetric)
         local ch = ffi_cast("ngx_wa_metrics_histogram_t *", hbuf)
         local h = { type = "histogram", value = {}, sum = tonumber(ch.sum) }
 
-        for i = 0, ch.n_bins do
+        for i = 0, (ch.n_bins - 1) do
             local cb = ch.bins[i]
             if cb.upper_bound == 0 then
                 break


### PR DESCRIPTION
Previously, when parsing a histogram without uninitialized bins, `parse_cmetric` would incorrectly build an extra bin from invalid memory.

Histograms with uninitialized bins were correctly parsed due to `parse_cmetric` stop parsing bins when an uninitialized one is found.