### PR TITLE
misc(metrics) space as metadata separator in metric name

### DIFF
--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -255,7 +255,8 @@ module
 
 Load a Wasm module from disk.
 
-- `name` is expected to be unique since it will be used to refer to this module.
+- `name` is expected to be unique since it will be used to refer to this module,
+  it also shouldn't contain any tabs or spaces.
 - `path` must point to a bytecode file whose format is `.wasm` (binary) or
   `.wat` (text).
 - `config` is an optional configuration string passed to `on_vm_start` when

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -38,9 +38,9 @@ gauge, or a histogram.
 ## Name Prefixing
 
 To avoid naming conflicts between Proxy-Wasm filters, the name of a metric is
-always prefixed with: `pw.{filter_name}.{metric_name}`. This means that a metric
-named `a_counter` inserted by `a_filter` will have its name stored as:
-`pw.a_filter.a_counter`.
+always prefixed with space-separated metadata: `pw {filter_name} `. This means
+that a metric named `a_counter` inserted by `a_filter` will have its name stored
+as: `pw a_filter a_counter`.
 
 Thus, the maximum length of a metric name configured via
 [max_metric_name_length] is enforced on the prefixed name and may need to be

--- a/lib/resty/wasmx/shm.lua
+++ b/lib/resty/wasmx/shm.lua
@@ -403,7 +403,7 @@ local function metrics_define(zone, name, metric_type, opts)
         end
     end
 
-    name = "lua." .. name
+    name = "lua " .. name
 
     local cname = ffi_new("ngx_str_t", { data = name, len = #name })
     local m_id = ffi_new("uint32_t[1]")
@@ -528,12 +528,12 @@ end
 
 
 ---
--- ngx_wasm_module internally prefixes metric names according to
--- where they have been defined, e.g. "pw.filter.*", "lua.*", or
--- "wa.*".
+-- ngx_wasm_module internally prefixes metric names with space-separated
+-- metadata indicating where they have been defined, e.g. "pw a_filter *",
+-- "lua *", or "wa ".
 --
 -- metrics_get_by_name assumes it is retrieving a Lua-defined metric
--- and will by default prefix the given name with `lua.`
+-- and will by default prefix the given name with `lua `
 --
 -- This behavior can be disabled by passing `opts.prefix` as false.
 local function metrics_get_by_name(zone, name, opts)
@@ -554,7 +554,7 @@ local function metrics_get_by_name(zone, name, opts)
     ffi_fill(_mbuf, _mbs)
     ffi_fill(_hbuf, _hbs)
 
-    name = (opts and opts.prefix == false) and name or "lua." .. name
+    name = (opts and opts.prefix == false) and name or "lua " .. name
 
     local cname = ffi_new("ngx_str_t", { data = name, len = #name })
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -1635,7 +1635,7 @@ ngx_proxy_wasm_hfuncs_define_metric(ngx_wavm_instance_t *instance,
     }
 
     prefixed_name.data = buf;
-    prefixed_name.len = ngx_sprintf(buf, "pw.%V.%V", filter_name, &name)
+    prefixed_name.len = ngx_sprintf(buf, "pw %V %V", filter_name, &name)
                         - buf;
 
     rc = ngx_wa_metrics_define(metrics, &prefixed_name, type, NULL, 0, id);

--- a/src/wasm/ngx_wasm_directives.c
+++ b/src/wasm/ngx_wasm_directives.c
@@ -257,6 +257,7 @@ ngx_wasm_core_shm_generic_directive(ngx_conf_t *cf, ngx_command_t *cmd,
 char *
 ngx_wasm_core_module_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+    size_t                 i;
     ngx_int_t              rc;
     ngx_str_t             *value, *name, *path;
     ngx_str_t             *config = NULL;
@@ -270,6 +271,16 @@ ngx_wasm_core_module_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "[wasm] invalid module name \"%V\"", name);
         return NGX_CONF_ERROR;
+    }
+
+    for (i = 0; i < name->len; i++) {
+        if (name->data[i] == ' ' || name->data[i] == '\t') {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "[wasm] invalid module name \"%V\":"
+                               " tabs and spaces not allowed",
+                               name);
+            return NGX_CONF_ERROR;
+        }
     }
 
     if (!path->len) {

--- a/t/01-wasm/directives/001-module_directive.t
+++ b/t/01-wasm/directives/001-module_directive.t
@@ -79,7 +79,7 @@ qr/\[emerg\] .*? invalid number of arguments in "module" directive/
 
 
 
-=== TEST 5: module directive - bad name
+=== TEST 5: module directive - empty name
 --- main_config
     wasm {
         module '' $TEST_NGINX_HTML_DIR/a.wat;
@@ -93,7 +93,35 @@ qr/\[emerg\] .*? invalid module name ""/
 
 
 
-=== TEST 6: module directive - bad path
+=== TEST 6: module directive - bad name, space
+--- main_config
+    wasm {
+        module 'bad name' $TEST_NGINX_HTML_DIR/a.wat;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid module name "bad name": tabs and spaces not allowed/
+--- no_error_log
+[error]
+[crit]
+--- must_die
+
+
+
+=== TEST 7: module directive - bad name, space
+--- main_config
+    wasm {
+        module 'bad\tname' $TEST_NGINX_HTML_DIR/a.wat;
+    }
+--- error_log eval
+qr/\[emerg\] .*? invalid module name "bad\tname": tabs and spaces not allowed/
+--- no_error_log
+[error]
+[crit]
+--- must_die
+
+
+
+=== TEST 8: module directive - bad path
 --- main_config
     wasm {
         module a '';
@@ -107,7 +135,7 @@ qr/\[emerg\] .*? invalid module path ""/
 
 
 
-=== TEST 7: module directive - already defined
+=== TEST 9: module directive - already defined
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wat;
@@ -125,7 +153,7 @@ qr/\[emerg\] .*? "a" module already defined/
 
 
 
-=== TEST 8: module directive - no such path
+=== TEST 10: module directive - no such path
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/none.wat;
@@ -139,7 +167,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 9: module directive - no .wat bytes - wasmtime, wasmer
+=== TEST 11: module directive - no .wat bytes - wasmtime, wasmer
 --- skip_eval: 4: !( $::nginxV =~ m/wasmtime/ || $::nginxV =~ m/wasmer/ )
 --- main_config
     wasm {
@@ -158,7 +186,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 10: module directive - no .wat bytes - v8
+=== TEST 12: module directive - no .wat bytes - v8
 --- skip_eval: 4: $::nginxV !~ m/v8/
 --- main_config
     wasm {
@@ -177,7 +205,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 11: module directive - no .wasm bytes
+=== TEST 13: module directive - no .wasm bytes
 --- main_config
     wasm {
         module a $TEST_NGINX_HTML_DIR/a.wasm;
@@ -195,7 +223,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 12: module directive - invalid .wat module - wasmtime, wasmer
+=== TEST 14: module directive - invalid .wat module - wasmtime, wasmer
 --- skip_eval: 4: !( $::nginxV =~ m/wasmtime/ || $::nginxV =~ m/wasmer/ )
 --- main_config
     wasm {
@@ -217,7 +245,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 13: module directive - invalid .wat module - v8
+=== TEST 15: module directive - invalid .wat module - v8
 --- skip_eval: 4: $::nginxV !~ m/v8/
 --- main_config
     wasm {
@@ -239,7 +267,7 @@ qr/\[emerg\] .*? \[wasm\] open\(\) ".*?none\.wat" failed \(2: No such file or di
 
 
 
-=== TEST 14: module directive - invalid module (NYI import types)
+=== TEST 16: module directive - invalid module (NYI import types)
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
@@ -264,7 +292,7 @@ qr/\[alert\] .*? \[wasm\] NYI: module import type not supported/
 
 
 
-=== TEST 15: module directive - invalid module (missing host function in env)
+=== TEST 17: module directive - invalid module (missing host function in env)
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code
@@ -291,7 +319,7 @@ qq{
 
 
 
-=== TEST 16: module directive - invalid module (missing WASI function)
+=== TEST 18: module directive - invalid module (missing WASI function)
 'daemon off' must be set to check exit_code is 2
 Valgrind mode already writes 'daemon off'
 HUP mode does not catch the worker exit_code

--- a/t/04-openresty/ffi/shm/020-metrics_define.t
+++ b/t/04-openresty/ffi/shm/020-metrics_define.t
@@ -40,10 +40,10 @@ __DATA__
 ok
 --- error_log eval
 [
-    qr/.*? \[debug\] .*? defined counter "lua.c1" with id \d+/,
-    qr/.*? \[debug\] .*? defined gauge "lua.g1" with id \d+/,
-    qr/.*? \[debug\] .*? defined histogram "lua.h1" with id \d+/,
-    qr/.*? \[debug\] .*? defined histogram "lua.ch1" with id \d+/,
+    qr/.*? \[debug\] .*? defined counter "lua c1" with id \d+/,
+    qr/.*? \[debug\] .*? defined gauge "lua g1" with id \d+/,
+    qr/.*? \[debug\] .*? defined histogram "lua h1" with id \d+/,
+    qr/.*? \[debug\] .*? defined histogram "lua ch1" with id \d+/,
 ]
 --- no_error_log
 [error]

--- a/t/04-openresty/ffi/shm/025-metrics_get_by_name.t
+++ b/t/04-openresty/ffi/shm/025-metrics_get_by_name.t
@@ -12,7 +12,7 @@ run_tests();
 __DATA__
 
 === TEST 1: shm_metrics - get_by_name() sanity FFI-defined metrics
-prefix: lua.*
+space-separated prefix: lua *
 --- valgrind
 --- metrics: 16k
 --- config
@@ -51,7 +51,7 @@ ch1: {sum=2,type="histogram",value={{count=0,ub=1},{count=1,ub=3},{count=0,ub=5}
 
 
 === TEST 2: shm_metrics - get_by_name() sanity non-FFI-defined metrics
-prefix: pw.hostcalls.*
+space-separated prefix: pw hostcalls *
 --- wasm_modules: hostcalls
 --- config eval
 my $record_histograms;
@@ -84,9 +84,9 @@ qq{
             local shm = require "resty.wasmx.shm"
             local pretty = require "pl.pretty"
 
-            ngx.say("c1: ", pretty.write(shm.metrics:get_by_name("pw.hostcalls.c1", { prefix = false }), ""))
-            ngx.say("g1: ", pretty.write(shm.metrics:get_by_name("pw.hostcalls.g1", { prefix = false }), ""))
-            ngx.say("h1: ", pretty.write(shm.metrics:get_by_name("pw.hostcalls.h1", { prefix = false }), ""))
+            ngx.say("c1: ", pretty.write(shm.metrics:get_by_name("pw hostcalls c1", { prefix = false }), ""))
+            ngx.say("g1: ", pretty.write(shm.metrics:get_by_name("pw hostcalls g1", { prefix = false }), ""))
+            ngx.say("h1: ", pretty.write(shm.metrics:get_by_name("pw hostcalls h1", { prefix = false }), ""))
         }
     }
 }

--- a/t/04-openresty/ffi/shm/026-metrics_iterate_keys.t
+++ b/t/04-openresty/ffi/shm/026-metrics_iterate_keys.t
@@ -32,9 +32,9 @@ __DATA__
         }
     }
 --- response_body
-lua.c1
-lua.g1
-lua.h1
+lua c1
+lua g1
+lua h1
 --- no_error_log
 [error]
 [crit]

--- a/t/04-openresty/ffi/shm/027-metrics_get_keys.t
+++ b/t/04-openresty/ffi/shm/027-metrics_get_keys.t
@@ -30,9 +30,9 @@ __DATA__
         }
     }
 --- response_body
-lua.c1
-lua.g1
-lua.h1
+lua c1
+lua g1
+lua h1
 --- no_error_log
 [error]
 [crit]


### PR DESCRIPTION
WasmX metrics defined in Proxy-Wasm filters have their names prefixed by `pw.{a_filter}` where `{a_filter}` is the name of the filter where the metric was defined, e.g. `pw.a_filter.a_counter`.

When the Gateway serializes a WasmX metric defined in a Proxy-Wasm filter it needs to extract the filter name from the metric name. The filter name is used to load potential label patterns associated with the filter which are then used to extract potential labels from the metric name.

This PR proposes changing the separator in metric names from the dot to the space (e.g. `pw a_filter a_counter`) and forbidding space-like characters in WASM modules names; which simplifies the task of extracting the filter name from a metric name.