### PR TITLE
misc(*) remove from `ngx_wasm_lua_resolver_resolve` call freeing 'rslv_ctx'

### DIFF
--- a/src/common/lua/ngx_wasm_lua_resolver.c
+++ b/src/common/lua/ngx_wasm_lua_resolver.c
@@ -207,8 +207,6 @@ error:
 
     dd("error exit");
 
-    ngx_free(rslv_ctx);
-
     return NGX_ERROR;
 }
 

--- a/src/common/ngx_wasm_socket_tcp.c
+++ b/src/common/ngx_wasm_socket_tcp.c
@@ -405,6 +405,14 @@ ngx_wasm_socket_tcp_connect(ngx_wasm_socket_tcp_t *sock)
     if (rc != NGX_OK && rc != NGX_AGAIN) {
         ngx_log_debug0(NGX_LOG_DEBUG_WASM, sock->log, 0,
                        "wasm tcp socket resolver failed before query");
+
+#if (NGX_WASM_LUA)
+        /* ngx_resolve_name frees rslv_ctx in case of error */
+        if (resolver_pt == ngx_wasm_lua_resolver_resolve) {
+            ngx_free(rslv_ctx);
+        }
+#endif
+
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
Presently the behavior of `ngx_wasm_lua_resolver_resolve` mimics the one from `ngx_resolve_name`, which frees its argument 'rslv_ctx' in case of any errors.

This commit changes `ngx_wasm_lua_resolver_resolve` to not free 'rslv_ctx' if any errors occur, delegating the responsibility to its caller.

Although it makes `ngx_wasm_lua_resolver_resolve` less consistent with `ngx_resolve_name`, this change allows the upcoming logic exposing `ngx_wasm_lua_resolver_resolve` as a PW foreign-function to allocate 'rslv_ctx' using memory from the pwexec's pool, instead of from malloc.