### PR TITLE
feat(proxy-wasm) invoke 'on_http_call_response' on dispatch failures

### DIFF
--- a/src/common/ngx_wasm_socket_tcp.h
+++ b/src/common/ngx_wasm_socket_tcp.h
@@ -18,6 +18,20 @@ typedef ngx_int_t (*ngx_wasm_socket_tcp_dns_resolver_pt)(
     ngx_resolver_ctx_t *rslv_ctx);
 
 
+typedef enum {
+    NGX_WASM_SOCKET_STATUS_OK = 0,
+    NGX_WASM_SOCKET_STATUS_BAD_ARGUMENT,
+    NGX_WASM_SOCKET_STATUS_TIMEOUT,
+    NGX_WASM_SOCKET_STATUS_BROKEN_CONNECTION,
+#if (NGX_SSL)
+    NGX_WASM_SOCKET_STATUS_TLS_FAILURE,
+#endif
+    NGX_WASM_SOCKET_STATUS_RESOLVER_FAILURE,
+    NGX_WASM_SOCKET_STATUS_READER_FAILURE,
+    NGX_WASM_SOCKET_STATUS_INTERNAL_FAILURE,
+} ngx_wasm_socket_status_e;
+
+
 typedef struct {
     ngx_str_t                                host;
     in_port_t                                port;
@@ -39,6 +53,7 @@ struct ngx_wasm_socket_tcp_s {
     ngx_wasm_subsys_env_t                   *env;
 
     ngx_wasm_socket_tcp_resume_handler_pt    resume_handler;
+    ngx_wasm_socket_status_e                 status;
     void                                    *data;
 #if (NGX_WASM_LUA)
     ngx_wasm_lua_ctx_t                      *lctx;
@@ -85,18 +100,18 @@ struct ngx_wasm_socket_tcp_s {
 
     /* flags */
 
-    unsigned                                 timedout:1;
     unsigned                                 connected:1;
     unsigned                                 eof:1;
     unsigned                                 closed:1;
     unsigned                                 read_closed:1;
     unsigned                                 write_closed:1;
-
 #if (NGX_SSL)
     unsigned                                 ssl_ready:1;
 #endif
 };
 
+
+ngx_str_t *ngx_wasm_socket_tcp_status_strerror(ngx_wasm_socket_status_e status);
 
 ngx_int_t ngx_wasm_socket_tcp_init(ngx_wasm_socket_tcp_t *sock,
     ngx_str_t *host, unsigned tls, ngx_str_t *sni, ngx_wasm_subsys_env_t *env);

--- a/src/common/ngx_wasm_socket_tcp_readers.h
+++ b/src/common/ngx_wasm_socket_tcp_readers.h
@@ -30,6 +30,7 @@ typedef struct {
 
 ngx_int_t ngx_wasm_read_http_response(ngx_buf_t *src, ngx_chain_t *buf_in,
     ssize_t bytes, ngx_wasm_http_reader_ctx_t *in_ctx);
+ngx_int_t ngx_wasm_http_reader_init(ngx_wasm_http_reader_ctx_t *in_ctx);
 #endif
 
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -852,7 +852,7 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
     }
 
     dd("<-- step rc: %ld, old_action: %d, ret action: %d, pwctx->action: %d, "
-       " ictx: %p", rc, old_action, action, pwctx->action, pwexec->ictx);
+       "ictx: %p", rc, old_action, action, pwctx->action, pwexec->ictx);
 
     /* pwctx->action writes in host calls overwrite action return value */
 

--- a/src/http/ngx_http_wasm.h
+++ b/src/http/ngx_http_wasm.h
@@ -79,6 +79,7 @@ struct ngx_http_wasm_req_ctx_s {
 
     unsigned                           ffi_attached:1;
     unsigned                           pwm_lua_resolver:1;      /* use Lua-land resolver in OpenResty */
+    unsigned                           pwm_log_dispatch_errors:1;
 };
 
 
@@ -95,11 +96,12 @@ typedef struct {
     ngx_bufs_t                         socket_large_buffers;   /* wasm_socket_large_buffer_size */
     ngx_bufs_t                         resp_body_buffers;      /* wasm_response_body_buffers */
 
-    ngx_flag_t                         pwm_req_headers_in_access;
-    ngx_flag_t                         pwm_lua_resolver;
-
     ngx_flag_t                         postpone_rewrite;
     ngx_flag_t                         postpone_access;
+
+    ngx_flag_t                         pwm_req_headers_in_access;
+    ngx_flag_t                         pwm_lua_resolver;
+    ngx_flag_t                         pwm_log_dispatch_errors;
 
     ngx_queue_t                        q;                      /* main_conf */
 } ngx_http_wasm_loc_conf_t;

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -144,8 +144,10 @@ ngx_http_proxy_wasm_dispatch_err(ngx_http_proxy_wasm_dispatch_t *call,
 #endif
 
     if (!pwexec->ictx->instance->hostcall || rctx->fake_request) {
-        ngx_wasm_log_error(NGX_LOG_ERR, pwexec->log, 0,
-                           "%*s", p - (u_char *) &errbuf, &errbuf);
+        if (rctx->pwm_log_dispatch_errors) {
+            ngx_wasm_log_error(NGX_LOG_ERR, pwexec->log, 0, "%*s",
+                               p - (u_char *) &errbuf, &errbuf);
+        }
 
     } else {
         /* in-vm, executing a hostcall */

--- a/src/wasm/ngx_wasm.h
+++ b/src/wasm/ngx_wasm.h
@@ -101,6 +101,7 @@ typedef struct {
     ngx_resolver_t                    *user_resolver;
 
     ngx_flag_t                         pwm_lua_resolver;
+    ngx_flag_t                         pwm_log_dispatch_errors;
 } ngx_wasm_core_conf_t;
 
 

--- a/src/wasm/ngx_wasm_core_module.c
+++ b/src/wasm/ngx_wasm_core_module.c
@@ -166,13 +166,6 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
       offsetof(ngx_wasm_core_conf_t, resolver_timeout),
       NULL },
 
-    { ngx_string("proxy_wasm_lua_resolver"),
-      NGX_WASM_CONF|NGX_CONF_TAKE1,
-      ngx_wasm_core_pwm_lua_resolver_directive,
-      NGX_WA_WASM_CONF_OFFSET,
-      offsetof(ngx_wasm_core_conf_t, pwm_lua_resolver),
-      NULL },
-
     { ngx_string("socket_connect_timeout"),
       NGX_WASM_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,
@@ -213,6 +206,20 @@ static ngx_command_t  ngx_wasm_core_commands[] = {
       ngx_conf_set_bufs_slot,
       NGX_WA_WASM_CONF_OFFSET,
       offsetof(ngx_wasm_core_conf_t, socket_large_buffers),
+      NULL },
+
+    { ngx_string("proxy_wasm_lua_resolver"),
+      NGX_WASM_CONF|NGX_CONF_TAKE1,
+      ngx_wasm_core_pwm_lua_resolver_directive,
+      NGX_WA_WASM_CONF_OFFSET,
+      offsetof(ngx_wasm_core_conf_t, pwm_lua_resolver),
+      NULL },
+
+    { ngx_string("proxy_wasm_log_dispatch_errors"),
+      NGX_WASM_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_WA_WASM_CONF_OFFSET,
+      offsetof(ngx_wasm_core_conf_t, pwm_log_dispatch_errors),
       NULL },
 
     ngx_null_command
@@ -364,6 +371,7 @@ ngx_wasm_core_create_conf(ngx_conf_t *cf)
     wcf->recv_timeout = NGX_CONF_UNSET_MSEC;
 
     wcf->pwm_lua_resolver = NGX_CONF_UNSET;
+    wcf->pwm_log_dispatch_errors = NGX_CONF_UNSET;
 
     wcf->socket_buffer_size = NGX_CONF_UNSET_SIZE;
     wcf->socket_buffer_reuse = NGX_CONF_UNSET;

--- a/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
@@ -7,7 +7,7 @@ use t::TestWasmX;
 our $ExtResolver = $t::TestWasmX::extresolver;
 our $ExtTimeout = $t::TestWasmX::exttimeout;
 
-plan_tests(4);
+plan_tests(5);
 run_tests();
 
 __DATA__
@@ -24,6 +24,7 @@ __DATA__
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - no host/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -40,6 +41,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - no host
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - no host/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -56,6 +58,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - no host
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid port/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -72,6 +75,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid host/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -88,6 +92,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid port/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -105,6 +110,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - invalid
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :method/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -123,6 +129,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :method/
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :method/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -140,6 +147,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :method/
 qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :path/
 --- no_error_log
 [crit]
+on_http_call_response
 
 
 
@@ -155,7 +163,10 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no :path/
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - Connection refused/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - Connection refused/,
+    "dispatch_status: broken connection"
+]
 --- no_error_log
 [crit]
 
@@ -174,7 +185,10 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - Connect
 --- error_code: 500
 --- response_body_like: 500 Internal Server Error
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no resolver defined to resolve "localhost"/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: no resolver defined to resolve "localhost"/,
+    "dispatch_status: resolver failure"
+]
 --- no_error_log
 [crit]
 
@@ -196,6 +210,8 @@ qq{
     qr/\[error\]/,
     qr/dispatch failed: tcp socket - no path in the unix domain socket/
 ]
+--- no_error_log
+on_http_call_response
 
 
 
@@ -214,7 +230,8 @@ qq{
 --- error_log eval
 [
     qr/\[crit\] .*? connect\(\) to unix:\/tmp\/inexistent_file\.sock failed .*? No such file or directory/,
-    qr/\[error\] .*? dispatch failed: tcp socket - No such file or directory/
+    qr/\[error\] .*? dispatch failed: tcp socket - No such file or directory/,
+    "dispatch_status: broken connection"
 ]
 
 
@@ -236,7 +253,8 @@ qq{
 --- error_log eval
 [
     qr/\[(error|crit)\] .*? connect\(\) to unix:\/tmp failed .*? (Connection refused|Socket operation on non-socket)/,
-    qr/\[error\] .*? dispatch failed: tcp socket - (Connection refused|Socket operation on non-socket)/
+    qr/\[error\] .*? dispatch failed: tcp socket - (Connection refused|Socket operation on non-socket)/,
+    "dispatch_status: broken connection"
 ]
 
 
@@ -257,11 +275,13 @@ qq{
     qr/\[error\]/,
     qr/dispatch failed: tcp socket - invalid host/
 ]
+--- no_error_log
+on_http_call_response
 
 
 
 === TEST 15: proxy_wasm - dispatch_http_call() sanity (default resolver)
---- skip_eval: 4: defined $ENV{GITHUB_ACTIONS}
+--- skip_eval: 5: defined $ENV{GITHUB_ACTIONS}
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- main_config eval
@@ -282,6 +302,7 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -309,6 +330,7 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -337,6 +359,7 @@ Hello back
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -375,6 +398,7 @@ Host: localhost\s*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -385,7 +409,7 @@ Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
 - HTTP 504 (httpbin.org Gateway timeout)
---- skip_eval: 4: $::osname =~ m/darwin/
+--- skip_eval: 5: $::osname =~ m/darwin/
 --- valgrind
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
@@ -412,12 +436,13 @@ qq{
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
 === TEST 20: proxy_wasm - dispatch_http_call() sanity resolver + hostname (IPv6), default port
 Disabled on GitHub Actions due to IPv6 constraint.
---- skip_eval: 4: system("ping6 -c 1 ::1 >/dev/null 2>&1") ne 0 || defined $ENV{GITHUB_ACTIONS}
+--- skip_eval: 5: system("ping6 -c 1 ::1 >/dev/null 2>&1") ne 0 || defined $ENV{GITHUB_ACTIONS}
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
@@ -439,6 +464,7 @@ qq{
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -476,6 +502,7 @@ qq{
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -498,7 +525,10 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - resolver error: Host not found/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - resolver error: Host not found/,
+    "dispatch_status: resolver failure"
+]
 --- no_error_log
 [crit]
 
@@ -524,6 +554,7 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -550,6 +581,7 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -584,6 +616,7 @@ qq{
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -622,6 +655,7 @@ qq{
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -660,6 +694,7 @@ K: 11.*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -689,6 +724,7 @@ tcp socket reading done
 tcp socket closing
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -717,6 +753,7 @@ tcp socket reading done
 tcp socket closing
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -747,6 +784,7 @@ tcp socket reading done
 tcp socket closing
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -770,6 +808,7 @@ Hello world
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -795,6 +834,7 @@ Content-Length: 0.*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -822,6 +862,7 @@ Content-Length: 0.*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -851,6 +892,7 @@ Hello world
 tcp socket trying to receive data (max: 1)
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -879,6 +921,7 @@ Hello world
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -907,6 +950,7 @@ Hello world
 tcp socket trying to receive data (max: 1)
 tcp socket trying to receive data (max: 11)
 tcp socket - upstream response headers too large, increase wasm_socket_large_buffers size
+dispatch_status: reader failure
 
 
 
@@ -935,6 +979,7 @@ tcp socket - upstream response headers too large, increase wasm_socket_large_buf
 tcp socket trying to receive data (max: 24)
 tcp socket trying to receive data (max: 5)
 tcp socket - upstream response headers too large, increase wasm_socket_large_buffers size
+dispatch_status: reader failure
 
 
 
@@ -965,7 +1010,8 @@ ok
 --- error_log eval
 [
     qr/tcp socket - not enough large buffers available, increase wasm_socket_large_buffers number/,
-    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/,
+    "dispatch_status: reader failure"
 ]
 
 
@@ -996,6 +1042,7 @@ Hello world
 --- error_log
 tcp socket trying to receive data (max: 1)
 tcp socket trying to receive data (max: 1023)
+on_http_call_response
 
 
 
@@ -1018,7 +1065,10 @@ sub {
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/,
+    "dispatch_status: reader failure"
+]
 --- no_error_log
 [crit]
 
@@ -1049,6 +1099,7 @@ Hello world
 --- error_log
 tcp socket trying to receive data (max: 24)
 tcp socket trying to receive data (max: 1017)
+on_http_call_response
 
 
 
@@ -1072,6 +1123,7 @@ tcp socket trying to receive data (max: 1017)
 ok
 --- error_log eval
 [
+    "on_http_call_response",
     qr/\[crit\] .*? panicked at/,
     qr/trap!/,
 ]
@@ -1098,7 +1150,10 @@ sub {
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser error/,
+    "dispatch_status: reader failure"
+]
 --- no_error_log
 [crit]
 
@@ -1149,6 +1204,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - parser 
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1183,6 +1239,7 @@ qr/^\*\d+ .*? on_http_call_response \(id: \d+[^*]*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1208,6 +1265,7 @@ X-Callout-Header: callout-header-value
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1251,6 +1309,7 @@ qr/^\*\d+ .*? on_http_call_response \(id: \d+, status: 200[^*]*
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1278,6 +1337,7 @@ helloworld
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1305,6 +1365,7 @@ helloworl
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1329,6 +1390,7 @@ cannot override the "Host" header, skipping
 cannot override the "Connection" header, skipping
 --- no_error_log
 [error]
+[crit]
 
 
 
@@ -1353,6 +1415,7 @@ cannot override the "Connection" header, skipping
 --- no_error_log
 [error]
 [crit]
+[alert]
 
 
 
@@ -1365,19 +1428,16 @@ cannot override the "Connection" header, skipping
     }
 
     location /t {
-        proxy_wasm hostcalls 'on=request_body \
+        proxy_wasm hostcalls 'on=request_headers \
                               test=/t/dispatch_http_call \
                               host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
                               path=/dispatched?foo=bár%20bla \
                               on_http_call_response=echo_response_body';
         echo failed;
     }
---- request
-GET /t
-
-Hello world
 --- response_body
 Hello back /dispatched?foo=bár%20bla /dispatched ? foo=bár%20bla
 --- no_error_log
 [error]
 [crit]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/132-proxy_dispatch_http_ssl.t
+++ b/t/03-proxy_wasm/hfuncs/132-proxy_dispatch_http_ssl.t
@@ -17,7 +17,7 @@ add_block_preprocessor(sub {
     }
 });
 
-plan_tests(4);
+plan_tests(6);
 run_tests();
 
 __DATA__
@@ -54,6 +54,9 @@ ok
     qr/\[warn\] .*? tls certificate not verified/,
     qr/\[warn\] .*? tls certificate host not verified/
 ]
+--- no_error_log
+[error]
+[crit]
 
 
 
@@ -93,7 +96,9 @@ ok
 --- no_error_log eval
 [
     qr/tls certificate not verified/,
-    qr/\[error\]/
+    "[error]",
+    "[crit]",
+    "[alert]"
 ]
 
 
@@ -138,6 +143,8 @@ Content-Length: 0.*
 qr/verifying tls certificate for "hostname:\d+" \(sni: "hostname"\)/
 --- no_error_log
 [error]
+[crit]
+[alert]
 
 
 
@@ -185,6 +192,8 @@ Content-Length: 0.*
 "verifying tls certificate for \"unix:$ENV{TEST_NGINX_UNIX_SOCKET}\" (sni: \"localhost\")"
 --- no_error_log
 [error]
+[crit]
+[alert]
 
 
 
@@ -213,7 +222,11 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \(10:certificate has expired\)/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \(10:certificate has expired\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -260,6 +273,8 @@ Content-Length: 0.*
 qr/checking tls certificate CN for "hostname:\d+" \(sni: "hostname"\)/
 --- no_error_log
 [error]
+[crit]
+[alert]
 
 
 
@@ -294,7 +309,11 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate CN does not match \"localhost\" sni/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate CN does not match \"localhost\" sni/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -325,7 +344,11 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/tls certificate verify error: \(19:self.signed certificate in certificate chain\)/
+[
+    qr/tls certificate verify error: \(19:self.signed certificate in certificate chain\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -353,7 +376,9 @@ ok
 --- error_log eval
 [
     qr/\[crit\] .*? SSL_do_handshake\(\) failed/,
-    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls handshake failed/
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls handshake failed/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
 ]
 
 
@@ -366,6 +391,8 @@ qr/\[emerg\] .*?no such file/i
 --- no_error_log
 [error]
 [crit]
+[alert]
+stub
 --- must_die
 
 
@@ -380,6 +407,8 @@ qr/\[emerg\] .*?no certificate or crl found/i
 --- no_error_log
 [error]
 [crit]
+[alert]
+stub
 --- must_die
 --- user_files
 >>> ca.pem
@@ -389,7 +418,7 @@ foo
 
 === TEST 12: proxy_wasm - dispatch_https_call() no trusted CA
 macOS: intermitent failures
---- skip_eval: 4: $::osname =~ m/darwin/
+--- skip_eval: $::osname =~ m/darwin/
 --- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
@@ -411,7 +440,11 @@ qq{
     }
 }
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \((18|20):(self-signed certificate|unable to get local issuer certificate)\)/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \((18|20):(self-signed certificate|unable to get local issuer certificate)\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 [emerg]
@@ -420,7 +453,7 @@ qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls cer
 
 === TEST 13: proxy_wasm - dispatch_https_call() empty trusted CA path
 macOS: intermitent failures
---- skip_eval: 4: $::osname =~ m/darwin/
+--- skip_eval: $::osname =~ m/darwin/
 --- timeout eval: $::ExtTimeout
 --- main_config eval
 qq{
@@ -446,7 +479,11 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \((18|20):(self-signed certificate|unable to get local issuer certificate)\)/
+[
+    qr/(\[error\]|Uncaught RuntimeError|\s+).*?dispatch failed: tcp socket - tls certificate verify error: \((18|20):(self-signed certificate|unable to get local issuer certificate)\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -490,6 +527,9 @@ ok
     qr/upstream tls server name: "hostname"/,
     qr/checking tls certificate CN for "hostname:\d+" \(sni: "hostname"\)/,
 ]
+--- no_error_log
+[error]
+[crit]
 
 
 
@@ -522,7 +562,11 @@ qq{
 --- response_body
 ok
 --- error_log eval
-qr/could not derive tls sni from host \("127\.0\.0\.1:\d+"\)/
+[
+    qr/could not derive tls sni from host \("127\.0\.0\.1:\d+"\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -552,7 +596,11 @@ SNI cannot be an IP address.
 --- response_body
 ok
 --- error_log eval
-qr/could not derive tls sni from host \("\[0:0:0:0:0:0:0:1\]:\d+"\)/
+[
+    qr/could not derive tls sni from host \("\[0:0:0:0:0:0:0:1\]:\d+"\)/,
+    qr/\*\d+ .*? on_http_call_response \(id: \d+, status: , headers: 0, body_bytes: 0/,
+    qr/dispatch_status: tls handshake failure/
+]
 --- no_error_log
 [crit]
 
@@ -595,8 +643,11 @@ ok
 --- error_log eval
 [
     "upstream tls server name: \"hostname\"",
-    qr/checking tls certificate CN for "127\.0\.0\.1:\d+" \(sni: "hostname"\)/,
+    qr/checking tls certificate CN for "127\.0\.0\.1:\d+" \(sni: "hostname"\)/
 ]
+--- no_error_log
+[error]
+[crit]
 
 
 
@@ -636,6 +687,8 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
+[emerg]
 
 
 
@@ -680,6 +733,9 @@ ok
     "upstream tls server name: \"hostname\"",
     "verifying tls certificate for \"unix:$ENV{TEST_NGINX_UNIX_SOCKET}\" (sni: \"hostname\")"
 ]
+--- no_error_log
+[error]
+[crit]
 
 
 
@@ -721,6 +777,8 @@ ok
 --- no_error_log
 [error]
 [crit]
+[alert]
+[emerg]
 
 
 
@@ -762,6 +820,9 @@ qq{
     qr/\[warn\] .*? tls certificate host not verified/,
     "on_root_http_call_response (id: 0, status: 200, headers: 5, body_bytes: 3, trailers: 0)",
 ]
+--- no_error_log
+[error]
+[crit]
 
 
 
@@ -805,3 +866,6 @@ qq{
     qr/checking tls certificate CN for "hostname:\d+" \(sni: "hostname"\)/,
     "on_root_http_call_response (id: 0, status: 200, headers: 5, body_bytes: 3, trailers: 0)",
 ]
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
@@ -395,10 +395,11 @@ qr/\A.*? on_request_headers.*
 --- grep_error_log_out eval
 qr/\A\[error] .*? dispatch failed: tcp socket - Connection refused
 \[error] .*? dispatch failed: tcp socket - Connection refused\Z/
+--- error_log
+dispatch_status: broken connection
+dispatch_status: broken connection
 --- no_error_log
 [crit]
-[emerg]
-[alert]
 
 
 
@@ -423,10 +424,11 @@ ok
 --- grep_error_log_out eval
 qr/\A\[error] .*? dispatch failed: tcp socket - Connection refused
 \[error] .*? dispatch failed: tcp socket - Connection refused\Z/
+--- error_log
+dispatch_status: broken connection
+dispatch_status: broken connection
 --- no_error_log
 [crit]
-[emerg]
-[alert]
 
 
 
@@ -452,4 +454,4 @@ proxy_wasm http dispatch cancelled
 --- no_error_log
 [crit]
 [emerg]
-[alert]
+on_http_call_response

--- a/t/03-proxy_wasm/sdks/002-go_sdk/005-dispatch_call_on_tick.t
+++ b/t/03-proxy_wasm/sdks/002-go_sdk/005-dispatch_call_on_tick.t
@@ -24,6 +24,7 @@ Missing IP for "web_service" host requested by the filter.
     location /t {
         return 200;
     }
+--- wait: 1
 --- ignore_response_body
 --- error_log eval
 qr/\[error\] .*? dispatch failed: tcp socket - resolver error: Host not found/
@@ -49,6 +50,7 @@ Connection refused on 127.0.0.1:81 requested by filter.
     location /t {
         return 200;
     }
+--- wait: 1
 --- ignore_response_body
 --- error_log eval
 qr/\[error\] .*? dispatch failed: tcp socket - Connection refused/

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -11,6 +11,7 @@ impl Context for TestHttp {
         body_size: usize,
         ntrailers: usize,
     ) {
+        let dispatch_status = self.get_http_call_response_header(":dispatch_status");
         let status = self.get_http_call_response_header(":status");
         let bytes = self.get_http_call_response_body(0, body_size);
         let op = self
@@ -22,6 +23,11 @@ impl Context for TestHttp {
             "[hostcalls] on_http_call_response (id: {}, status: {}, headers: {}, body_bytes: {}, trailers: {}, op: {})",
             token_id, status.unwrap_or("".to_string()), nheaders, body_size, ntrailers, op
         );
+
+        match dispatch_status.as_deref() {
+            Some(s) => info!("dispatch_status: {}", s),
+            None => {}
+        }
 
         self.add_http_response_header("pwm-call-id", token_id.to_string().as_str());
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -214,10 +214,16 @@ impl Context for TestRoot {
         ntrailers: usize,
     ) {
         let status = self.get_http_call_response_header(":status");
+        let dispatch_status = self.get_http_call_response_header(":dispatch_status");
 
         info!(
             "[hostcalls] on_root_http_call_response (id: {}, status: {}, headers: {}, body_bytes: {}, trailers: {})",
             token_id, status.unwrap_or("".to_string()), nheaders, body_size, ntrailers
         );
+
+        match dispatch_status.as_deref() {
+            Some(s) => info!("dispatch_status: {}", s),
+            None => {}
+        }
     }
 }

--- a/util/sdks/go.sh
+++ b/util/sdks/go.sh
@@ -101,6 +101,17 @@ EOF
               }
              }
 EOF
+        patch --forward --ignore-whitespace examples/dispatch_call_on_tick/main.go <<'EOF'
+            @@ -21,7 +21,7 @@ import (
+                    "github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+             )
+
+            -const tickMilliseconds uint32 = 100
+            +const tickMilliseconds uint32 = 1000
+
+             func main() {
+                    proxywasm.SetVMContext(&vmContext{})
+EOF
         set -e
 
         notice "compiling Go examples..."


### PR DESCRIPTION
Invoke `on_http_call_response` on dispatch connection failures. This allows catching failures such as:

- timeout
- broken connection
- resolver failures
- TLS handshake failures
- Any other failures *after the connection has attempted to be established*

Dispatch failures occurring *before* a connection has attempted to be established will not trigger `on_http_call_response` as they are already supposed to trigger a Wasm exception (i.e. trap).

When a dispatch connection failure occurs, `on_http_call_response` is invoked with: `on_http_call_response(call_id, 0, 0, 0)` (i.e. no header, no body, no trailers). Calls to retrieve the response `:status` will return `None`. A user may triage the connection failure by querying the `:dispatch_status` pseudo-header:

```rust
fn on_http_call_response(
    &mut self,
    token_id: u32,
    nheaders: usize,
    body_size: usize,
    ntrailers: usize,
) {
    let dispatch_status = self.get_http_call_response_header(":dispatch_status");

    match dispatch_status.as_deref() {
        Some("timeout") => {},
        Some("broken connection") => {},
        Some("tls handshake failure") => {},
        Some("resolver failure") => {},
        Some("reader failure") => {},
        Some(s) => info!("dispatch_status: {}", s),
        None => {}
    }

    self.resume_http_request()
}
```

The socket status `"bad argument"` also exists but since the connection has not been attempted yet, it won't show up during `on_http_call_response` and is for internal use only (i.e. could be added to the socket error log for example).

Fix #622.

---

TODO

- ~[ ] contribute `proxy_get_status()` for HTTP dispatch calls to proxy-wasm-rust-sdk~
- [x] a directive to not log socket errors
- [x] document connection error handling & Envoy disparities in our docs