### PR TITLE
feat(proxy-wasm) foreign function support

### DIFF
--- a/config
+++ b/config
@@ -144,7 +144,8 @@ NGX_WASMX_DEPS="\
     $ngx_addon_dir/src/common/metrics/ngx_wa_metrics.h \
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm.h \
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_maps.h \
-    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_properties.h"
+    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_properties.h \
+    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.h"
 
 NGX_WASMX_SRCS="\
     $ngx_addon_dir/src/ngx_wasmx.c \
@@ -160,8 +161,9 @@ NGX_WASMX_SRCS="\
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm.c \
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_host.c \
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_maps.c \
+    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_util.c \
     $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_properties.c \
-    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_util.c"
+    $ngx_addon_dir/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.c"
 
 # wasm
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -440,8 +440,8 @@ ngx_proxy_wasm_ctx_destroy(ngx_proxy_wasm_ctx_t *pwctx)
         ngx_pfree(pwctx->pool, pwctx->root_id.data);
     }
 
-    if (pwctx->call_status.data) {
-        ngx_pfree(pwctx->pool, pwctx->call_status.data);
+    if (pwctx->dispatch_call_status.data) {
+        ngx_pfree(pwctx->pool, pwctx->dispatch_call_status.data);
     }
 
     if (pwctx->response_status.data) {
@@ -897,8 +897,8 @@ ngx_proxy_wasm_dispatch_calls_total(ngx_proxy_wasm_exec_t *pwexec)
     ngx_queue_t  *q;
     ngx_uint_t    n = 0;
 
-    for (q = ngx_queue_head(&pwexec->calls);
-         q != ngx_queue_sentinel(&pwexec->calls);
+    for (q = ngx_queue_head(&pwexec->dispatch_calls);
+         q != ngx_queue_sentinel(&pwexec->dispatch_calls);
          q = ngx_queue_next(q), n++) { /* void */ }
 
     dd("n: %ld", n);
@@ -914,8 +914,8 @@ ngx_proxy_wasm_dispatch_calls_cancel(ngx_proxy_wasm_exec_t *pwexec)
     ngx_queue_t                     *q;
     ngx_http_proxy_wasm_dispatch_t  *call;
 
-    while (!ngx_queue_empty(&pwexec->calls)) {
-        q = ngx_queue_head(&pwexec->calls);
+    while (!ngx_queue_empty(&pwexec->dispatch_calls)) {
+        q = ngx_queue_head(&pwexec->dispatch_calls);
         call = ngx_queue_data(q, ngx_http_proxy_wasm_dispatch_t, q);
 
         ngx_log_debug1(NGX_LOG_DEBUG_ALL, pwexec->log, 0,
@@ -1148,7 +1148,7 @@ ngx_proxy_wasm_create_context(ngx_proxy_wasm_filter_t *filter,
             rexec->filter = filter;
             rexec->ictx = ictx;
 
-            ngx_queue_init(&rexec->calls);
+            ngx_queue_init(&rexec->dispatch_calls);
 
             log = filter->log;
 
@@ -1266,7 +1266,7 @@ ngx_proxy_wasm_create_context(ngx_proxy_wasm_filter_t *filter,
                 pwexec->ictx = ictx;
                 pwexec->store = ictx->store;
 
-                ngx_queue_init(&pwexec->calls);
+                ngx_queue_init(&pwexec->dispatch_calls);
 
             } else {
                 if (in->ictx != ictx) {
@@ -1393,11 +1393,11 @@ ngx_proxy_wasm_on_done(ngx_proxy_wasm_exec_t *pwexec)
 
 #if 0
 #ifdef NGX_WASM_HTTP
-    call = pwexec->call;
+    call = pwexec->dispatch_call;
     if (call) {
         ngx_http_proxy_wasm_dispatch_destroy(call);
 
-        pwexec->call = NULL;
+        pwexec->dispatch_call = NULL;
     }
 #endif
 #endif

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -188,9 +188,9 @@ struct ngx_proxy_wasm_exec_s {
     ngx_proxy_wasm_store_t            *store;
     ngx_event_t                       *ev;
 #ifdef NGX_WASM_HTTP
-    ngx_http_proxy_wasm_dispatch_t    *call;  /* swap pointer for host functions */
+    ngx_http_proxy_wasm_dispatch_t    *dispatch_call;  /* swap pointer for host functions */
 #endif
-    ngx_queue_t                        calls;
+    ngx_queue_t                        dispatch_calls;
 
     /* flags */
 
@@ -232,19 +232,19 @@ struct ngx_proxy_wasm_ctx_s {
     size_t                                        req_body_len;
     ngx_str_t                                     authority;
     ngx_str_t                                     scheme;
-    ngx_str_t                                     path;              /* r->uri + r->args */
-    ngx_str_t                                     start_time;        /* r->start_sec + r->start_msec */
-    ngx_str_t                                     upstream_address;  /* 1st part of ngx.upstream_addr */
-    ngx_str_t                                     upstream_port;     /* 2nd part of ngx.upstsream_addr */
-    ngx_str_t                                     connection_id;     /* r->connection->number */
-    ngx_str_t                                     mtls;              /* ngx.https && ngx.ssl_client_verify */
-    ngx_str_t                                     root_id;           /* pwexec->root_id */
-    ngx_str_t                                     call_status;       /* dispatch response status */
-    ngx_str_t                                     response_status;   /* response status */
+    ngx_str_t                                     path;                  /* r->uri + r->args */
+    ngx_str_t                                     start_time;            /* r->start_sec + r->start_msec */
+    ngx_str_t                                     upstream_address;      /* 1st part of ngx.upstream_addr */
+    ngx_str_t                                     upstream_port;         /* 2nd part of ngx.upstsream_addr */
+    ngx_str_t                                     connection_id;         /* r->connection->number */
+    ngx_str_t                                     mtls;                  /* ngx.https && ngx.ssl_client_verify */
+    ngx_str_t                                     root_id;               /* pwexec->root_id */
+    ngx_str_t                                     dispatch_call_status;  /* dispatch response status */
+    ngx_str_t                                     response_status;       /* response status */
 #if (NGX_DEBUG)
-    ngx_str_t                                     worker_id;         /* ngx_worker */
+    ngx_str_t                                     worker_id;             /* ngx_worker */
 #endif
-    ngx_uint_t                                    call_code;
+    ngx_uint_t                                    dispatch_call_code;
     ngx_uint_t                                    response_code;
 
     /* host properties */
@@ -259,9 +259,9 @@ struct ngx_proxy_wasm_ctx_s {
 
     /* flags */
 
-    unsigned                                      main:1;            /* r->main */
-    unsigned                                      init:1;            /* can be utilized (has no filters) */
-    unsigned                                      ready:1;           /* filters chain ready */
+    unsigned                                      main:1;                /* r->main */
+    unsigned                                      init:1;                /* can be utilized (has no filters) */
+    unsigned                                      ready:1;               /* filters chain ready */
     unsigned                                      req_headers_in_access:1;
 };
 

--- a/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.c
@@ -1,0 +1,305 @@
+#ifndef DDEBUG
+#define DDEBUG 0
+#endif
+#include "ddebug.h"
+
+#if (NGX_WASM_LUA)
+#include <ngx_wasm_lua_resolver.h>
+#endif
+#include <ngx_proxy_wasm_foreign_call.h>
+
+
+void
+ngx_proxy_wasm_foreign_call_destroy(ngx_proxy_wasm_foreign_call_t *call)
+{
+    ngx_pfree(call->pwexec->pool, call);
+}
+
+
+#if (NGX_WASM_HTTP)
+#if (NGX_WASM_LUA)
+static void
+ngx_proxy_wasm_foreign_call(ngx_proxy_wasm_dispatch_op_t *dop)
+{
+    ngx_proxy_wasm_exec_t          *pwexec;
+    ngx_proxy_wasm_step_e           step;
+    ngx_proxy_wasm_foreign_call_t  *call;
+
+    ngx_wa_assert(dop->type == NGX_PROXY_WASM_DISPATCH_FOREIGN_CALL);
+
+    call = dop->call.foreign;
+    pwexec = call->pwexec;
+    pwexec->foreign_call = call;
+    step = pwexec->parent->step;
+
+    ngx_queue_remove(&dop->q);
+
+    pwexec->parent->phase = ngx_wasm_phase_lookup(&ngx_http_wasm_subsystem,
+                                                  NGX_WASM_BACKGROUND_PHASE);
+
+    ngx_proxy_wasm_run_step(pwexec, NGX_PROXY_WASM_STEP_FOREIGN_CALLBACK);
+
+    /* potential trap ignored as it's already logged and no futher handling is
+     * needed */
+
+    pwexec->parent->step = step;
+    pwexec->foreign_call = NULL;
+
+    if (ngx_proxy_wasm_dispatch_ops_total(pwexec)) {
+        ngx_log_debug0(NGX_LOG_DEBUG_WASM, pwexec->log, 0,
+                       "proxy_wasm more dispatch operations pending...");
+
+        ngx_wasm_yield(&call->rctx->env);
+        ngx_proxy_wasm_ctx_set_next_action(pwexec->parent,
+                                           NGX_PROXY_WASM_ACTION_PAUSE);
+
+    } else {
+        ngx_log_debug0(NGX_LOG_DEBUG_WASM, pwexec->log, 0,
+                       "proxy_wasm last foreign function callback handled");
+
+        ngx_wasm_continue(&call->rctx->env);
+        ngx_proxy_wasm_ctx_set_next_action(pwexec->parent,
+                                           NGX_PROXY_WASM_ACTION_CONTINUE);
+
+        ngx_proxy_wasm_resume(pwexec->parent, pwexec->parent->phase, step);
+    }
+
+    ngx_proxy_wasm_foreign_call_destroy(call);
+}
+
+
+static void
+ngx_proxy_wasm_hfuncs_resolve_lua_handler(ngx_resolver_ctx_t *rslv_ctx)
+{
+#if (NGX_HAVE_INET6)
+    struct sockaddr_in6            *sin6;
+#endif
+    struct sockaddr_in             *sin;
+    u_char                         *p;
+    u_short                         sa_family = AF_INET;
+    ngx_buf_t                      *b;
+    ngx_str_t                       args;
+    ngx_wasm_lua_ctx_t             *lctx;
+    ngx_wasm_socket_tcp_t          *sock = rslv_ctx->data;
+    ngx_proxy_wasm_dispatch_op_t   *dop = sock->data;
+    ngx_proxy_wasm_foreign_call_t  *call = dop->call.foreign;
+    u_char                          buf[rslv_ctx->name.len +
+#if (NGX_HAVE_INET6)
+                                        sizeof(struct in6_addr) + 1];
+#else
+                                        sizeof(struct in_addr) + 1];
+#endif
+
+    if (rslv_ctx->addr.socklen == sizeof(struct sockaddr_in6)) {
+        sa_family = AF_INET6;
+    }
+
+    lctx = sock->lctx;
+    p = buf;
+
+    ngx_memzero(buf, sizeof(buf));
+
+    if (rslv_ctx->state || !rslv_ctx->naddrs) {
+        p++;  /* buffer's 1st byte is address length; 0 if address not found */
+        goto not_found;
+    }
+
+    ngx_wa_assert(rslv_ctx->naddrs == 1);
+
+    switch (sa_family) {
+#if (NGX_HAVE_INET6)
+    case AF_INET6:
+          sin6 = (struct sockaddr_in6 *) rslv_ctx->addr.sockaddr;
+          *(p++) = sizeof(struct in6_addr);
+          p = ngx_cpymem(p, &sin6->sin6_addr, sizeof(struct in6_addr));
+          break;
+#endif
+    default: /* AF_INET */
+          sin = (struct sockaddr_in *) rslv_ctx->addr.sockaddr;
+          *(p++) = sizeof(struct in_addr);
+          p = ngx_cpymem(p, &sin->sin_addr, sizeof(struct in_addr));
+    }
+
+not_found:
+
+    p = ngx_cpymem(p, rslv_ctx->name.data, rslv_ctx->name.len);
+    args.data = buf;
+    args.len = p - buf;
+
+    call->args_out = ngx_wasm_chain_get_free_buf(call->pwexec->pool,
+                                                 &call->rctx->free_bufs,
+                                                 args.len, buf_tag, 1);
+
+    if (call->args_out == NULL) {
+        goto error;
+    }
+
+    b = call->args_out->buf;
+    b->last = ngx_cpymem(b->last, args.data, args.len);
+
+    if (lctx->yielded) {
+        ngx_proxy_wasm_foreign_call(dop);
+
+        if (rslv_ctx->state == NGX_WASM_LUA_RESOLVE_ERR) {
+            ngx_wasm_resume(&call->rctx->env);
+        }
+    }
+
+error:
+
+    ngx_free(rslv_ctx);
+}
+#endif  /* NGX_WASM_LUA */
+
+
+ngx_int_t
+ngx_proxy_wasm_foreign_call_resolve_lua(ngx_wavm_instance_t *instance,
+    ngx_http_wasm_req_ctx_t *rctx, ngx_str_t *fargs, ngx_wavm_ptr_t *ret_data,
+    int32_t *ret_size, wasm_val_t rets[])
+{
+    ngx_proxy_wasm_exec_t          *pwexec = ngx_proxy_wasm_instance2pwexec(
+                                                 instance);
+#if (NGX_WASM_LUA)
+    size_t                          s;
+    ngx_int_t                       rc;
+    ngx_buf_t                      *b;
+    ngx_resolver_ctx_t             *rslv_ctx;
+    ngx_wasm_core_conf_t           *wcf;
+    ngx_wasm_socket_tcp_t          *sock;
+    ngx_http_request_t             *r;
+    ngx_proxy_wasm_dispatch_op_t   *dop;
+    ngx_proxy_wasm_foreign_call_t  *call;
+    ngx_wavm_ptr_t                  p;
+
+    /* check context */
+
+    switch (pwexec->parent->step) {
+    case NGX_PROXY_WASM_STEP_REQ_HEADERS:
+    case NGX_PROXY_WASM_STEP_REQ_BODY:
+    case NGX_PROXY_WASM_STEP_TICK:
+    case NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE:
+    case NGX_PROXY_WASM_STEP_FOREIGN_CALLBACK:
+        break;
+    default:
+        return ngx_proxy_wasm_result_trap(pwexec,
+                                          "can only call resolve_lua "
+                                          "during "
+                                          "\"on_request_headers\", "
+                                          "\"on_request_body\", "
+                                          "\"on_tick\", "
+                                          "\"on_dispatch_response\", "
+                                          "\"on_foreign_function\"",
+                                          rets, NGX_WAVM_BAD_USAGE);
+    }
+
+    /* check name */
+
+    if (!fargs->len) {
+        return ngx_proxy_wasm_result_trap(pwexec,
+                                          "cannot resolve, missing name",
+                                          rets, NGX_WAVM_BAD_USAGE);
+    }
+
+
+    call = ngx_pcalloc(pwexec->pool, sizeof(ngx_proxy_wasm_foreign_call_t));
+    if (call == NULL) {
+        goto error;
+    }
+
+    call->pwexec = pwexec;
+    call->fcode = NGX_PROXY_WASM_FOREIGN_RESOLVE_LUA;
+
+    /* rctx or fake rctx */
+
+    if (rctx == NULL) {
+        if (ngx_http_wasm_create_fake_rctx(pwexec, &r, &call->rctx) != NGX_OK) {
+            goto error;
+        }
+
+
+    } else {
+        r = rctx->r;
+        call->rctx = rctx;
+    }
+
+    /* dispatch */
+
+    dop = ngx_pcalloc(pwexec->pool, sizeof(ngx_proxy_wasm_dispatch_op_t));
+    if (dop == NULL) {
+        goto error;
+    }
+
+    dop->type = NGX_PROXY_WASM_DISPATCH_FOREIGN_CALL;
+    dop->call.foreign = call;
+
+    sock = ngx_pcalloc(pwexec->pool, sizeof(ngx_wasm_socket_tcp_t));
+    if (sock == NULL) {
+        goto error;
+    }
+
+    sock->env = &call->rctx->env;
+    sock->log = pwexec->log;
+    sock->pool = pwexec->pool;
+    sock->data = dop;
+
+    /* resolve */
+
+    wcf = ngx_wasm_core_cycle_get_conf(ngx_cycle);
+    if (wcf == NULL) {
+        goto error;
+    }
+
+    rslv_ctx = ngx_resolve_start(wcf->resolver, NULL);
+    if (rslv_ctx == NULL || rslv_ctx == NGX_NO_RESOLVER) {
+        goto error;
+    }
+
+    rslv_ctx->name.data = fargs->data;
+    rslv_ctx->name.len = fargs->len;
+    rslv_ctx->handler = ngx_proxy_wasm_hfuncs_resolve_lua_handler;
+    rslv_ctx->data = sock;
+
+    rc = ngx_wasm_lua_resolver_resolve(rslv_ctx);
+
+    ngx_wa_assert(rc == NGX_OK || rc == NGX_AGAIN || rc == NGX_ERROR);
+
+    switch (rc) {
+    case NGX_OK:
+        b = call->args_out->buf;
+        s = *b->start;
+
+        p = ngx_proxy_wasm_alloc(pwexec, s);
+        if (!p) {
+            goto error;
+        }
+
+        if (!ngx_wavm_memory_memcpy(instance->memory, p, b->start + 1, s)) {
+            return ngx_proxy_wasm_result_invalid_mem(rets);
+        }
+
+        *ret_data = p;
+        *ret_size = s;
+
+        return ngx_proxy_wasm_result_ok(rets);
+
+    case NGX_AGAIN:
+        ngx_queue_insert_head(&pwexec->dispatch_ops, &dop->q);
+        return ngx_proxy_wasm_result_ok(rets);
+
+    default:  /* NGX_ERROR */
+        /* rslv_ctx is freed by ngx_wasm_lua_resolver_resolve */
+        break;
+    }
+
+error:
+
+    return ngx_proxy_wasm_result_trap(pwexec, "failed resolving name",
+                                      rets, NGX_WAVM_ERROR);
+#else
+
+    return ngx_proxy_wasm_result_trap(pwexec,
+                                      "cannot resolve, no lua support",
+                                      rets, NGX_WAVM_ERROR);
+#endif
+}
+#endif  /* NGX_WASM_HTTP */

--- a/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_foreign_call.h
@@ -1,0 +1,32 @@
+#ifndef _NGX_PROXY_WASM_FOREIGN_CALLBACK_H_INCLUDED_
+#define _NGX_PROXY_WASM_FOREIGN_CALLBACK_H_INCLUDED_
+
+
+#include <ngx_wavm.h>
+#include <ngx_wasm.h>
+#include <ngx_proxy_wasm.h>
+#include <ngx_wasm_subsystem.h>
+#ifdef NGX_WASM_HTTP
+#include <ngx_http_proxy_wasm.h>
+#endif
+
+
+struct ngx_proxy_wasm_foreign_call_s {
+    ngx_proxy_wasm_exec_t              *pwexec;
+#if (NGX_WASM_HTTP)
+    ngx_http_wasm_req_ctx_t            *rctx;
+#endif
+    ngx_proxy_wasm_foreign_function_e   fcode;
+    ngx_chain_t                        *args_out;
+};
+
+
+void ngx_proxy_wasm_foreign_call_destroy(ngx_proxy_wasm_foreign_call_t *call);
+
+
+#if (NGX_WASM_HTTP)
+ngx_int_t ngx_proxy_wasm_foreign_call_resolve_lua(ngx_wavm_instance_t *instance,
+    ngx_http_wasm_req_ctx_t *rctx, ngx_str_t *fargs, ngx_wavm_ptr_t *ret_data,
+    int32_t *ret_size, wasm_val_t rets[]);
+#endif
+#endif

--- a/src/common/proxy_wasm/ngx_proxy_wasm_host.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_host.c
@@ -127,7 +127,7 @@ ngx_proxy_wasm_get_buffer_helper(ngx_wavm_instance_t *instance,
 
             /* get */
 
-            call = pwexec->call;
+            call = pwexec->dispatch_call;
             if (call == NULL) {
                 return NULL;
             }

--- a/src/common/proxy_wasm/ngx_proxy_wasm_util.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_util.c
@@ -41,7 +41,8 @@ static ngx_str_t  ngx_proxy_wasm_steplist[] = {
     ngx_string("on_log"),
     ngx_string("on_done"),
     ngx_string("on_tick"),
-    ngx_string("on_dispatch_response")
+    ngx_string("on_dispatch_response"),
+    ngx_string("on_foreign_function")
 };
 
 
@@ -62,7 +63,7 @@ ngx_proxy_wasm_step_name(ngx_proxy_wasm_step_e step)
     ngx_str_t  *name;
 
     ngx_wa_assert(step);
-    ngx_wa_assert(step <= NGX_PROXY_WASM_STEP_DISPATCH_RESPONSE);
+    ngx_wa_assert(step <= NGX_PROXY_WASM_STEP_FOREIGN_CALLBACK);
 
     name = &ngx_proxy_wasm_steplist[step];
 

--- a/src/http/ngx_http_wasm_util.c
+++ b/src/http/ngx_http_wasm_util.c
@@ -632,7 +632,7 @@ ngx_http_wasm_init_fake_connection(ngx_connection_t *c)
 }
 
 
-static ngx_connection_t *
+ngx_connection_t *
 ngx_http_wasm_create_fake_connection(ngx_pool_t *pool)
 {
 #if 0
@@ -725,7 +725,7 @@ ngx_http_wasm_cleanup_nop(void *data)
 #endif
 
 
-static ngx_http_request_t *
+ngx_http_request_t *
 ngx_http_wasm_create_fake_request(ngx_connection_t *c)
 {
     ngx_http_request_t     *r;

--- a/src/http/ngx_http_wasm_util.h
+++ b/src/http/ngx_http_wasm_util.h
@@ -27,9 +27,9 @@ ngx_int_t ngx_http_wasm_ops_add_filter(ngx_wasm_ops_plan_t *plan,
     ngx_str_t *name, ngx_str_t *config, ngx_wavm_t *vm);
 
 /* fake requests */
-ngx_connection_t *ngx_http_wasm_create_fake_connection(ngx_pool_t *pool);
-ngx_http_request_t *ngx_http_wasm_create_fake_request(ngx_connection_t *c);
 void ngx_http_wasm_finalize_fake_request(ngx_http_request_t *r, ngx_int_t rc);
+ngx_int_t ngx_http_wasm_create_fake_rctx(ngx_proxy_wasm_exec_t *pwexec,
+    ngx_http_request_t **r_out, ngx_http_wasm_req_ctx_t **out);
 
 
 #endif /* _NGX_HTTP_WASM_UTIL_H_INCLUDED_ */

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm.c
@@ -316,7 +316,7 @@ ngx_http_proxy_wasm_on_dispatch_response(ngx_proxy_wasm_exec_t *pwexec)
     ngx_uint_t                       n_headers, body_len;
     ngx_list_part_t                 *part;
     ngx_proxy_wasm_filter_t         *filter = pwexec->filter;
-    ngx_http_proxy_wasm_dispatch_t  *call = pwexec->call;
+    ngx_http_proxy_wasm_dispatch_t  *call = pwexec->dispatch_call;
     ngx_http_wasm_req_ctx_t         *rctx = call->rctx;
 
     n_headers = 0;

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -63,7 +63,7 @@ invoke_on_http_dispatch_response(ngx_proxy_wasm_exec_t *pwexec,
      * Set current call for subsequent call detection after the step
      * (no yielding).
      */
-    pwexec->call = call;
+    pwexec->dispatch_call = call;
 
     /**
      * Save step: ngx_proxy_wasm_run_step will set pwctx->step (for host
@@ -92,7 +92,7 @@ invoke_on_http_dispatch_response(ngx_proxy_wasm_exec_t *pwexec,
     pwexec->parent->step = step;
 
     /* remove current call now that callback was invoked */
-    pwexec->call = NULL;
+    pwexec->dispatch_call = NULL;
 
     return NGX_OK;
 }
@@ -161,7 +161,7 @@ ngx_http_proxy_wasm_dispatch_err(ngx_http_proxy_wasm_dispatch_t *call,
 
     ngx_http_proxy_wasm_dispatch_destroy(call);
 
-    pwexec->call = NULL;
+    pwexec->dispatch_call = NULL;
 }
 
 
@@ -430,7 +430,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 
     call->ev = ev;
 
-    ngx_queue_insert_head(&pwexec->calls, &call->q);
+    ngx_queue_insert_head(&pwexec->dispatch_calls, &call->q);
 
     ngx_proxy_wasm_ctx_set_next_action(pwctx, NGX_PROXY_WASM_ACTION_PAUSE);
 

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -199,7 +199,6 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
 #if 0
     ngx_pool_cleanup_t              *cln;
 #endif
-    ngx_connection_t                *c;
     ngx_http_request_t              *r;
     ngx_http_wasm_req_ctx_t         *rctxp = NULL;
     ngx_http_proxy_wasm_dispatch_t  *call = NULL;
@@ -209,26 +208,9 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
     /* rctx or fake request */
 
     if (rctx == NULL) {
-        ngx_wa_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
-        ngx_wa_assert(pwexec->parent->id == NGX_PROXY_WASM_ROOT_CTX_ID);
-
-        c = ngx_http_wasm_create_fake_connection(pwexec->pool);
-        if (c == NULL) {
-            return NULL;
+        if (ngx_http_wasm_create_fake_rctx(pwexec, &r, &rctxp) != NGX_OK) {
+            goto error;
         }
-
-        r = ngx_http_wasm_create_fake_request(c);
-        if (r == NULL) {
-            return NULL;
-        }
-
-        if (ngx_http_wasm_rctx(r, &rctxp) != NGX_OK) {
-            return NULL;
-        }
-
-        ngx_wa_assert(r->pool == rctxp->pool);
-
-        rctxp->data = pwexec->parent;
 
     } else {
         r = rctx->r;

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
@@ -29,7 +29,6 @@ typedef enum {
 
 struct ngx_http_proxy_wasm_dispatch_s {
     ngx_pool_t                             *pool;  /* owned */
-    ngx_queue_t                             q;     /* stored by caller */
     uint32_t                                id;
     ngx_msec_t                              timeout;
     ngx_wasm_socket_tcp_t                   sock;

--- a/src/wasm/vm/ngx_wavm_host.h
+++ b/src/wasm/vm/ngx_wavm_host.h
@@ -50,7 +50,7 @@ extern const wasm_valkind_t *ngx_wavm_arity_i32x5_i64x2_i32x2[];
 /* hfuncs */
 
 
-#define NGX_WAVM_HFUNCS_MAX_TRAP_LEN   128
+#define NGX_WAVM_HFUNCS_MAX_TRAP_LEN   256
 
 #define ngx_wavm_hfunc_null            { ngx_null_string, NULL, NULL, NULL }
 

--- a/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
+++ b/t/03-proxy_wasm/hfuncs/133-proxy_dispatch_http_edge_cases.t
@@ -147,7 +147,7 @@ qr/\A.*? on_request_headers.*
 .*? on_response_body.*
 .*? on_log/
 --- error_log eval
-qr/\[notice\] .*? local response produced, cancelling pending dispatch calls/
+qr/\[notice\] .*? local response produced, cancelling pending dispatch operations/
 --- no_error_log
 [error]
 

--- a/t/03-proxy_wasm/hfuncs/140-proxy_call_foreign_function.t
+++ b/t/03-proxy_wasm/hfuncs/140-proxy_call_foreign_function.t
@@ -1,0 +1,41 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX;
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - call_foreign_function(), unknown function
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/call_foreign_function \
+                              name=foo';
+    }
+--- error_code: 500
+--- error_log eval
+qr/host trap \(internal error\): unknown foreign function/
+--- no_error_log
+[crit]
+[emerg]
+
+
+
+=== TEST 2: proxy_wasm - call_foreign_function(), known function
+--- skip_eval: 4: $::nginxV =~ m/openresty/
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/call_foreign_function \
+                              name=resolve_lua';
+    }
+--- error_code: 500
+--- error_log eval
+qr/host trap \(internal error\): cannot resolve, no lua support/
+--- no_error_log
+[crit]
+[emerg]

--- a/t/03-proxy_wasm/hfuncs/contexts/002-set_tick_period.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/002-set_tick_period.t
@@ -180,3 +180,20 @@ can only set tick_period in root context
 --- no_error_log
 [crit]
 [alert]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_tick_period on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_tick_period';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+can only set tick_period in root context
+--- no_error_log
+[crit]
+[alert]

--- a/t/03-proxy_wasm/hfuncs/contexts/100-proxy_log.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/100-proxy_log.t
@@ -187,3 +187,20 @@ proxy_log msg
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - proxy_log on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=proxy_log';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+proxy_log msg
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/107-proxy_add_http_request_header.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/107-proxy_add_http_request_header.t
@@ -183,3 +183,20 @@ should not be retrievable after on_response_body since buffers are consumed
 can only set request headers before response is produced
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - add_http_request_header on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=add_request_header|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set request headers before response is produced
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/108-proxy_add_http_response_header.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/108-proxy_add_http_response_header.t
@@ -267,3 +267,20 @@ add_response_header status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 14: proxy_wasm contexts - add_http_response_header on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=add_response_header|:foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers before "on_response_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/109-proxy_set_http_request_headers.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/109-proxy_set_http_request_headers.t
@@ -183,3 +183,20 @@ should not be retrievable after on_response_body since buffers are consumed
 can only set request headers before response is produced
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_request_headers on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_request_headers|foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set request headers before response is produced
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/110-proxy_set_http_response_headers.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/110-proxy_set_http_response_headers.t
@@ -267,3 +267,20 @@ set_response_headers status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 14: proxy_wasm contexts - set_http_response_headers on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_response_headers|:foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers before "on_response_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/111-proxy_set_http_request_header.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/111-proxy_set_http_request_header.t
@@ -184,3 +184,20 @@ should not be retrievable after on_response_body since buffers are consumed
 can only set request headers before response is produced
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_request_header on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_request_header|:foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set request headers before response is produced
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/112-proxy_set_http_response_header.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/112-proxy_set_http_response_header.t
@@ -267,3 +267,20 @@ set_response_header status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 14: proxy_wasm contexts - set_http_response_header on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_response_header|:foo=bar';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response headers before "on_response_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/113-proxy_get_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/113-proxy_get_http_request_body.t
@@ -186,3 +186,20 @@ get_request_body_buffer status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - get_http_request_body on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=get_request_body_buffer';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only get request body during "on_request_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/114-proxy_set_http_request_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/114-proxy_set_http_request_body.t
@@ -182,3 +182,20 @@ can only set request body during "on_request_body"
 can only set request body during "on_request_body"
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_request_body on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_request_body_buffer';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set request body during "on_request_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/115-proxy_get_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/115-proxy_get_http_response_body.t
@@ -185,3 +185,20 @@ get_response_body_buffer status: 0
 can only get response body during "on_response_body"
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_response_body on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=get_response_body_buffer';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only get response body during "on_response_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/116-proxy_set_http_response_body.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/116-proxy_set_http_response_body.t
@@ -185,3 +185,20 @@ should not be retrievable after on_response_body since buffers are consumed
 can only set response body during "on_response_body"
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - set_http_response_body on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=set_response_body_buffer';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only set response body during "on_response_body"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/130-proxy_dispatch_http.t
@@ -25,7 +25,7 @@ __DATA__
 --- must_die: 0
 --- error_log
 [error]
-can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_dispatch_response", "on_tick"
+can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
 --- no_error_log
 [crit]
 
@@ -41,7 +41,7 @@ can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_
 --- must_die: 0
 --- error_log
 [error]
-can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_dispatch_response", "on_tick"
+can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
 --- no_error_log
 [crit]
 
@@ -132,7 +132,7 @@ dispatch failed: no :method
 --- ignore_response_body
 --- error_log
 [error]
-can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_dispatch_response", "on_tick"
+can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
 --- no_error_log
 [crit]
 
@@ -149,7 +149,7 @@ can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_
 --- ignore_response_body
 --- error_log
 [error]
-can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_dispatch_response", "on_tick"
+can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
 --- no_error_log
 [crit]
 
@@ -164,6 +164,23 @@ can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_
     }
 --- error_log
 [error]
-can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_dispatch_response", "on_tick"
+can only send HTTP dispatch during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - dispatch_http_call on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=dispatch_http_call';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+dispatch failed: no :method
 --- no_error_log
 [crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/140-proxy_foreign_function_resolve_lua.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/140-proxy_foreign_function_resolve_lua.t
@@ -167,3 +167,19 @@ can only call resolve_lua during "on_request_headers", "on_request_body", "on_ti
 can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
 --- no_error_log
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - call_resolve_lua on_foreign_function
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=call_resolve_lua';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+cannot resolve, missing name
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/140-proxy_foreign_function_resolve_lua.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/140-proxy_foreign_function_resolve_lua.t
@@ -1,0 +1,169 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX::Lua;
+
+skip_hup();
+skip_no_debug();
+skip_no_openresty();
+
+plan_tests(4);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm contexts - call_resolve_lua on_vm_start
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm 'call_resolve_lua';
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks;
+        return 200;
+    }
+--- must_die: 0
+--- error_log
+[error]
+can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 2: proxy_wasm contexts - call_resolve_lua on_configure
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_configure=call_resolve_lua';
+        return 200;
+    }
+--- must_die: 0
+--- error_log
+[error]
+can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 3: proxy_wasm contexts - call_resolve_lua on_tick
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_tick=call_resolve_lua';
+        return 200;
+    }
+--- error_log
+[error]
+cannot resolve, missing name
+--- no_error_log
+[crit]
+
+
+
+=== TEST 4: proxy_wasm contexts - call_resolve_lua on_http_dispatch_response
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_http_dispatch_response=call_resolve_lua \
+                                   host=127.0.0.1:$TEST_NGINX_SERVER_PORT';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- error_log
+[error]
+cannot resolve, missing name
+--- no_error_log
+[crit]
+
+
+
+=== TEST 5: proxy_wasm contexts - call_resolve_lua on_request_headers
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_headers=call_resolve_lua';
+        return 200;
+    }
+--- error_code: 500
+--- ignore_response_body
+--- error_log
+[error]
+cannot resolve, missing name
+--- no_error_log
+[crit]
+
+
+
+=== TEST 6: proxy_wasm contexts - call_resolve_lua on_request_body
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_request_body=call_resolve_lua';
+        echo ok;
+    }
+--- request
+POST /t
+payload
+--- error_code: 500
+--- ignore_response_body
+--- error_log
+[error]
+cannot resolve, missing name
+--- no_error_log
+[crit]
+
+
+
+=== TEST 7: proxy_wasm contexts - call_resolve_lua on_response_headers
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_headers=call_resolve_lua';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 8: proxy_wasm contexts - call_resolve_lua on_response_body
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_response_body=call_resolve_lua';
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log
+[error]
+can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]
+
+
+
+=== TEST 9: proxy_wasm contexts - call_resolve_lua on_log
+--- wasm_modules: context_checks
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_log=call_resolve_lua';
+        return 200;
+    }
+--- error_log
+[error]
+can only call resolve_lua during "on_request_headers", "on_request_body", "on_tick", "on_dispatch_response", "on_foreign_function"
+--- no_error_log
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/metrics/001-proxy_define_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/metrics/001-proxy_define_metric.t
@@ -185,3 +185,23 @@ define_metric status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - define_metric on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=define_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+define_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/metrics/010-proxy_increment_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/metrics/010-proxy_increment_metric.t
@@ -183,3 +183,23 @@ increment_metric status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - increment_metric on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=increment_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+increment_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/metrics/020-proxy_record_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/metrics/020-proxy_record_metric.t
@@ -183,3 +183,23 @@ record_metric status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - record_metric on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=record_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+record_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/contexts/metrics/030-proxy_get_metric.t
+++ b/t/03-proxy_wasm/hfuncs/contexts/metrics/030-proxy_get_metric.t
@@ -183,3 +183,23 @@ get_metric status: 0
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 10: proxy_wasm contexts - get_metric on_foreign_function
+--- skip_eval: 4: $::nginxV !~ m/openresty/
+--- main_config
+    wasm {
+        module context_checks $TEST_NGINX_CRATES_DIR/context_checks.wasm;
+    }
+--- config
+    location /t {
+        proxy_wasm context_checks 'on_foreign_function=get_metric';
+        return 200;
+    }
+--- ignore_response_body
+--- error_log
+get_metric status: 0
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/foreign/001-resolve_lua.t
+++ b/t/03-proxy_wasm/hfuncs/foreign/001-resolve_lua.t
@@ -1,0 +1,188 @@
+# vim:set ft= ts=4 sts=4 sw=4 et fdm=marker:
+
+use strict;
+use lib '.';
+use t::TestWasmX::Lua;
+
+skip_no_openresty();
+
+plan_tests(5);
+run_tests();
+
+__DATA__
+
+=== TEST 1: proxy_wasm - resolve_lua, NXDOMAIN
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=foo';
+        return 200;
+    }
+--- error_log eval
+qr/could not resolve foo/
+--- no_error_log
+[crit]
+[emerg]
+[stub]
+
+
+
+=== TEST 2: proxy_wasm - resolve_lua (no yielding)
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=localhost';
+        return 200;
+    }
+--- error_log eval
+qr/resolved \(no yielding\) localhost to \[127, 0, 0, 1\]/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 3: proxy_wasm - resolve_lua (yielding)
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=httpbin.org';
+        return 200;
+    }
+--- error_log eval
+qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 4: proxy_wasm - resolve_lua, IPv6 record
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=ipv6.google.com';
+        return 200;
+    }
+--- error_log eval
+qr/resolved \(yielding\) ipv6\.google\.com to \[\d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+, \d+\]/
+--- no_error_log
+[error]
+[crit]
+[emerg]
+
+
+
+=== TEST 5: proxy_wasm - resolve_lua, multiple calls (yielding)
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=httpbin.org,wikipedia.org';
+        return 200;
+    }
+--- error_log eval
+[
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/,
+    qr/resolved \(yielding\) wikipedia\.org to \[\d+, \d+, \d+, \d+\]/
+]
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 6: proxy_wasm - resolve_lua, multiple calls (mixed)
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm_lua_resolver on;
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              name=localhost,httpbin.org';
+        return 200;
+    }
+--- error_log eval
+[
+    qr/resolved \(no yielding\) localhost to \[127, 0, 0, 1\]/,
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/
+]
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 7: proxy_wasm - resolve_lua, on_tick
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=500 \
+                              on_tick=resolve_lua \
+                              name=localhost,httpbin.org';
+        return 200;
+    }
+--- error_log eval
+[
+    qr/resolved \(no yielding\) localhost to \[127, 0, 0, 1\]/,
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/
+]
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 8: proxy_wasm - resolve_lua, on_http_call_response
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatch \
+                              on_http_call_response=resolve_lua \
+                              name=httpbin.org,wikipedia.org';
+        return 200;
+    }
+
+    location /dispatch {
+        return 200;
+    }
+--- error_log eval
+[
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/,
+    qr/resolved \(yielding\) wikipedia\.org to \[\d+, \d+, \d+, \d+\]/
+]
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 9: proxy_wasm - resolve_lua, on_foreign_function
+--- wasm_modules: hostcalls
+--- config
+    location /t {
+        proxy_wasm hostcalls 'test=/t/resolve_lua \
+                              on_foreign_function=resolve_lua \
+                              name=httpbin.org';
+        return 200;
+    }
+--- error_log eval
+[
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/,
+    qr/resolved \(yielding\) httpbin\.org to \[\d+, \d+, \d+, \d+\]/
+]
+--- no_error_log
+[error]
+[crit]

--- a/t/lib/Cargo.lock
+++ b/t/lib/Cargo.lock
@@ -129,7 +129,7 @@ name = "context-checks"
 version = "0.1.0"
 dependencies = [
  "log",
- "proxy-wasm 0.2.2",
+ "proxy-wasm 0.2.3-dev",
 ]
 
 [[package]]

--- a/t/lib/Cargo.lock
+++ b/t/lib/Cargo.lock
@@ -157,6 +157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +176,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "getrandom"
@@ -208,6 +220,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,7 +243,7 @@ dependencies = [
  "enum-utils",
  "http",
  "log",
- "proxy-wasm 0.2.2",
+ "proxy-wasm 0.2.3-dev",
  "urlencoding",
 ]
 
@@ -352,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14a5a4df5a1ab77235e36a0a0f638687ee1586d21ee9774037693001e94d4e11"
 dependencies = [
  "hashbrown 0.14.5",
+ "log",
+]
+
+[[package]]
+name = "proxy-wasm"
+version = "0.2.3-dev"
+source = "git+https://github.com/kong/proxy-wasm-rust-sdk.git?branch=main#e58dd9395904f611c8a71d75517a882c92e65979"
+dependencies = [
+ "hashbrown 0.15.1",
  "log",
 ]
 

--- a/t/lib/proxy-wasm-tests/context-checks/Cargo.toml
+++ b/t/lib/proxy-wasm-tests/context-checks/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-proxy-wasm = "0.2"
+proxy-wasm = { git = "https://github.com/kong/proxy-wasm-rust-sdk.git", branch = "main" }
 log = "0.4"

--- a/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use log::*;
 use proxy_wasm::types::*;
-use std::ptr::{null, null_mut};
+use std::ptr::null_mut;
 
 #[allow(improper_ctypes)]
 extern "C" {
@@ -468,15 +468,21 @@ extern "C" {
     ) -> Status;
 }
 
-pub fn call_resolve_lua(_ctx: &TestContext) {
-    let name = "resolve_lua";
+pub fn call_resolve_lua(_ctx: &TestContext, name: &str) {
+    let f_name = "resolve_lua";
 
     let mut ret_data: *mut u8 = null_mut();
     let mut ret_size: usize = 0;
 
     unsafe {
         let status = proxy_call_foreign_function(
-            name.as_ptr(), name.len(), null(), 0, &mut ret_data, &mut ret_size);
+            f_name.as_ptr(),
+            f_name.len(),
+            name.as_ptr(),
+            name.len(),
+            &mut ret_data,
+            &mut ret_size,
+        );
 
         info!("resolve_lua status: {}", status as u32);
     }

--- a/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/hostcalls.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use log::*;
 use proxy_wasm::types::*;
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 #[allow(improper_ctypes)]
 extern "C" {
@@ -453,5 +453,31 @@ pub fn increment_metric(_ctx: &TestContext) {
         proxy_define_metric(metric_type, name.as_ptr(), name.len(), &mut metric_id);
         let status = proxy_increment_metric(metric_id, 1);
         info!("increment_metric status: {}", status as u32);
+    }
+}
+
+#[allow(improper_ctypes)]
+extern "C" {
+    fn proxy_call_foreign_function(
+        function_name_data: *const u8,
+        function_name_size: usize,
+        arguments_data: *const u8,
+        arguments_size: usize,
+        results_data: *mut *mut u8,
+        results_size: *mut usize,
+    ) -> Status;
+}
+
+pub fn call_resolve_lua(_ctx: &TestContext) {
+    let name = "resolve_lua";
+
+    let mut ret_data: *mut u8 = null_mut();
+    let mut ret_size: usize = 0;
+
+    unsafe {
+        let status = proxy_call_foreign_function(
+            name.as_ptr(), name.len(), null(), 0, &mut ret_data, &mut ret_size);
+
+        info!("resolve_lua status: {}", status as u32);
     }
 }

--- a/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
@@ -23,6 +23,7 @@ impl TestContext {
             "increment_metric" => increment_metric(self),
             "record_metric" => record_metric(self),
             "get_metric" => get_metric(self),
+            "call_resolve_lua" => call_resolve_lua(self),
             "set_tick_period" => set_tick_period(self),
             "add_request_header" => add_request_header(self, arg),
             "add_response_header" => add_response_header(self, arg),

--- a/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/context-checks/src/lib.rs
@@ -23,7 +23,7 @@ impl TestContext {
             "increment_metric" => increment_metric(self),
             "record_metric" => record_metric(self),
             "get_metric" => get_metric(self),
-            "call_resolve_lua" => call_resolve_lua(self),
+            "call_resolve_lua" => call_resolve_lua(self, arg),
             "set_tick_period" => set_tick_period(self),
             "add_request_header" => add_request_header(self, arg),
             "add_response_header" => add_response_header(self, arg),
@@ -89,6 +89,11 @@ impl HttpContext for TestHttp {
             }
 
             return Action::Pause;
+        } else if self.tester.get_config("on_foreign_function").is_some() {
+            self.tester
+                .check_host_function("call_resolve_lua|httpbin.org");
+
+            return Action::Pause;
         }
 
         Action::Continue
@@ -145,6 +150,17 @@ impl Context for TestHttp {
         );
 
         if let Some(name) = self.tester.get_config("on_http_dispatch_response") {
+            self.tester.check_host_function(name);
+        }
+    }
+
+    fn on_foreign_function(&mut self, function_id: u32, args_size: usize) {
+        info!(
+            "on_foreign_function (id: {}, args_size: {})",
+            function_id, args_size
+        );
+
+        if let Some(name) = self.tester.get_config("on_foreign_function") {
             self.tester.check_host_function(name);
         }
     }

--- a/t/lib/proxy-wasm-tests/hostcalls/Cargo.toml
+++ b/t/lib/proxy-wasm-tests/hostcalls/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-proxy-wasm = "0.2"
+proxy-wasm = { git = "https://github.com/kong/proxy-wasm-rust-sdk.git", branch = "main" }
 log = "0.4"
 http = "1.2"
 enum-utils = "0.1.2"

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -1,7 +1,8 @@
-use crate::{test_http::*, types::*};
+use crate::{test_http::*, types::*, tests::*, foreign_callbacks::*};
 use http::StatusCode;
 use log::*;
-use proxy_wasm::{traits::*, types::*};
+use proxy_wasm::{traits::*, types::*, hostcalls::*};
+
 
 impl Context for TestHttp {
     fn on_http_call_response(
@@ -109,10 +110,40 @@ impl Context for TestHttp {
                     Some(format!("called {} times", self.n_sync_calls + 1).as_str()),
                 );
             }
+            "resolve_lua" => {
+                self.pending_callbacks = test_proxy_resolve_lua(self);
+                if self.pending_callbacks > 0 {
+                    return;
+                }
+            }
             _ => {}
         }
 
         self.resume_http_request()
+    }
+
+    fn on_foreign_function(&mut self, function_id: u32, args_size: usize) {
+        info!("[hostcalls] on_foreign_function!");
+
+        let f: WasmxForeignFunction = unsafe { ::std::mem::transmute(function_id) };
+        let args = get_buffer(BufferType::CallData, 0, args_size).unwrap();
+
+        match f {
+            WasmxForeignFunction::ResolveLua => {
+                resolve_lua_callback(args);
+            }
+        }
+
+        match self.get_config("on_foreign_function").unwrap_or("") {
+            "resolve_lua" => { test_proxy_resolve_lua(self); }
+            _ => (),
+        }
+
+        self.pending_callbacks -= 1;
+
+        if self.pending_callbacks == 0 {
+            self.send_plain_response(StatusCode::OK, Some("resolved"));
+        }
     }
 
     fn on_done(&mut self) -> bool {

--- a/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/filter.rs
@@ -1,8 +1,7 @@
-use crate::{test_http::*, types::*, tests::*, foreign_callbacks::*};
+use crate::{foreign_callbacks::*, test_http::*, tests::*, types::*};
 use http::StatusCode;
 use log::*;
-use proxy_wasm::{traits::*, types::*, hostcalls::*};
-
+use proxy_wasm::{hostcalls::*, traits::*, types::*};
 
 impl Context for TestHttp {
     fn on_http_call_response(
@@ -135,7 +134,9 @@ impl Context for TestHttp {
         }
 
         match self.get_config("on_foreign_function").unwrap_or("") {
-            "resolve_lua" => { test_proxy_resolve_lua(self); }
+            "resolve_lua" => {
+                test_proxy_resolve_lua(self);
+            }
             _ => (),
         }
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/foreign_callbacks/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/foreign_callbacks/mod.rs
@@ -1,0 +1,18 @@
+use log::*;
+
+pub fn resolve_lua_callback(args: Option<Vec<u8>>) {
+    match args {
+        Some(args) => {
+            let address_size = args[0] as usize;
+            let name = std::str::from_utf8(&args[(address_size + 1)..]).unwrap();
+
+            if address_size > 0 {
+                let address = &args[1..address_size + 1];
+                info!("resolved (yielding) {} to {:?}", name, address);
+            } else {
+                info!("could not resolve {}", name)
+            }
+        }
+        _ => info!("empty args")
+    }
+}

--- a/t/lib/proxy-wasm-tests/hostcalls/src/foreign_callbacks/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/foreign_callbacks/mod.rs
@@ -13,6 +13,6 @@ pub fn resolve_lua_callback(args: Option<Vec<u8>>) {
                 info!("could not resolve {}", name)
             }
         }
-        _ => info!("empty args")
+        _ => info!("empty args"),
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::single_match)]
 
 mod filter;
+mod foreign_callbacks;
 mod tests;
 mod types;
-mod foreign_callbacks;
 
-use crate::{tests::*, types::test_http::*, types::test_root::*, types::*, foreign_callbacks::*};
+use crate::{foreign_callbacks::*, tests::*, types::test_http::*, types::test_root::*, types::*};
 use log::*;
-use proxy_wasm::{traits::*, types::*, hostcalls::*};
+use proxy_wasm::{hostcalls::*, traits::*, types::*};
 use std::{collections::BTreeMap, collections::HashMap, time::Duration};
 
 proxy_wasm::main! {{
@@ -127,13 +127,11 @@ impl RootContext for TestRoot {
                 for name in names.split(",") {
                     info!("attempting to resolve {}", name);
                     match call_foreign_function("resolve_lua", Some(name.as_bytes())) {
-                        Ok(ret) => {
-                            match ret {
-                                Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
-                                _ => ()
-                            }
-                        }
-                        _ => ()
+                        Ok(ret) => match ret {
+                            Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
+                            _ => (),
+                        },
+                        _ => (),
                     }
                 }
             }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -3,10 +3,11 @@
 mod filter;
 mod tests;
 mod types;
+mod foreign_callbacks;
 
-use crate::{tests::*, types::test_http::*, types::test_root::*, types::*};
+use crate::{tests::*, types::test_http::*, types::test_root::*, types::*, foreign_callbacks::*};
 use log::*;
-use proxy_wasm::{traits::*, types::*};
+use proxy_wasm::{traits::*, types::*, hostcalls::*};
 use std::{collections::BTreeMap, collections::HashMap, time::Duration};
 
 proxy_wasm::main! {{
@@ -116,6 +117,26 @@ impl RootContext for TestRoot {
                 self.n_sync_calls += 1;
             }
             "set_property" => test_set_property(self),
+            "resolve_lua" => {
+                let names = self
+                    .config
+                    .get("name")
+                    .map(|x| x.as_str())
+                    .expect("expected a name argument");
+
+                for name in names.split(",") {
+                    info!("attempting to resolve {}", name);
+                    match call_foreign_function("resolve_lua", Some(name.as_bytes())) {
+                        Ok(ret) => {
+                            match ret {
+                                Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
+                                _ => ()
+                            }
+                        }
+                        _ => ()
+                    }
+                }
+            }
             "dispatch" => {
                 let mut timeout = Duration::from_secs(0);
                 let mut headers = Vec::new();
@@ -203,6 +224,7 @@ impl RootContext for TestRoot {
             on_phases: phases,
             metrics: self.metrics.clone(),
             n_sync_calls: 0,
+            pending_callbacks: 0,
         }))
     }
 }
@@ -226,6 +248,19 @@ impl Context for TestRoot {
         match dispatch_status.as_deref() {
             Some(s) => info!("dispatch_status: {}", s),
             None => {}
+        }
+    }
+
+    fn on_foreign_function(&mut self, function_id: u32, args_size: usize) {
+        info!("[hostcalls] on_foreign_function!");
+
+        let f: WasmxForeignFunction = unsafe { ::std::mem::transmute(function_id) };
+        let args = get_buffer(BufferType::CallData, 0, args_size).unwrap();
+
+        match f {
+            WasmxForeignFunction::ResolveLua => {
+                resolve_lua_callback(args);
+            }
         }
     }
 }

--- a/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
@@ -707,15 +707,13 @@ pub(crate) fn test_proxy_resolve_lua(ctx: &TestHttp) -> u32 {
     for name in names.split(",") {
         info!("attempting to resolve {}", name);
         match call_foreign_function("resolve_lua", Some(name.as_bytes())) {
-            Ok(ret) => {
-                match ret {
-                    Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
-                    _ => {
-                        pending_callbacks += 1;
-                    }
+            Ok(ret) => match ret {
+                Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
+                _ => {
+                    pending_callbacks += 1;
                 }
-            }
-            _ => ()
+            },
+            _ => (),
         }
     }
 

--- a/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/tests/mod.rs
@@ -695,3 +695,29 @@ pub(crate) fn test_proxy_get_header_map_value_misaligned_return_data(_ctx: &Test
         );
     }
 }
+
+pub(crate) fn test_proxy_resolve_lua(ctx: &TestHttp) -> u32 {
+    let mut pending_callbacks = 0;
+    let names = ctx
+        .config
+        .get("name")
+        .map(|x| x.as_str())
+        .expect("expected a name argument");
+
+    for name in names.split(",") {
+        info!("attempting to resolve {}", name);
+        match call_foreign_function("resolve_lua", Some(name.as_bytes())) {
+            Ok(ret) => {
+                match ret {
+                    Some(bytes) => info!("resolved (no yielding) {} to {:?}", name, bytes),
+                    _ => {
+                        pending_callbacks += 1;
+                    }
+                }
+            }
+            _ => ()
+        }
+    }
+
+    return pending_callbacks;
+}

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/mod.rs
@@ -16,6 +16,11 @@ pub enum TestPhase {
     Log,
 }
 
+#[repr(u32)]
+pub enum WasmxForeignFunction {
+    ResolveLua = 0,
+}
+
 pub trait TestContext {
     fn get_config(&self, name: &str) -> Option<&str>;
     fn get_metrics_mapping(&self) -> &BTreeMap<String, u32>;

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -8,6 +8,7 @@ pub struct TestHttp {
     pub config: HashMap<String, String>,
     pub metrics: BTreeMap<String, u32>,
     pub n_sync_calls: usize,
+    pub pending_callbacks: u32,
 }
 
 impl TestHttp {
@@ -148,6 +149,26 @@ impl TestHttp {
                 let h_id =
                     define_metric(MetricType::Histogram, "h1").expect("cannot define new metric");
                 get_metric(h_id).unwrap();
+            }
+
+            /* foreign functions */
+            "/t/call_foreign_function" => {
+                let name = self.config.get("name").expect("expected a name argument");
+
+                let ret = match self.config.get("arg") {
+                    Some(arg) => call_foreign_function(name, Some((&arg).as_bytes())).unwrap(),
+                    None => call_foreign_function(name, None).unwrap(),
+                }.unwrap();
+
+                info!("foreign function {} returned {:?}", name, ret);
+            }
+            "/t/resolve_lua" => {
+                self.pending_callbacks = test_proxy_resolve_lua(self);
+
+                if self.pending_callbacks > 0 {
+                    return Action::Pause
+                }
+
             }
 
             /* errors */

--- a/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/types/test_http.rs
@@ -158,7 +158,8 @@ impl TestHttp {
                 let ret = match self.config.get("arg") {
                     Some(arg) => call_foreign_function(name, Some((&arg).as_bytes())).unwrap(),
                     None => call_foreign_function(name, None).unwrap(),
-                }.unwrap();
+                }
+                .unwrap();
 
                 info!("foreign function {} returned {:?}", name, ret);
             }
@@ -166,9 +167,8 @@ impl TestHttp {
                 self.pending_callbacks = test_proxy_resolve_lua(self);
 
                 if self.pending_callbacks > 0 {
-                    return Action::Pause
+                    return Action::Pause;
                 }
-
             }
 
             /* errors */

--- a/util/morestyle.pl
+++ b/util/morestyle.pl
@@ -209,6 +209,10 @@ for my $file (@ARGV) {
                 } elsif ($line =~ /^\s+[\+\-\*\/] [\s\w\(\)\+\-\*\/\.\-\>]/) {
                     # ignoring line with a portion of a wrapped expression
 
+                } elsif ($line =~ /^\s+(\w+(, )?)+\);/) {
+                    # ignoring line with arguments wrapped from previous line
+                    # TODO: ensure arguments' leading spaces are correct
+
                 } elsif (!$cur_line_is_empty) {
                     if ($n_vars > 0 && $min_var_space - $max_var_type > 3) {
                         var_output "excessive spacing in variable alignment: needs 2 spaces from longest type to first name/pointer.";


### PR DESCRIPTION
### Foreign Function Support

The Proxy-Wasm [spec](https://github.com/proxy-wasm/spec/tree/main/abi-versions/v0.2.1#foreign-function-interface-ffi) defines the function `proxy_call_foreign_function` and the callback `proxy_on_foreign_function` that filter developers can use to invoke host specific functions, a.k.a. foreign functions, and receive callbacks.

A foreign function invoked with `proxy_call_foreign_function` may return its value immediately -- as part of the returned value of the `proxy_call_foreign_function` call; or it can return it later, writing it to the `FOREIGN_FUNCTION_ARGUMENTS` [buffer](https://github.com/proxy-wasm/spec/tree/main/abi-versions/v0.2.1#foreign-function-interface-ffi), and invoking `proxy_on_foreign_function` with an id identifying the function initially called.

This PR adds support for the mechanism described above; and although the spec doesn't restrict when foreign functions can be called, in `ngx_wasm_module` they cannot be invoked from `proxy_on_configure` or `proxy_on_vm_start`.

### DNS resolution

This PR also exposes the Lua DNS resolver through the `resolve_lua` foreign function.

This function expects the name to be resolved as its single argument. If the name can be resolved without performing any IO, the resolved address is put in the returned value of `proxy_call_foreign_function`.

If the resolver needs to forward the resolution request to a DNS server, the resolved address and the name itself are written to the `FOREIGN_FUNCTION_ARGUMENTS` buffer and the `proxy_on_foreign_function` callback is invoked with `function_id` 0, as soon as the address is returned from the server.

### TODO

- [x] `on_tick` support
- [x] update docs
- [x] general review
