### PR TITLE
feat(proxy-wasm) set querystring when setting ":path"

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_maps.c
@@ -511,15 +511,17 @@ ngx_proxy_wasm_maps_set_path(ngx_wavm_instance_t *instance, ngx_str_t *value,
     ngx_proxy_wasm_ctx_t     *pwctx = pwexec->parent;
     ngx_http_wasm_req_ctx_t  *rctx = ngx_http_proxy_wasm_get_rctx(instance);
     ngx_http_request_t       *r = rctx->r;
+    u_char                   *query;
+    size_t                    len = value->len;
 
-    if (ngx_strchr(value->data, '?')) {
-        ngx_wavm_instance_trap_printf(instance,
-                                      "NYI - cannot set request path "
-                                      "with querystring");
-        return NGX_ERROR;
+    query = (u_char *) ngx_strchr(value->data, '?');
+    if (query) {
+        len = query - value->data;
+        r->args.len = value->len - len - 1;
+        r->args.data = query + 1;
     }
 
-    r->uri.len = value->len;
+    r->uri.len = len;
     r->uri.data = value->data;
 
     if (pwctx->path.len) {

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.c
@@ -258,8 +258,8 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
                 call->method.data = elt->value.data;
 
             } else if (ngx_str_eq(elt->key.data, elt->key.len, ":path", -1)) {
-                call->uri.len = elt->value.len;
-                call->uri.data = elt->value.data;
+                call->path.len = elt->value.len;
+                call->path.data = elt->value.data;
 
             } else if (ngx_str_eq(elt->key.data, elt->key.len,
                                   ":authority", -1))
@@ -330,7 +330,7 @@ ngx_http_proxy_wasm_dispatch(ngx_proxy_wasm_exec_t *pwexec,
         call->error = NGX_HTTP_PROXY_WASM_DISPATCH_ERR_BAD_METHOD;
         goto error;
 
-    } else if (!call->uri.len) {
+    } else if (!call->path.len) {
         call->error = NGX_HTTP_PROXY_WASM_DISPATCH_ERR_BAD_PATH;
         goto error;
     }
@@ -577,7 +577,7 @@ ngx_http_proxy_wasm_dispatch_request(ngx_http_proxy_wasm_dispatch_t *call)
      * Connection:
      * Content-Length:
      */
-    len += call->method.len + 1 + call->uri.len + 1
+    len += call->method.len + 1 + call->path.len + 1
            + sizeof(ngx_http_header_version11) - 1;
 
     len += sizeof(ngx_http_host_header) - 1 + sizeof(": ") - 1
@@ -638,7 +638,7 @@ ngx_http_proxy_wasm_dispatch_request(ngx_http_proxy_wasm_dispatch_t *call)
     b->last = ngx_cpymem(b->last, call->method.data, call->method.len);
     *b->last++ = ' ';
 
-    b->last = ngx_cpymem(b->last, call->uri.data, call->uri.len);
+    b->last = ngx_cpymem(b->last, call->path.data, call->path.len);
     *b->last++ = ' ';
 
     b->last = ngx_cpymem(b->last, ngx_http_header_version11,

--- a/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
+++ b/src/http/proxy_wasm/ngx_http_proxy_wasm_dispatch.h
@@ -40,7 +40,7 @@ struct ngx_http_proxy_wasm_dispatch_s {
 
     ngx_str_t                               host;
     ngx_str_t                               method;
-    ngx_str_t                               uri;
+    ngx_str_t                               path;  /* ":path" (including query) */
     ngx_str_t                               authority;
     ngx_array_t                             headers;
     ngx_array_t                             trailers;

--- a/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
@@ -1357,3 +1357,31 @@ Hello back /dispatched?foo=bar /dispatched ? foo=bar
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 52: proxy_wasm - dispatch_http_call() can use ':path' with querystring, passes through invalid characters
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        return 200 "Hello back $request_uri $uri $is_args $args";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_body \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched?foo=bár%20bla \
+                              on_http_call_response=echo_response_body';
+        echo failed;
+    }
+--- request
+GET /t
+
+Hello world
+--- response_body
+Hello back /dispatched?foo=bár%20bla /dispatched ? foo=bár%20bla
+--- no_error_log
+[error]
+[crit]

--- a/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
@@ -1329,3 +1329,31 @@ cannot override the "Host" header, skipping
 cannot override the "Connection" header, skipping
 --- no_error_log
 [error]
+
+
+
+=== TEST 51: proxy_wasm - dispatch_http_call() can use ':path' with querystring
+--- load_nginx_modules: ngx_http_echo_module
+--- wasm_modules: hostcalls
+--- config
+    location /dispatched {
+        return 200 "Hello back $request_uri $uri $is_args $args";
+    }
+
+    location /t {
+        proxy_wasm hostcalls 'on=request_body \
+                              test=/t/dispatch_http_call \
+                              host=127.0.0.1:$TEST_NGINX_SERVER_PORT \
+                              path=/dispatched?foo=bar \
+                              on_http_call_response=echo_response_body';
+        echo failed;
+    }
+--- request
+GET /t
+
+Hello world
+--- response_body
+Hello back /dispatched?foo=bar /dispatched ? foo=bar
+--- no_error_log
+[error]
+[crit]


### PR DESCRIPTION
* [tests(proxy-wasm) check that querystring works in dispatch_http_call](https://github.com/Kong/ngx_wasm_module/commit/67d48a344f01c37dddc12de398202a9893be5e73) - looks like setting the query passing `:path` to dispatch already worked; I added a test to verify this.
* [feat(proxy-wasm) set querystring when setting ":path"](https://github.com/Kong/ngx_wasm_module/commit/0bacf513bc9c6ea0766d6813bbdcaa3decd88392) - this one addresses the NYI, and includes some tests.
* [refactor(proxy-wasm) rename call->uri to call->path](https://github.com/Kong/ngx_wasm_module/commit/fd0fdcca407ae8a3f0dbaafe17483070b9559c75) - This third one is opinionated, feel free to keep or drop it. I just changed it to clarify that it matches `":path"` (that is, path including querystring), making the field name match the pseudo-header, as is the case with the other entries in `ngx_http_proxy_wasm_dispatch_s`.
