### PR TITLE
tests(*) increase robustness of httpbin-reliant tests

### DIFF
--- a/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
+++ b/t/03-proxy_wasm/hfuncs/130-proxy_dispatch_http.t
@@ -408,6 +408,7 @@ Needs IPv4 resolution + external I/O to succeed.
 Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
+- HTTP 503 (httpbin.org Service Temporarily Unavailable)
 - HTTP 504 (httpbin.org Gateway timeout)
 --- skip_eval: 5: $::osname =~ m/darwin/
 --- valgrind
@@ -428,11 +429,11 @@ qq{
         echo fail;
     }
 }
---- error_code_like: (200|502|504)
+--- error_code_like: (200|502|503|504)
 --- response_body_like
 (\s*"Hello": "world",\s*
 .*?
-\s*"X-Thing": "foo,bar"\s*|.*?502 Bad Gateway.*|.*?504 Gateway Time-out.*)
+\s*"X-Thing": "foo,bar"\s*|.*?502 Bad Gateway.*|.*?503 Service Temporarily Unavailable.*|.*?504 Gateway Time-out.*)
 --- no_error_log
 [error]
 [crit]

--- a/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
+++ b/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
@@ -18,6 +18,7 @@ __DATA__
 Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
+- HTTP 503 (httpbin.org Service Temporarily Unavailable)
 - HTTP 504 (httpbin.org Gateway timeout)
 --- skip_no_debug
 --- timeout eval: $::ExtTimeout
@@ -33,8 +34,8 @@ Succeeds on:
                               on_http_call_response=echo_response_body';
         echo failed;
     }
---- error_code_like: (200|502|504)
---- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?504 Gateway Time-out.*)
+--- error_code_like: (200|502|503|504)
+--- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?503 Service Temporarily Unavailable.*|.*?504 Gateway Time-out.*)
 --- error_log eval
 [
     qr/\[debug\] .*? wasm lua resolver thread/,
@@ -291,6 +292,7 @@ Needs IPv4 resolution + external I/O to succeed.
 Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
+- HTTP 503 (httpbin.org Service Temporarily Unavailable)
 - HTTP 504 (httpbin.org Gateway timeout)
 --- skip_eval: 5: $t::TestWasmX::nginxV !~ m/--with-debug/ || defined $ENV{GITHUB_ACTIONS}
 --- skip_no_debug
@@ -307,8 +309,8 @@ Succeeds on:
                               on_http_call_response=echo_response_body';
         echo failed;
     }
---- error_code_like: (200|502|504)
---- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?504 Gateway Time-out.*)
+--- error_code_like: (200|502|503|504)
+--- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?503 Service Temporarily Unavailable.*|.*?504 Gateway Time-out.*)
 --- error_log eval
 [
     qr/\[debug\] .*? wasm lua resolver creating new dns_client/,

--- a/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
+++ b/t/04-openresty/lua-bridge/003-proxy_wasm_lua_resolver_timeouts.t
@@ -25,6 +25,7 @@ __DATA__
 Succeeds on:
 - HTTP 200 (httpbin.org/headers success)
 - HTTP 502 (httpbin.org Bad Gateway)
+- HTTP 503 (httpbin.org Service Temporarily Unavailable)
 - HTTP 504 (httpbin.org Gateway timeout)
 --- skip_no_debug
 --- timeout eval: $::ExtTimeout
@@ -40,8 +41,8 @@ Succeeds on:
                               on_http_call_response=echo_response_body';
         echo failed;
     }
---- error_code_like: (200|502|504)
---- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?504 Gateway Time-out.*)
+--- error_code_like: (200|502|503|504)
+--- response_body_like: ("Host": "httpbin\.org"|.*?502 Bad Gateway.*|.*?503 Service Temporarily Unavailable.*|.*?504 Gateway Time-out.*)
 --- error_log eval
 [
     qr/\[debug\] .*? wasm lua resolver thread/,


### PR DESCRIPTION
We sometimes get a real 503 from httpbin.org as well. The tests still succeed in case of upstream errors.