### PR TITLE
chore(v8bridge) minor fixes for v8bridge build

### DIFF
--- a/lib/v8bridge/Makefile
+++ b/lib/v8bridge/Makefile
@@ -2,7 +2,7 @@
 
 TARGET ?= /usr/local
 V8_INCDIR ?= /usr/local/include
-CXXFLAGS += -I $(V8_INCDIR) -std=c++17 -O3
+CXXFLAGS += -I $(V8_INCDIR) -std=c++20 -O3
 
 build: libv8bridge
 

--- a/util/runtimes/v8.sh
+++ b/util/runtimes/v8.sh
@@ -218,7 +218,7 @@ build_v8bridge() {
         make -C "$NGX_WASM_DIR/lib/v8bridge" clean
     fi
 
-    local v8_cxx="$CC"
+    local v8_cxx="${CC:-gcc}"
 
     if [[ "$v8_cxx" = "clang" ]]; then
         # Use the same V8 clang toolchain to build v8bridge - C++ ABI compatibility


### PR DESCRIPTION
These need to be fixed in order to produce a bump to `ngx_wasm_runtimes`.

This puts us in an almost chicken-and-egg situation when bumping V8. We need to make a 3 (or rather 4) step process for bumping V8 if their build process changes:

1. make the tweaks in `ngx_wasm_module`
2. start an ARM VM and build the ARM binary image
3. bump in `ngx_wasm_runtimes`
4. bump the CI in `ngx_wasm_module`

This time I've done things out-of-order by tweaking the repo by hand in the ARM VM to get step 2 done first, but then I realized that step 3 won't work without step 1 (this PR). Another PR with step 4 will then follow.

(Perhaps the build part of `util/runtimes/v8.sh` should instead live in `ngx_wasm_runtimes`, so that all steps for building a new V8 artifact lived there, and then `ngx_wasm_module` could just treat` ngx_wasm_runtimes` as its V8 upstream, and in its own `util/runtimes/v8.sh`, if a build from source is desired, it could fetch that repo and run `make` on it.)