### PR TITLE
fix(wavm) use PRIu64 for printf portability across architectures

### DIFF
--- a/src/wasm/vm/ngx_wavm.c
+++ b/src/wasm/vm/ngx_wavm.c
@@ -1151,7 +1151,7 @@ ngx_wavm_val_vec_set(wasm_val_vec_t *out, const wasm_valtype_vec_t *valtypes,
 
         case WASM_I64:
             ui64 = va_arg(args, uint64_t);
-            dd("arg %ld i64: %llu", i, ui64);
+            dd("arg %ld i64: %" PRIu64, i, ui64);
             ngx_wasm_vec_set_i64(out, i, ui64);
             break;
 


### PR DESCRIPTION
Fixes #653