### PR TITLE
fix(proxy-wasm) catch get/set all scoped properties outside of requests

### DIFF
--- a/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
+++ b/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
@@ -683,3 +683,95 @@ qr/\[info\] .*? property not found: nonexistent_property,/
 --- no_error_log
 [error]
 [crit]
+
+
+
+=== TEST 16: proxy_wasm - get_property() request.* - not available on: tick (isolation: global)
+--- skip_hup
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=log_property \
+                              name=request.id';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/value: InternalFailure/,
+]
+
+
+
+=== TEST 17: proxy_wasm - get_property() response.* - not available on: tick (isolation: global)
+--- skip_hup
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=log_property \
+                              name=response.grpc_status';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/value: InternalFailure/,
+]
+
+
+
+=== TEST 18: proxy_wasm - get_property() upstream.* - not available on: tick (isolation: global)
+--- skip_hup
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=log_property \
+                              name=upstream.address';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/value: InternalFailure/,
+]
+
+
+
+=== TEST 19: proxy_wasm - get_property() upstream.* - not available on: configure (isolation: global)
+--- skip_hup
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=log_property \
+                              name=upstream.address';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- must_die: 0
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/value: InternalFailure/,
+    qr/\[emerg\] .*? failed initializing "hostcalls"/,
+]

--- a/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/119-proxy_properties_get_ngx.t
@@ -147,7 +147,7 @@ ngx_http_* calls.
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot get ngx properties outside of a request/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/value: InternalFailure/,
 ]

--- a/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
+++ b/t/03-proxy_wasm/hfuncs/120-proxy_properties_get_host.t
@@ -142,7 +142,7 @@ qr/\[info\] .*? property not found: was,/
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot get host properties outside of a request/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/value: InternalFailure/,
 ]
@@ -166,7 +166,7 @@ qr/\[info\] .*? property not found: was,/
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot get host properties outside of a request/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/value: InternalFailure/,
 ]

--- a/t/03-proxy_wasm/hfuncs/121-proxy_properties_set.t
+++ b/t/03-proxy_wasm/hfuncs/121-proxy_properties_set.t
@@ -59,3 +59,95 @@ forward the NotFound status back to the caller.
 ]
 --- no_error_log
 [emerg]
+
+
+
+=== TEST 3: proxy_wasm - set_property() request.* - not available on: tick (isolation: global)
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=set_property \
+                              name=request.id \
+                              show_old=false';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/unexpected status: 10/,
+]
+
+
+
+=== TEST 4: proxy_wasm - set_property() response.* - not available on: tick (isolation: global)
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=set_property \
+                              name=response.grpc_status \
+                              show_old=false';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/unexpected status: 10/,
+]
+
+
+
+=== TEST 5: proxy_wasm - set_property() upstream.* - not available on: tick (isolation: global)
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=set_property \
+                              name=upstream.address \
+                              show_old=false';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[info\] .*? \[hostcalls\] on_tick/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/unexpected status: 10/,
+]
+
+
+
+=== TEST 6: proxy_wasm - set_property() upstream.* - not available on: configure (isolation: global)
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'on_configure=set_property \
+                              name=upstream.address \
+                              show_old=false';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- must_die: 0
+--- ignore_response_body
+--- error_log eval
+[
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
+    qr/\[crit\] .*? panicked at/,
+    qr/unexpected status: 10/,
+    qr/\[emerg\] .*? failed initializing "hostcalls"/,
+]

--- a/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_ngx.t
+++ b/t/03-proxy_wasm/hfuncs/122-proxy_properties_set_ngx.t
@@ -212,7 +212,7 @@ ngx_http_* calls.
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot set ngx properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/unexpected status: 10/,
 ]
@@ -247,7 +247,7 @@ HTTP 200 since the root and request instances are different.
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot set ngx properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/unexpected status: 10/,
 ]

--- a/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
+++ b/t/03-proxy_wasm/hfuncs/123-proxy_properties_set_host.t
@@ -159,7 +159,7 @@ ngx_http_* calls.
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot set host properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/unexpected status: 10/,
 ]
@@ -191,7 +191,7 @@ ngx_http_* calls.
 --- error_log eval
 [
     qr/\[info\] .*? \[hostcalls\] on_tick/,
-    qr/\[error\] .*? cannot set host properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[crit\] .*? panicked at/,
     qr/unexpected status: 10/,
 ]

--- a/t/04-openresty/ffi/300-proxy_wasm_properties_get_ngx.t
+++ b/t/04-openresty/ffi/300-proxy_wasm_properties_get_ngx.t
@@ -39,7 +39,7 @@ __DATA__
 ok
 --- error_log eval
 [
-    qr/\[error\] .*? cannot get ngx properties outside of a request/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
     qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: unknown error/,
 ]
 --- no_error_log

--- a/t/04-openresty/ffi/301-proxy_wasm_properties_get_host.t
+++ b/t/04-openresty/ffi/301-proxy_wasm_properties_get_host.t
@@ -39,7 +39,7 @@ __DATA__
 ok
 --- error_log eval
 [
-    qr/\[error\] .*? cannot get host properties outside of a request/,
+    qr/\[error\] .*? cannot get scoped properties outside of a request/,
     qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: unknown error/,
 ]
 

--- a/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
+++ b/t/04-openresty/ffi/302-proxy_wasm_properties_set_ngx.t
@@ -41,7 +41,7 @@ __DATA__
 ok
 --- error_log eval
 [
-    qr/\[error\] .*? cannot set ngx properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: unknown error/,
 ]
 --- no_error_log

--- a/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
+++ b/t/04-openresty/ffi/303-proxy_wasm_properties_set_host.t
@@ -39,7 +39,7 @@ __DATA__
 ok
 --- error_log eval
 [
-    qr/\[error\] .*? cannot set host properties outside of a request/,
+    qr/\[error\] .*? cannot set scoped properties outside of a request/,
     qr/\[error\] .*? init_worker_by_lua(\(nginx\.conf:\d+\))?:\d+: unknown error/,
 ]
 --- no_error_log

--- a/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
+++ b/t/04-openresty/lua-bridge/002-proxy_wasm_lua_resolver_sanity.t
@@ -85,6 +85,20 @@ ok
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -111,6 +125,20 @@ called 3 times
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -612,6 +640,20 @@ ok
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -638,6 +680,20 @@ TODO: also test with no_postpone
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -689,6 +745,20 @@ ok
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -715,6 +785,20 @@ TODO: also test with no_postpone
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -766,6 +850,20 @@ ok
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;
@@ -798,6 +896,20 @@ ok
 --- timeout eval: $::ExtTimeout
 --- load_nginx_modules: ngx_http_echo_module
 --- wasm_modules: hostcalls
+--- http_config eval
+qq{
+    init_worker_by_lua_block {
+        dns_client = require 'resty.dns.client'
+        assert(dns_client.init({
+            noSynchronisation = false, -- default
+            order = { 'A' },
+            resolvConf = {
+                'nameserver $::ExtResolver',
+                'options timeout:$::ExtTimeout',
+            }
+        }))
+    }
+}
 --- config
     location /t {
         proxy_wasm_lua_resolver on;

--- a/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
+++ b/t/lib/proxy-wasm-tests/hostcalls/src/lib.rs
@@ -82,6 +82,8 @@ impl RootContext for TestRoot {
                 test_define_metrics(self);
                 test_record_metric(self, TestPhase::Configure);
             }
+            "log_property" => test_log_property(self),
+            "set_property" => test_set_property(self),
             _ => (),
         }
 


### PR DESCRIPTION
Scoped properties (e.g. `request.*`, `response.*`, `upstream.*`, ...) can only be read/written from within the context of a request. Only non-scoped properties (e.g. `worker_id`) can be accessed from root contexts.

Prior to this commit, only `ngx.*` and `wasmx.*` (host) properties were caught. Other scoped properties that did not map to either of those would cause a segfault.

We now catch all scoped properties (i.e. containing a `.` character) when getting/setting properties outside of a request.