### PR TITLE
chore(ci) bump clang builds to clang-14 + clang-18

### DIFF
--- a/.github/workflows/ci-large.yml
+++ b/.github/workflows/ci-large.yml
@@ -168,7 +168,7 @@ jobs:
       matrix:
         label: [""]
         os: [ubuntu-latest]
-        cc: [clang-13, clang-14, gcc-10, gcc-11]
+        cc: [clang-14, clang-18, gcc-10, gcc-11]
         ngx: [1.27.3]
         runtime: [wasmtime, wasmer, v8]
         wasmtime: [26.0.0]


### PR DESCRIPTION
Ubuntu 24.04 does not have clang-13 anymore.