### PR TITLE
fix(proxy-wasm) support get 'plugin_name' in tick context

### DIFF
--- a/src/common/proxy_wasm/ngx_proxy_wasm.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.c
@@ -840,9 +840,12 @@ ngx_proxy_wasm_run_step(ngx_proxy_wasm_exec_t *pwexec,
         rc = filter->subsystem->resume(pwexec, step, &action);
         break;
     case NGX_PROXY_WASM_STEP_TICK:
+        ngx_wa_assert(pwexec->root_id == NGX_PROXY_WASM_ROOT_CTX_ID);
+        pwctx->rexec = pwexec;
         pwexec->in_tick = 1;
         rc = ngx_proxy_wasm_on_tick(pwexec);
         pwexec->in_tick = 0;
+        pwctx->rexec = NULL;
         break;
     default:
         ngx_proxy_wasm_log_error(NGX_LOG_WASM_NYI, pwctx->log, 0,

--- a/src/common/proxy_wasm/ngx_proxy_wasm.h
+++ b/src/common/proxy_wasm/ngx_proxy_wasm.h
@@ -213,6 +213,7 @@ struct ngx_proxy_wasm_ctx_s {
     ngx_uint_t                                    isolation;
     ngx_proxy_wasm_store_t                        store;
     ngx_proxy_wasm_context_type_e                 type;
+    ngx_proxy_wasm_exec_t                        *rexec;  /* root exec ctx */
     ngx_log_t                                    *log;
     ngx_pool_t                                   *pool;
     ngx_pool_t                                   *parent_pool;

--- a/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
+++ b/src/common/proxy_wasm/ngx_proxy_wasm_properties.c
@@ -378,9 +378,15 @@ get_filter_name(ngx_proxy_wasm_ctx_t *pwctx, ngx_str_t *path,
     ngx_proxy_wasm_exec_t    *pwexec, *pwexecs;
     ngx_proxy_wasm_filter_t  *filter;
 
-    pwexecs = (ngx_proxy_wasm_exec_t *) pwctx->pwexecs.elts;
-    pwexec = &pwexecs[pwctx->exec_index];
-    filter = pwexec->filter;
+    if (pwctx->step == NGX_PROXY_WASM_STEP_TICK) {
+        /* no filter chain initialized */
+        filter = pwctx->rexec->filter;
+
+    } else {
+        pwexecs = (ngx_proxy_wasm_exec_t *) pwctx->pwexecs.elts;
+        pwexec = &pwexecs[pwctx->exec_index];
+        filter = pwexec->filter;
+    }
 
     value->len = filter->name->len;
     value->data = filter->name->data;

--- a/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
+++ b/t/03-proxy_wasm/hfuncs/117-proxy_properties_get.t
@@ -695,7 +695,49 @@ qr/request\.is_subrequest: true at RequestHeaders/
 
 
 
-=== TEST 16: proxy_wasm - get_property() - unknown property on: request_headers
+=== TEST 16: proxy_wasm - get_property() plugin_name on: tick
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=log_property \
+                              name=plugin_name';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- response_body
+ok
+--- error_log
+plugin_name: hostcalls
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 17: proxy_wasm - get_property() plugin_root_id on: tick
+--- wasm_modules: hostcalls
+--- load_nginx_modules: ngx_http_echo_module
+--- config
+    location /t {
+        proxy_wasm hostcalls 'tick_period=200 \
+                              on_tick=log_property \
+                              name=plugin_root_id';
+        echo_sleep 0.5;
+        echo ok;
+    }
+--- response_body
+ok
+--- error_log
+plugin_root_id: 0
+--- no_error_log
+[error]
+[crit]
+
+
+
+=== TEST 18: proxy_wasm - get_property() - unknown property on: request_headers
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
 --- config
@@ -714,7 +756,7 @@ qr/\[info\] .*? property not found: nonexistent_property,/
 
 
 
-=== TEST 17: proxy_wasm - get_property() request.* - not available on: tick (isolation: global)
+=== TEST 19: proxy_wasm - get_property() request.* - not available on: tick (isolation: global)
 --- skip_hup
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
@@ -737,7 +779,7 @@ qr/\[info\] .*? property not found: nonexistent_property,/
 
 
 
-=== TEST 18: proxy_wasm - get_property() response.* - not available on: tick (isolation: global)
+=== TEST 20: proxy_wasm - get_property() response.* - not available on: tick (isolation: global)
 --- skip_hup
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
@@ -760,7 +802,7 @@ qr/\[info\] .*? property not found: nonexistent_property,/
 
 
 
-=== TEST 19: proxy_wasm - get_property() upstream.* - not available on: tick (isolation: global)
+=== TEST 21: proxy_wasm - get_property() upstream.* - not available on: tick (isolation: global)
 --- skip_hup
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module
@@ -783,7 +825,7 @@ qr/\[info\] .*? property not found: nonexistent_property,/
 
 
 
-=== TEST 20: proxy_wasm - get_property() upstream.* - not available on: configure (isolation: global)
+=== TEST 22: proxy_wasm - get_property() upstream.* - not available on: configure (isolation: global)
 --- skip_hup
 --- wasm_modules: hostcalls
 --- load_nginx_modules: ngx_http_echo_module


### PR DESCRIPTION
No filter chain initialized on tick contexts means the root context must be stored in the empty filter chain context for later retrieval.